### PR TITLE
Add Symfony-based rsync file copier alternative and end-to-end functional test coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,9 +99,9 @@
             "@coverage",
             "@security"
         ],
-        "coverage": "phpunit --coverage-html var/phpunit/coverage-report --coverage-text --color=always | grep --invert-match --extended-regexp '(^PhpTuf\\.*\\\\|Methods)'",
+        "coverage": "phpunit --coverage-html $(pwd)/var/phpunit/coverage-report --coverage-text --color=always | grep --invert-match --extended-regexp '(^PhpTuf\\.*\\\\|Methods)'",
         "lint": "parallel-lint --no-progress bin/composer-stage src tests",
-        "open-coverage": "open var/phpunit/coverage-report/index.html || echo 'Run the \"coverage\" command to generate the coverage report.'",
+        "open-coverage": "open $(pwd)/var/phpunit/coverage-report/index.html || echo 'Run the \"coverage\" command to generate the coverage report.'",
         "phpcbf": "phpcbf --standard=PhpTuf ./src ./tests",
         "phpcs": "phpcs -s --standard=PhpTuf ./src ./tests",
         "phpmd": "phpmd src text phpmd",

--- a/config/services.yml
+++ b/config/services.yml
@@ -17,6 +17,11 @@ services:
         exclude:
             - '../src/Console/Output'
 
+    PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierFactory: ~
+
+    PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface:
+        factory: [ '@PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierFactory', 'create' ]
+
     Symfony\Component\Process\ExecutableFinder: ~
 
     Symfony\Component\Filesystem\Filesystem: ~

--- a/src/Domain/Beginner.php
+++ b/src/Domain/Beginner.php
@@ -6,12 +6,12 @@ use PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Exception\DirectoryAlreadyExistsException;
 use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
 use PhpTuf\ComposerStager\Infrastructure\Filesystem\FilesystemInterface;
