### PR TITLE
Implement "clean" command

### DIFF
--- a/src/Console/Command/CleanCommand.php
+++ b/src/Console/Command/CleanCommand.php
@@ -3,13 +3,26 @@
 namespace PhpTuf\ComposerStager\Console\Command;
 
 use PhpTuf\ComposerStager\Console\Misc\ExitCode;
+use PhpTuf\ComposerStager\Domain\Cleaner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class CleanCommand extends Command
 {
     protected static $defaultName = 'clean';
+
+    /**
+     * @var \PhpTuf\ComposerStager\Domain\Cleaner
+     */
+    private $cleaner;
+
+    public function __construct(Cleaner $cleaner)
+    {
+        parent::__construct(static::$defaultName);
+        $this->cleaner = $cleaner;
+    }
 
     protected function configure(): void
     {
@@ -18,6 +31,40 @@ class CleanCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        return ExitCode::SUCCESS;
+        /** @var string $stagingDir */
+        $stagingDir = $input->getOption('staging-dir');
+
+        if (!$this->cleaner->directoryExists($stagingDir)) {
+            $output->writeln(sprintf('<error>The staging directory does not exist at "%s"</error>', $stagingDir));
+            return ExitCode::FAILURE;
+        }
+
+        if (!$this->confirm($input, $output)) {
+            return ExitCode::FAILURE;
+        }
+
+        try {
+            $this->cleaner->clean($stagingDir);
+            return ExitCode::SUCCESS;
+
+        // Prevent ugly "explosions" from unhandled exceptions by catching and
+        // formatting absolutely anything.
+        } catch (\Throwable $e) {
+            $output->writeln("<error>{$e->getMessage()}</error>");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    public function confirm(InputInterface $input, OutputInterface $output): bool
+    {
+        /** @var bool $noInteraction */
+        $noInteraction = $input->getOption('no-interaction');
+        if ($noInteraction) {
+            return true;
+        }
+
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion('You are about to permanently remove the staging directory. This action cannot be undone. Continue? ');
+        return $helper->ask($input, $output, $question);
     }
 }

--- a/src/Domain/Cleaner.php
+++ b/src/Domain/Cleaner.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Domain;
+
+use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
+use PhpTuf\ComposerStager\Infrastructure\Filesystem\Filesystem;
+
+class Cleaner
+{
+    /**
+     * @var \PhpTuf\ComposerStager\Infrastructure\Filesystem\Filesystem
+     */
+    private $filesystem;
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @throws \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
+     */
+    public function clean(string $stagingDir): void
+    {
+        if (!$this->directoryExists($stagingDir)) {
+            throw new DirectoryNotFoundException($stagingDir, 'The staging directory does not exist at "%s"');
+        }
+
+        $this->filesystem->remove($stagingDir);
+    }
+
+    public function directoryExists(string $stagingDir): bool
+    {
+        return $this->filesystem->exists($stagingDir);
+    }
+}

--- a/tests/Console/Command/CleanCommandTest.php
+++ b/tests/Console/Command/CleanCommandTest.php
@@ -4,21 +4,40 @@ namespace PhpTuf\ComposerStager\Tests\Console\Command;
 
 use PhpTuf\ComposerStager\Console\Command\CleanCommand;
 use PhpTuf\ComposerStager\Console\Misc\ExitCode;
+use PhpTuf\ComposerStager\Domain\Cleaner;
+use PhpTuf\ComposerStager\Exception\DirectoryNotWritableException;
+use PhpTuf\ComposerStager\Exception\IOException;
 use PhpTuf\ComposerStager\Tests\Console\CommandTestCase;
+use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Console\Command\CleanCommand
+ * @covers \PhpTuf\ComposerStager\Console\Command\CleanCommand::__construct
  * @uses \PhpTuf\ComposerStager\Console\Application
- * @uses \PhpTuf\ComposerStager\Console\Command\CleanCommand
+ * @uses \PhpTuf\ComposerStager\Console\Command\CleanCommand::configure
+ * @uses \PhpTuf\ComposerStager\Console\Command\CleanCommand::confirm
  * @uses \PhpTuf\ComposerStager\Console\GlobalOptions
+ *
+ * @property \PhpTuf\ComposerStager\Domain\Cleaner|\Prophecy\Prophecy\ObjectProphecy $cleaner
  */
 class CleanCommandTest extends CommandTestCase
 {
+    protected function setUp(): void
+    {
+        $this->cleaner = $this->prophesize(Cleaner::class);
+        $this->cleaner
+            ->directoryExists(Argument::cetera())
+            ->willReturn(true);
+        parent::setUp();
+    }
+
     protected function createSut(): Command
     {
-        return new CleanCommand();
+        $cleaner = $this->cleaner->reveal();
+        return new CleanCommand($cleaner);
     }
+
 
     /**
      * @covers ::configure
@@ -39,13 +58,98 @@ class CleanCommandTest extends CommandTestCase
     }
 
     /**
+     * @covers ::confirm
      * @covers ::execute
      */
     public function testBasicExecution(): void
     {
-        $this->executeCommand();
+        $this->cleaner
+            ->clean(static::STAGING_DIR)
+            ->shouldBeCalledOnce();
+
+        $this->executeCommand([
+            '--staging-dir' => static::STAGING_DIR,
+            '--no-interaction' => true,
+        ]);
 
         self::assertSame('', $this->getDisplay(), 'Displayed correct output.');
         self::assertSame(ExitCode::SUCCESS, $this->getStatusCode(), 'Returned correct status code.');
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testStagingDirectoryNotFound(): void
+    {
+        $this->cleaner
+            ->directoryExists(Argument::cetera())
+            ->willReturn(false);
+        $this->cleaner
+            ->clean(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->executeCommand(['--no-interaction' => true]);
+
+        self::assertStringContainsString('staging directory does not exist', $this->getDisplay(), 'Displayed correct output.');
+        self::assertSame(ExitCode::FAILURE, $this->getStatusCode(), 'Returned correct status code.');
+    }
+
+    /**
+     * @covers ::confirm
+     * @covers ::execute
+     *
+     * @dataProvider providerConfirmationPrompt
+     */
+    public function testConfirmationPrompt($input, $calls, $exit): void
+    {
+        $this->cleaner
+            ->clean(Argument::cetera())
+            ->shouldBeCalledTimes($calls);
+
+        $this->executeCommand([], [$input]);
+
+        self::assertStringContainsString('Continue?', $this->getDisplay(), 'Displayed correct output.');
+        self::assertSame($exit, $this->getStatusCode(), 'Returned correct status code.');
+    }
+
+    public function providerConfirmationPrompt(): array
+    {
+        return [
+            [
+                'input' => 'yes',
+                'calls' => 1,
+                'exit' => ExitCode::SUCCESS,
+            ],
+            [
+                'input' => 'no',
+                'calls' => 0,
+                'exit' => ExitCode::FAILURE,
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::execute
+     *
+     * @dataProvider providerCommandFailure
+     */
+    public function testCommandFailure($exception, $message): void
+    {
+        $this->cleaner
+            ->clean(Argument::cetera())
+            ->willThrow($exception);
+
+        $this->executeCommand(['--no-interaction' => true]);
+
+        self::assertSame($message . PHP_EOL, $this->getDisplay(), 'Displayed correct output.');
+        self::assertSame(ExitCode::FAILURE, $this->getStatusCode(), 'Returned correct status code.');
+    }
+
+    public function providerCommandFailure(): array
+    {
+        return [
+            ['exception' => new IOException('Lorem'), 'message' => 'Lorem'],
+            ['exception' => new DirectoryNotWritableException(static::STAGING_DIR, 'Ipsum'), 'message' => 'Ipsum'],
+        ];
     }
 }

--- a/tests/Console/Command/StageCommandTest.php
+++ b/tests/Console/Command/StageCommandTest.php
@@ -27,8 +27,8 @@ class StageCommandTest extends CommandTestCase
 {
     protected function setUp(): void
     {
-        $this->setUpGlobalOptions();
         $this->stager = $this->prophesize(Stager::class);
+        parent::setUp();
     }
 
     protected function createSut(): Command

--- a/tests/Domain/CleanerTest.php
+++ b/tests/Domain/CleanerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Tests\Domain;
+
+use PhpTuf\ComposerStager\Domain\Cleaner;
+use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
+use PhpTuf\ComposerStager\Infrastructure\Filesystem\Filesystem;
+use PhpTuf\ComposerStager\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Cleaner
+ * @covers \PhpTuf\ComposerStager\Domain\Cleaner::__construct
+ * @uses \PhpTuf\ComposerStager\Domain\Cleaner::directoryExists
+ * @uses \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
+ * @uses \PhpTuf\ComposerStager\Exception\PathException
+ *
+ * @property \PhpTuf\ComposerStager\Infrastructure\Filesystem\Filesystem|\Prophecy\Prophecy\ObjectProphecy $filesystem
+ */
+class CleanerTest extends TestCase
+{
+    private const STAGING_DIR = '/lorem/ipsum';
+
+    public function setUp(): void
+    {
+        $this->filesystem = $this->prophesize(Filesystem::class);
+        $this->filesystem
+            ->exists(static::STAGING_DIR)
+            ->willReturn(true);
+    }
+
+    public function createSut(): Cleaner
+    {
+        $filesystem = $this->filesystem->reveal();
+        return new Cleaner($filesystem);
+    }
+
+    /**
+     * @covers ::clean
+     */
+    public function testCleanHappyPath(): void
+    {
+        $this->filesystem
+            ->remove(static::STAGING_DIR)
+            ->shouldBeCalledOnce();
+        $sut = $this->createSut();
+
+        $sut->clean(static::STAGING_DIR);
+    }
+
+    /**
+     * @covers ::clean
+     */
+    public function testCleanDirectoryNotFound(): void
+    {
+        $this->expectException(DirectoryNotFoundException::class);
+        $this->expectExceptionMessageMatches('/staging directory.*exist/');
+
+        $this->filesystem
+            ->exists(static::STAGING_DIR)
+            ->willReturn(false);
+        $this->filesystem
+            ->remove(static::STAGING_DIR)
+            ->shouldNotBeCalled();
+        $sut = $this->createSut();
+
+        $sut->clean(static::STAGING_DIR);
+    }
+
+    /**
+     * @covers ::directoryExists
+     *
+     * @dataProvider providerDirectoryExists
+     */
+    public function testDirectoryExists($expected): void
+    {
+        $this->filesystem
+            ->exists(static::STAGING_DIR)
+            ->shouldBeCalledOnce()
+            ->willReturn($expected);
+        $sut = $this->createSut();
+
+        $actual = $sut->directoryExists(static::STAGING_DIR);
+
+        self::assertSame($expected, $actual, 'Correctly detected existence of staging directory.');
+    }
+
+    public function providerDirectoryExists(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+}


### PR DESCRIPTION
Command output:

```
$ ./bin/composer-stage clean --help
Description:
  Removes the staging directory

Usage:
  clean

Options:
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi                     Force ANSI output
      --no-ansi                  Disable ANSI output
  -n, --no-interaction           Do not ask any interactive question
  -d, --active-dir=ACTIVE-DIR    Use the given directory as active directory [default: "/Users/travis.carden/Projects/autoupdates/composer-stager"]
  -s, --staging-dir=STAGING-DIR  Use the given directory as staging directory [default: "/Users/travis.carden/Projects/autoupdates/composer-stager/.composer_staging"]
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```