-use PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface;
 
 final class Beginner implements BeginnerInterface
 {
     /**
-     * @var \PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface
+     * @var \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface
      */
     private $fileCopier;
 

--- a/src/Domain/Committer.php
+++ b/src/Domain/Committer.php
@@ -6,12 +6,12 @@ use PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
 use PhpTuf\ComposerStager\Exception\DirectoryNotWritableException;
 use PhpTuf\ComposerStager\Infrastructure\Filesystem\FilesystemInterface;
-use PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface;
 
 final class Committer implements CommitterInterface
 {
     /**
-     * @var \PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface
+     * @var \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface
      */
     private $fileCopier;
 

--- a/src/Infrastructure/Process/FileCopier/FileCopierFactory.php
+++ b/src/Infrastructure/Process/FileCopier/FileCopierFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
+
+use Symfony\Component\Process\ExecutableFinder;
+
+/**
+ * @internal
+ */
+final class FileCopierFactory implements FileCopierFactoryInterface
+{
+    /**
+     * @var \Symfony\Component\Process\ExecutableFinder
+     */
+    private $executableFinder;
+
+    /**
+     * @var \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\RsyncFileCopierInterface
+     */
+    private $rsyncFileCopier;
+
+    /**
+     * @var \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopierInterface
+     */
+    private $symfonyFileCopier;
+
+    public function __construct(
+        ExecutableFinder $executableFinder,
+        RsyncFileCopierInterface $rsyncFileCopier,
+        SymfonyFileCopierInterface $symfonyFileCopier
+    ) {
+        $this->executableFinder = $executableFinder;
+        $this->rsyncFileCopier = $rsyncFileCopier;
+        $this->symfonyFileCopier = $symfonyFileCopier;
+    }
+
+    public function create(): FileCopierInterface
+    {
+        if ($this->executableFinder->find('rsync') !== null) {
+            return $this->rsyncFileCopier;
+        }
+        return $this->symfonyFileCopier;
+    }
+}

--- a/src/Infrastructure/Process/FileCopier/FileCopierFactoryInterface.php
+++ b/src/Infrastructure/Process/FileCopier/FileCopierFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
+
+/**
+ * Creates file copiers.
+ */
+interface FileCopierFactoryInterface
+{
+    /**
+     * Creates the correct file copier given available tools, e.g., rsync.
+     */
+    public function create(): FileCopierInterface;
+}

--- a/src/Infrastructure/Process/FileCopier/FileCopierInterface.php
+++ b/src/Infrastructure/Process/FileCopier/FileCopierInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpTuf\ComposerStager\Infrastructure\Process;
+namespace PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
 
 use PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface;
 
@@ -23,7 +23,10 @@ interface FileCopierInterface
      * @param \PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      *
+     * @throws \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
+     *   If the source ("from") directory is not found.
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
+     *   If the command process doesn't terminate successfully.
      */
     public function copy(
         string $from,

--- a/src/Infrastructure/Process/FileCopier/RsyncFileCopier.php
+++ b/src/Infrastructure/Process/FileCopier/RsyncFileCopier.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpTuf\ComposerStager\Infrastructure\Process;
+namespace PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
 
 use PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Exception\ExceptionInterface;
@@ -10,7 +10,7 @@ use PhpTuf\ComposerStager\Infrastructure\Process\Runner\RsyncRunnerInterface;
 /**
  * @internal
  */
-final class FileCopier implements FileCopierInterface
+final class RsyncFileCopier implements RsyncFileCopierInterface
 {
     /**
      * @var \PhpTuf\ComposerStager\Infrastructure\Process\Runner\RsyncRunnerInterface

--- a/src/Infrastructure/Process/FileCopier/RsyncFileCopierInterface.php
+++ b/src/Infrastructure/Process/FileCopier/RsyncFileCopierInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
+
+/**
+ * Copies files from one location to another using rsync.
+ */
+interface RsyncFileCopierInterface extends FileCopierInterface
+{
+}

--- a/src/Infrastructure/Process/FileCopier/SymfonyFileCopier.php
+++ b/src/Infrastructure/Process/FileCopier/SymfonyFileCopier.php
@@ -45,7 +45,7 @@ final class SymfonyFileCopier implements SymfonyFileCopierInterface
         try {
             $directoryIterator = new RecursiveDirectoryIterator($from);
         } catch (UnexpectedValueException $e) {
-            throw new DirectoryNotFoundException($from, 'The "copy from" directory does not exist at "%s"');
+            throw new DirectoryNotFoundException($from, 'The "copy from" directory does not exist at "%s"', (int) $e->getCode(), $e);
         }
 
         /** @var callable(mixed, mixed, \RecursiveIterator<mixed, mixed>):bool $callback */

--- a/src/Infrastructure/Process/FileCopier/SymfonyFileCopier.php
+++ b/src/Infrastructure/Process/FileCopier/SymfonyFileCopier.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
+
+use PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface;
+use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
+use PhpTuf\ComposerStager\Exception\ProcessFailedException;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use SplFileInfo;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use UnexpectedValueException;
+
+/**
+ * @internal
+ */
+final class SymfonyFileCopier implements SymfonyFileCopierInterface
+{
+    /**
+     * @var \Symfony\Component\Filesystem\Filesystem
+     */
+    private $filesystem;
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public function copy(string $from, string $to, array $exclusions = [], ?ProcessOutputCallbackInterface $callback = null): void
+    {
+        try {
+            $iterator = $this->createIterator($from);
+            $this->filesystem->mirror($from, $to, $iterator);
+        } catch (IOException $e) {
+            throw new ProcessFailedException($e->getMessage(), (int) $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @throws \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
+     */
+    private function createIterator(string $from): RecursiveCallbackFilterIterator
+    {
+        try {
+            $directoryIterator = new RecursiveDirectoryIterator($from);
+        } catch (UnexpectedValueException $e) {
+            throw new DirectoryNotFoundException($from, 'The "copy from" directory does not exist at "%s"');
+        }
+
+        /** @var callable(mixed, mixed, \RecursiveIterator<mixed, mixed>):bool $callback */
+        $callback = function (SplFileInfo $current): bool {
+            // Ignore current and parent directories.
+            if (in_array($current->getFilename(), ['.', '..'], true)) {
+                return false;
+            }
+
+            return true;
+        };
+
+        return new RecursiveCallbackFilterIterator($directoryIterator, $callback);
+    }
+}

--- a/src/Infrastructure/Process/FileCopier/SymfonyFileCopierInterface.php
+++ b/src/Infrastructure/Process/FileCopier/SymfonyFileCopierInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
+
+/**
+ * Copies files from one location to another using Symfony Filesystem.
+ */
+interface SymfonyFileCopierInterface extends FileCopierInterface
+{
+}

--- a/src/Infrastructure/Process/Runner/RsyncRunner.php
+++ b/src/Infrastructure/Process/Runner/RsyncRunner.php
@@ -8,7 +8,8 @@ namespace PhpTuf\ComposerStager\Infrastructure\Process\Runner;
  * Before using this class outside the infrastructure layer, consider a
  * higher-level abstraction:
  *
- * @see \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier
+ * @see \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface
+ * @see \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierFactoryInterface
  */
 final class RsyncRunner extends AbstractRunner implements RsyncRunnerInterface
 {

--- a/tests/Functional/EndToEndTest.php
+++ b/tests/Functional/EndToEndTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Tests\Functional;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @coversNothing
+ */
+class EndToEndTest extends TestCase
+{
+    private const ACTIVE_DIR = 'active-dir';
+    private const STAGING_DIR = 'staging-dir';
+
+    private $testEnv;
+
+    protected function setUp(): void
+    {
+        $filesystem = new Filesystem();
+
+        // Create the test environment and cd into it,
+        $this->testEnv = __DIR__ . '/../../var/phpunit/test-env/' . md5(mt_rand());
+        $filesystem->mkdir($this->testEnv);
+        chdir($this->testEnv);
+
+        // Create the active directory only. The staging directory is created
+        // when the "begin" command is exercised.
+        $filesystem->mkdir(self::ACTIVE_DIR);
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove the test environment.
+        $filesystem = new Filesystem();
+        if ($filesystem->exists($this->testEnv)) {
+            $filesystem->remove($this->testEnv);
+        }
+    }
+
+    protected function runFrontScript(string $commandString): array
+    {
+        // Override default directory paths to be adjacent rather than nested
+        // for easier comparison of contents.
+        $commandString = sprintf(
+            '--active-dir=%s --staging-dir=%s %s',
+            self::ACTIVE_DIR,
+            self::STAGING_DIR,
+            $commandString
+        );
+        return parent::runFrontScript($commandString);
+    }
+
+    public function testEndToEnd(): void
+    {
+        $this->assertTestPreconditions();
+        $this->prepareActiveDirectory();
+
+        $this->testBegin();
+        $this->testStage();
+        $this->testCommit();
+        $this->testClean();
+    }
+
+    private function assertTestPreconditions(): void
+    {
+        self::assertActiveDirectoryExists();
+        self::assertActiveDirectoryIsEmpty();
+        self::assertStagingDirectoryDoesNotExist();
+    }
+
+    private function prepareActiveDirectory(): void
+    {
+        // Initialize composer.json.
+        self::exec(sprintf(
+            'composer --working-dir=%s init --name="lorem/ipsum" --no-interaction',
+            self::ACTIVE_DIR
+        ));
+
+        self::assertActiveComposerJsonExists();
+    }
+
+    private function testBegin(): void
+    {
+        $this->runFrontScript('begin');
+
+        self::assertActiveAndStagingDirectoriesSame();
+    }
+
+    private function testStage(): void
+    {
+        // A "composer config" command is a good one to stage to avoid "testing
+        // the Internet" since it makes no HTTP requests.
+        $newName = 'dolor/sit';
+        $this->runFrontScript("stage -- config name {$newName}");
+        $actualName = $this->runFrontScript('stage -- config name')[0];
+
+        self::assertEquals($newName, $actualName, 'Composer commands succeeded.');
+        self::assertActiveAndStagingDirectoriesNotSame();
+    }
+
+    private function testCommit(): void
+    {
+        $this->runFrontScript('commit --no-interaction');
+
+        self::assertActiveAndStagingDirectoriesSame();
+    }
+
+    private function testClean(): void
+    {
+        $this->runFrontScript('clean --no-interaction');
+
+        self::assertStagingDirectoryDoesNotExist();
+    }
+
+    private static function assertActiveComposerJsonExists(): void
+    {
+        self::assertFileExists(self::ACTIVE_DIR . '/composer.json');
+    }
+
+    private static function assertActiveDirectoryExists(): void
+    {
+        self::assertFileExists(self::ACTIVE_DIR, 'Active directory exists.');
+    }
+
+    private static function assertActiveDirectoryIsEmpty(): void
+    {
+        $contents = scandir(self::ACTIVE_DIR);
+
+        // Remove items for the current and parent directories.
+        $contents = array_diff($contents, ['.', '..']);
+
+        // Reindex the return array for clearer diffs.
+        self::assertEmpty(array_values($contents), 'Active directory is empty.');
+    }
+
+    private static function assertStagingDirectoryDoesNotExist(): void
+    {
+        self::assertFileDoesNotExist(self::STAGING_DIR, 'Staging directory does not exist.');
+    }
+
+    private static function assertActiveAndStagingDirectoriesSame(): void
+    {
+        self::assertSame(
+            [],
+            self::getActiveAndStagingDirectoriesDiff(),
+            'Active and staging directories are the same.'
+        );
+    }
+
+    private static function assertActiveAndStagingDirectoriesNotSame(): void
+    {
+        self::assertNotSame(
+            [],
+            self::getActiveAndStagingDirectoriesDiff(),
+            'Active and staging directories are not the same.'
+        );
+    }
+
+    private static function getActiveAndStagingDirectoriesDiff(): array
+    {
+        $diff = self::exec(sprintf(
+            'diff %s %s',
+            self::ACTIVE_DIR,
+            self::STAGING_DIR
+        ));
+        return array_filter($diff);
+    }
+}

--- a/tests/Functional/EndToEndTest.php
+++ b/tests/Functional/EndToEndTest.php
@@ -2,8 +2,6 @@
 
 namespace PhpTuf\ComposerStager\Tests\Functional;
 
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 /**
@@ -11,23 +9,15 @@ use Symfony\Component\Process\Process;
  */
 class EndToEndTest extends TestCase
 {
-    private const TEST_ENV = __DIR__ . '/../../var/phpunit/test-env/EndToEndTest';
-    private const ACTIVE_DIR = 'active-dir';
-    private const STAGING_DIR = 'staging-dir';
-
     public static function setUpBeforeClass(): void
     {
         self::createTestEnvironment();
-        self::prepareActiveDirectory();
+        self::initializeComposerJson();
     }
 
     public static function tearDownAfterClass(): void
     {
-        // Remove the test environment.
-        $filesystem = new Filesystem();
-        if ($filesystem->exists(self::TEST_ENV)) {
-            $filesystem->remove(self::TEST_ENV);
-        }
+        self::removeTestEnvironment();
     }
 
     protected static function runFrontScript(array $args, string $cwd = __DIR__): Process
@@ -40,38 +30,11 @@ class EndToEndTest extends TestCase
         ], $args), self::TEST_ENV);
     }
 
-    private static function createTestEnvironment(): void
-    {
-        $filesystem = new Filesystem();
-
-        // Create the test environment and cd into it,
-        $filesystem->mkdir(self::TEST_ENV);
-        chdir(self::TEST_ENV);
-
-        // Create the active directory only. The staging directory is created
-        // when the "begin" command is exercised.
-        $filesystem->mkdir(self::ACTIVE_DIR);
-    }
-
-    private static function prepareActiveDirectory(): void
-    {
-        // Initialize composer.json.
-        $process = new Process([
-            'composer',
-            '--working-dir=' . self::ACTIVE_DIR,
-            'init',
-            '--name=lorem/ipsum',
-            '--no-interaction',
-        ]);
-        $process->mustRun();
-
-        self::assertActiveComposerJsonExists();
-    }
-
     public function testBegin(): void
     {
         $process = self::runFrontScript(['begin']);
 
+        self::assertSame('', $process->getErrorOutput());
         self::assertSame(0, $process->getExitCode());
         self::assertActiveAndStagingDirectoriesSame();
     }
@@ -127,46 +90,5 @@ class EndToEndTest extends TestCase
         self::assertSame('', $process->getErrorOutput());
         self::assertEquals(0, $process->getExitCode());
         self::assertStagingDirectoryDoesNotExist();
-    }
-
-    private static function assertActiveComposerJsonExists(): void
-    {
-        self::assertFileExists(self::ACTIVE_DIR . '/composer.json');
-    }
-
-    private static function assertStagingDirectoryDoesNotExist(): void
-    {
-        self::assertFileDoesNotExist(self::STAGING_DIR, 'Staging directory does not exist.');
-    }
-
-    private static function assertActiveAndStagingDirectoriesSame(): void
-    {
-        self::assertTrue(
-            self::activeAndStagingDirectoriesAreSame(),
-            'Active and staging directories are the same.'
-        );
-    }
-
-    private static function assertActiveAndStagingDirectoriesNotSame(): void
-    {
-        self::assertFalse(
-            self::activeAndStagingDirectoriesAreSame(),
-            'Active and staging directories are not the same.'
-        );
-    }
-
-    private static function activeAndStagingDirectoriesAreSame(): bool
-    {
-        try {
-            $process = new Process([
-                'diff',
-                self::ACTIVE_DIR,
-                self::STAGING_DIR,
-            ]);
-            $process->mustRun();
-        } catch (ProcessFailedException $e) {
-            return false;
-        }
-        return true;
     }
 }

--- a/tests/Functional/FrontScriptTest.php
+++ b/tests/Functional/FrontScriptTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace PhpTuf\ComposerStager\Tests\Unit\Console;
-
-use PHPUnit\Framework\TestCase;
+namespace PhpTuf\ComposerStager\Tests\Functional;
 
 /**
  * @coversNothing This actually covers the front script, obviously, but PHPUnit
@@ -38,20 +36,5 @@ class FrontScriptTest extends TestCase
             'list',
             'stage',
         ], $commands);
-    }
-
-    private function runFrontScript(string $commandString): array
-    {
-        $output = [];
-
-        $command = implode(' ', [
-            'bin' => 'php',
-            'script_path' => __DIR__ . '/../../../bin/composer-stage',
-            'command_string' => $commandString,
-        ]);
-
-        exec($command, $output);
-
-        return $output;
     }
 }

--- a/tests/Functional/FrontScriptTest.php
+++ b/tests/Functional/FrontScriptTest.php
@@ -14,16 +14,18 @@ class FrontScriptTest extends TestCase
      */
     public function testBasicExecution(): void
     {
-        $output = $this->runFrontScript('--version');
+        $process = self::runFrontScript(['--version']);
+        $output = $process->getOutput();
 
-        self::assertStringStartsWith('Composer Stager v', $output[0]);
+        self::assertStringStartsWith('Composer Stager v', $output);
     }
 
     public function testCommandList(): void
     {
-        $output = $this->runFrontScript('--format=json list');
+        $process = self::runFrontScript(['--format=json', 'list']);
+        $output = $process->getOutput();
 
-        $data = json_decode($output[0], true, 512, JSON_THROW_ON_ERROR);
+        $data = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
         $commands = array_map(static function ($value) {
             return $value['name'];
         }, $data['commands']);

--- a/tests/Functional/SymfonyFileCopierTest.php
+++ b/tests/Functional/SymfonyFileCopierTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Tests\Functional;
+
+use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopier;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopier
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopier::__construct
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopier::copy
+ */
+class SymfonyFileCopierTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::createTestEnvironment();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::removeTestEnvironment();
+    }
+
+    private function createSut(): SymfonyFileCopier
+    {
+        $filesystem = new Filesystem();
+        return new SymfonyFileCopier($filesystem);
+    }
+
+    /**
+     * @covers ::createIterator
+     */
+    public function testCopy(): void
+    {
+        touch(self::ACTIVE_DIR . '/lorem.txt');
+        touch(self::ACTIVE_DIR . '/ipsum.txt');
+        $sut = $this->createSut();
+
+        $sut->copy(self::ACTIVE_DIR, self::STAGING_DIR, []);
+
+        self::assertActiveAndStagingDirectoriesSame();
+    }
+
+    /**
+     * @covers ::createIterator
+     * @uses \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
+     * @uses \PhpTuf\ComposerStager\Exception\PathException
+     * @uses \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopier
+     */
+    public function testCopyFromDirectoryNotFound(): void
+    {
+        $this->expectException(DirectoryNotFoundException::class);
+
+        $sut = $this->createSut();
+
+        $sut->copy('non-existent/directory', 'lorem/ipsum');
+    }
+}

--- a/tests/Functional/TestCase.php
+++ b/tests/Functional/TestCase.php
@@ -2,40 +2,18 @@
 
 namespace PhpTuf\ComposerStager\Tests\Functional;
 
+use Symfony\Component\Process\Process;
+
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    protected function runFrontScript(string $commandString): array
+    protected static function runFrontScript(array $args, string $cwd = __DIR__): Process
     {
-        $command = implode(' ', [
+        $command = array_merge([
             'bin' => 'php',
             'scriptPath' => realpath(__DIR__ . '/../../bin/composer-stage'),
-            'commandString' => $commandString,
-        ]);
-
-        return self::exec($command);
-    }
-
-    protected static function exec(string $command): array
-    {
-        // These ridiculous proc_open() acrobatics are necessary to prevent tests
-        // from printing output, because it is impossible to suppress stderr
-        // from exec() and other simpler functions, even with output buffering.
-        // @see https://stackoverflow.com/questions/33171386/capture-supress-all-output-from-php-exec-including-stderr
-        // @see https://www.php.net/manual/function.proc-open.php
-        $process = proc_open($command, [
-            0 => ['pipe', 'r'],
-            1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
-        ], $pipes);
-
-        if (!is_resource($process)) {
-            throw new \RuntimeException('Could not create a valid process.');
-        }
-
-        $stdout = stream_get_contents($pipes[1]);
-
-        proc_close($process);
-
-        return explode(PHP_EOL, $stdout);
+        ], $args);
+        $process = new Process($command, $cwd);
+        $process->mustRun();
+        return $process;
     }
 }

--- a/tests/Functional/TestCase.php
+++ b/tests/Functional/TestCase.php
@@ -75,7 +75,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         self::assertSame(
             '',
-            self::activeAndStagingDirectoriesDiff(),
+            self::getActiveAndStagingDirectoriesDiff(),
             'Active and staging directories are the same.'
         );
     }
@@ -84,12 +84,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         self::assertNotSame(
             '',
-            self::activeAndStagingDirectoriesDiff(),
+            self::getActiveAndStagingDirectoriesDiff(),
             'Active and staging directories are not the same.'
         );
     }
 
-    protected static function activeAndStagingDirectoriesDiff(): string
+    protected static function getActiveAndStagingDirectoriesDiff(): string
     {
         $process = new Process([
             'diff',

--- a/tests/Functional/TestCase.php
+++ b/tests/Functional/TestCase.php
@@ -2,10 +2,59 @@
 
 namespace PhpTuf\ComposerStager\Tests\Functional;
 
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    protected const TEST_ENV = __DIR__ . '/../../var/phpunit/test-env';
+    protected const ACTIVE_DIR = 'active-dir';
+    protected const STAGING_DIR = 'staging-dir';
+
+    protected static function createTestEnvironment(): void
+    {
+        $filesystem = new Filesystem();
+
+        // Create the test environment and cd into it,
+        $filesystem->mkdir(self::TEST_ENV);
+        chdir(self::TEST_ENV);
+
+        // Create the active directory only. The staging directory is created
+        // when the "begin" command is exercised.
+        $filesystem->mkdir(self::ACTIVE_DIR);
+    }
+
+    protected static function removeTestEnvironment(): void
+    {
+        $filesystem = new Filesystem();
+        if ($filesystem->exists(self::TEST_ENV)) {
+            try {
+                $filesystem->remove(self::TEST_ENV);
+            } catch (IOException $e) {
+                // @todo Windows chokes on this every time, e.g.,
+                //    | Failed to remove directory
+                //    | "D:\a\composer-stager\composer-stager\tests\Functional/../../var/phpunit/test-env":
+                //    | rmdir(D:\a\composer-stager\composer-stager\tests\Functional/../../var/phpunit/test-env):
+                //    | Resource temporarily unavailable.
+                //   Obviously, this error suppression is likely to bite us in the future
+                //   even though it doesn't seem to cause any problems now. Fix it.
+            }
+        }
+    }
+
+    protected static function initializeComposerJson(): void
+    {
+        $process = new Process([
+            'composer',
+            '--working-dir=' . self::ACTIVE_DIR,
+            'init',
+            '--name=lorem/ipsum',
+            '--no-interaction',
+        ]);
+        $process->mustRun();
+    }
+
     protected static function runFrontScript(array $args, string $cwd = __DIR__): Process
     {
         $command = array_merge([
@@ -15,5 +64,39 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $process = new Process($command, $cwd);
         $process->mustRun();
         return $process;
+    }
+
+    protected static function assertStagingDirectoryDoesNotExist(): void
+    {
+        self::assertFileDoesNotExist(self::STAGING_DIR, 'Staging directory does not exist.');
+    }
+
+    protected static function assertActiveAndStagingDirectoriesSame(): void
+    {
+        self::assertSame(
+            '',
+            self::activeAndStagingDirectoriesDiff(),
+            'Active and staging directories are the same.'
+        );
+    }
+
+    protected static function assertActiveAndStagingDirectoriesNotSame(): void
+    {
+        self::assertNotSame(
+            '',
+            self::activeAndStagingDirectoriesDiff(),
+            'Active and staging directories are not the same.'
+        );
+    }
+
+    protected static function activeAndStagingDirectoriesDiff(): string
+    {
+        $process = new Process([
+            'diff',
+            self::ACTIVE_DIR,
+            self::STAGING_DIR,
+        ]);
+        $process->run();
+        return $process->getOutput();
     }
 }

--- a/tests/Unit/Domain/BeginnerTest.php
+++ b/tests/Unit/Domain/BeginnerTest.php
@@ -6,7 +6,7 @@ use PhpTuf\ComposerStager\Domain\Beginner;
 use PhpTuf\ComposerStager\Exception\DirectoryAlreadyExistsException;
 use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
 use PhpTuf\ComposerStager\Infrastructure\Filesystem\FilesystemInterface;
-use PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\RsyncFileCopierInterface;
 use PhpTuf\ComposerStager\Tests\Unit\TestCase;
 
 /**
@@ -17,13 +17,13 @@ use PhpTuf\ComposerStager\Tests\Unit\TestCase;
  * @uses \PhpTuf\ComposerStager\Exception\PathException
  *
  * @property \PhpTuf\ComposerStager\Infrastructure\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy filesystem
- * @property \PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface|\Prophecy\Prophecy\ObjectProphecy fileCopier
+ * @property \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\RsyncFileCopierInterface|\Prophecy\Prophecy\ObjectProphecy fileCopier
  */
 class BeginnerTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->fileCopier = $this->prophesize(FileCopierInterface::class);
+        $this->fileCopier = $this->prophesize(RsyncFileCopierInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
             ->exists(self::ACTIVE_DIR_DEFAULT)

--- a/tests/Unit/Domain/CommitterTest.php
+++ b/tests/Unit/Domain/CommitterTest.php
@@ -6,7 +6,7 @@ use PhpTuf\ComposerStager\Domain\Committer;
 use PhpTuf\ComposerStager\Exception\DirectoryNotFoundException;
 use PhpTuf\ComposerStager\Exception\DirectoryNotWritableException;
 use PhpTuf\ComposerStager\Infrastructure\Filesystem\FilesystemInterface;
-use PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface;
 use PhpTuf\ComposerStager\Tests\Unit\TestCase;
 use Prophecy\Argument;
 
@@ -18,7 +18,7 @@ use Prophecy\Argument;
  * @uses \PhpTuf\ComposerStager\Exception\PathException
  *
  * @property \PhpTuf\ComposerStager\Infrastructure\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy filesystem
- * @property \PhpTuf\ComposerStager\Infrastructure\Process\FileCopierInterface|\Prophecy\Prophecy\ObjectProphecy fileCopier
+ * @property \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierInterface|\Prophecy\Prophecy\ObjectProphecy fileCopier
  */
 class CommitterTest extends TestCase
 {

--- a/tests/Unit/Infrastructure/Process/FileCopier/FileCopierFactoryTest.php
+++ b/tests/Unit/Infrastructure/Process/FileCopier/FileCopierFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Tests\Unit\Infrastructure\Process\FileCopier;
+
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierFactory;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\RsyncFileCopierInterface;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopierInterface;
+use PhpTuf\ComposerStager\Tests\Unit\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Process\ExecutableFinder;
+
+/**
+ * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\FileCopierFactory
+ * @covers ::__construct
+ *
+ * @property \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\RsyncFileCopier|\Prophecy\Prophecy\ObjectProphecy rsyncFileCopier
+ * @property \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopierInterface|\Prophecy\Prophecy\ObjectProphecy symfonyFileCopier
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Process\ExecutableFinder executableFinder
+ */
+class FileCopierFactoryTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->executableFinder = $this->prophesize(ExecutableFinder::class);
+        $this->executableFinder
+            ->find(Argument::any())
+            ->willReturn(null);
+        $this->rsyncFileCopier = $this->prophesize(RsyncFileCopierInterface::class);
+        $this->symfonyFileCopier = $this->prophesize(SymfonyFileCopierInterface::class);
+    }
+
+    private function createSut(): FileCopierFactory
+    {
+        $executableFinder = $this->executableFinder->reveal();
+        $rsyncFileCopier = $this->rsyncFileCopier->reveal();
+        $symfonyFileCopier = $this->symfonyFileCopier->reveal();
+        return new FileCopierFactory($executableFinder, $rsyncFileCopier, $symfonyFileCopier);
+    }
+
+    /**
+     * @covers ::create
+     *
+     * @dataProvider providerCreate
+     */
+    public function testCreate($executable, $calledTimes, $path, $instanceOf): void
+    {
+        $this->executableFinder
+            ->find($executable)
+            ->shouldBeCalledTimes($calledTimes)
+            ->willReturn($path);
+        $sut = $this->createSut();
+
+        $fileCopier = $sut->create();
+
+        self::assertInstanceOf($instanceOf, $fileCopier, 'Returned correct file copier.');
+    }
+
+    public function providerCreate(): array
+    {
+        return [
+            [
+                'executable' => 'rsync',
+                'calledTimes' => 1,
+                'path' => '/usr/bin/rsync',
+                'instanceOf' => RsyncFileCopierInterface::class,
+            ],
+            [
+                'executable' => 'n/a',
+                'calledTimes' => 0,
+                'path' => null,
+                'instanceOf' => SymfonyFileCopierInterface::class,
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Infrastructure/Process/FileCopier/RsyncFileCopierTest.php
+++ b/tests/Unit/Infrastructure/Process/FileCopier/RsyncFileCopierTest.php
@@ -1,33 +1,33 @@
 <?php
 
-namespace PhpTuf\ComposerStager\Tests\Unit\Infrastructure\Process;
+namespace PhpTuf\ComposerStager\Tests\Unit\Infrastructure\Process\FileCopier;
 
 use PhpTuf\ComposerStager\Exception\IOException;
 use PhpTuf\ComposerStager\Exception\LogicException;
 use PhpTuf\ComposerStager\Exception\ProcessFailedException;
-use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\RsyncFileCopier;
 use PhpTuf\ComposerStager\Infrastructure\Process\Runner\RsyncRunnerInterface;
 use PhpTuf\ComposerStager\Tests\Unit\Domain\TestProcessOutputCallback;
 use PhpTuf\ComposerStager\Tests\Unit\TestCase;
 use Prophecy\Argument;
 
 /**
- * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier
+ * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\RsyncFileCopier
  * @covers ::__construct
  *
  * @property \PhpTuf\ComposerStager\Infrastructure\Process\Runner\RsyncRunnerInterface|\Prophecy\Prophecy\ObjectProphecy rsync
  */
-class FileCopierTest extends TestCase
+class RsyncFileCopierTest extends TestCase
 {
     public function setUp(): void
     {
         $this->rsync = $this->prophesize(RsyncRunnerInterface::class);
     }
 
-    protected function createSut(): FileCopier
+    protected function createSut(): RsyncFileCopier
     {
         $rsync = $this->rsync->reveal();
-        return new FileCopier($rsync);
+        return new RsyncFileCopier($rsync);
     }
 
     /**
@@ -40,9 +40,9 @@ class FileCopierTest extends TestCase
         $this->rsync
             ->run($command, $callback)
             ->shouldBeCalledOnce();
-        $copier = $this->createSut();
+        $sut = $this->createSut();
 
-        $copier->copy($from, $to, [], $callback);
+        $sut->copy($from, $to, [], $callback);
     }
 
     public function providerCopy(): array
@@ -87,9 +87,9 @@ class FileCopierTest extends TestCase
         $this->rsync
             ->run(Argument::cetera())
             ->willThrow($exception);
-        $copier = $this->createSut();
+        $sut = $this->createSut();
 
-        $copier->copy('lorem', 'ipsum', []);
+        $sut->copy('lorem', 'ipsum', []);
     }
 
     public function providerCopyFailure(): array

--- a/tests/Unit/Infrastructure/Process/FileCopier/SymfonyFileCopierTest.php
+++ b/tests/Unit/Infrastructure/Process/FileCopier/SymfonyFileCopierTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace PhpTuf\ComposerStager\Tests\Unit\Infrastructure\Process\FileCopier;
+
+use PhpTuf\ComposerStager\Exception\ProcessFailedException;
+use PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopier;
+use PhpTuf\ComposerStager\Tests\Unit\Domain\TestProcessOutputCallback;
+use PhpTuf\ComposerStager\Tests\Unit\TestCase;
+use Prophecy\Argument;
+use RecursiveCallbackFilterIterator;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Process\FileCopier\SymfonyFileCopier
+ * @covers ::__construct
+ * @covers ::createIterator
+ *
+ * @property \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Filesystem\Filesystem filesystem
+ */
+class SymfonyFileCopierTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->filesystem = $this->prophesize(Filesystem::class);
+    }
+
+    protected function createSut(): SymfonyFileCopier
+    {
+        $filesystem = $this->filesystem->reveal();
+        return new SymfonyFileCopier($filesystem);
+    }
+
+    /**
+     * @covers ::copy
+     *
+     * @dataProvider providerCopy
+     */
+    public function testCopy($from, $to, $exclusions, $callback): void
+    {
+        $this->filesystem
+            ->mirror($from, $to, Argument::type(RecursiveCallbackFilterIterator::class))
+            ->shouldBeCalledOnce();
+        $sut = $this->createSut();
+
+        $sut->copy($from, $to, $exclusions, $callback);
+    }
+
+    public function providerCopy(): array
+    {
+        return [
+            [
+                'from' => '.',
+                'to' => 'ipsum/lorem',
+                'exclusions' => [],
+                'callback' => null,
+            ],
+            [
+                'from' => '..',
+                'to' => 'dolor/sit',
+                'exclusions' => [
+                    'amet',
+                    'consectetur',
+                ],
+                'callback' => new TestProcessOutputCallback(),
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::copy
+     */
+    public function testCopyFailure(): void
+    {
+        $this->expectException(ProcessFailedException::class);
+
+        $this->filesystem
+            ->mirror(Argument::cetera())
+            ->willThrow(IOException::class);
+        $copier = $this->createSut();
+
+        $copier->copy('.', 'lorem', []);
+    }
+}


### PR DESCRIPTION
This adds a Symfony Filesystem-based file copier that's automatically used on hosts (like Windows) that don't have `rsync` available. It also adds full, end-to-end functional testing of the entire project. Functional tests are currently restricted to the happy path. We can decide later which edge error/edge conditions are important enough to test.