### PR TITLE
Allow process runners to accept an arbitrary timeout

### DIFF
--- a/src/Domain/Beginner.php
+++ b/src/Domain/Beginner.php
@@ -26,8 +26,12 @@ final class Beginner implements BeginnerInterface
         $this->filesystem = $filesystem;
     }
 
-    public function begin(string $activeDir, string $stagingDir, ?ProcessOutputCallbackInterface $callback = null): void
-    {
+    public function begin(
+        string $activeDir,
+        string $stagingDir,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void {
         if (!$this->filesystem->exists($activeDir)) {
             throw new DirectoryNotFoundException($activeDir, 'The active directory does not exist at "%s"');
         }
@@ -46,7 +50,8 @@ final class Beginner implements BeginnerInterface
             $activeDir,
             $stagingDir,
             $exclusions,
-            $callback
+            $callback,
+            $timeout
         );
     }
 }

--- a/src/Domain/BeginnerInterface.php
+++ b/src/Domain/BeginnerInterface.php
@@ -20,6 +20,9 @@ interface BeginnerInterface
      *   directory (CWD), e.g., "/var/www/staging" or "staging".
      * @param \PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @throws \PhpTuf\ComposerStager\Exception\DirectoryAlreadyExistsException
      *   If the staging directory already exists.
@@ -28,5 +31,10 @@ interface BeginnerInterface
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
      *   If the command process doesn't terminate successfully.
      */
-    public function begin(string $activeDir, string $stagingDir, ?ProcessOutputCallbackInterface $callback = null): void;
+    public function begin(
+        string $activeDir,
+        string $stagingDir,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void;
 }

--- a/src/Domain/Cleaner.php
+++ b/src/Domain/Cleaner.php
@@ -17,13 +17,13 @@ final class Cleaner implements CleanerInterface
         $this->filesystem = $filesystem;
     }
 
-    public function clean(string $stagingDir): void
+    public function clean(string $stagingDir, ?int $timeout = 120): void
     {
         if (!$this->directoryExists($stagingDir)) {
             throw new DirectoryNotFoundException($stagingDir, 'The staging directory does not exist at "%s"');
         }
 
-        $this->filesystem->remove($stagingDir);
+        $this->filesystem->remove($stagingDir, $timeout);
     }
 
     public function directoryExists(string $stagingDir): bool

--- a/src/Domain/CleanerInterface.php
+++ b/src/Domain/CleanerInterface.php
@@ -13,13 +13,16 @@ interface CleanerInterface
      * @param string $stagingDir
      *   The staging directory as an absolute path or relative to the working
      *   directory (CWD), e.g., "/var/www/staging" or "staging".
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @throws \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
      *   If the staging directory is not found.
      * @throws \PhpTuf\ComposerStager\Exception\IOException
      *   If removal fails.
      */
-    public function clean(string $stagingDir): void;
+    public function clean(string $stagingDir, ?int $timeout = 120): void;
 
     /**
      * Determines whether or not the staging directory exists.

--- a/src/Domain/Committer.php
+++ b/src/Domain/Committer.php
@@ -26,8 +26,12 @@ final class Committer implements CommitterInterface
         $this->filesystem = $filesystem;
     }
 
-    public function commit(string $stagingDir, string $activeDir, ?ProcessOutputCallbackInterface $callback = null): void
-    {
+    public function commit(
+        string $stagingDir,
+        string $activeDir,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void {
         if (!$this->filesystem->exists($stagingDir)) {
             throw new DirectoryNotFoundException($stagingDir, 'The staging directory does not exist at "%s"');
         }
@@ -40,7 +44,7 @@ final class Committer implements CommitterInterface
             throw new DirectoryNotWritableException($activeDir, 'The active directory is not writable at "%s"');
         }
 
-        $this->fileCopier->copy($stagingDir, $activeDir, [], $callback);
+        $this->fileCopier->copy($stagingDir, $activeDir, [], $callback, $timeout);
     }
 
     public function directoryExists(string $stagingDir): bool

--- a/src/Domain/CommitterInterface.php
+++ b/src/Domain/CommitterInterface.php
@@ -20,6 +20,9 @@ interface CommitterInterface
      *   directory (CWD), e.g., "/var/www/public" or "public".
      * @param \PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @throws \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
      *   If the active directory or the staging directory is not found.
@@ -28,7 +31,12 @@ interface CommitterInterface
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
      *   If the command process doesn't terminate successfully.
      */
-    public function commit(string $stagingDir, string $activeDir, ?ProcessOutputCallbackInterface $callback = null): void;
+    public function commit(
+        string $stagingDir,
+        string $activeDir,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void;
 
     /**
      * Determines whether or not the staging directory exists.

--- a/src/Domain/Stager.php
+++ b/src/Domain/Stager.php
@@ -41,12 +41,16 @@ final class Stager implements StagerInterface
         $this->filesystem = $filesystem;
     }
 
-    public function stage(array $composerCommand, string $stagingDir, ?ProcessOutputCallbackInterface $callback = null): void
-    {
+    public function stage(
+        array $composerCommand,
+        string $stagingDir,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void {
         $this->composerCommand = $composerCommand;
         $this->stagingDir = $stagingDir;
         $this->validate();
-        $this->runCommand($callback);
+        $this->runCommand($callback, $timeout);
     }
 
     /**
@@ -94,14 +98,14 @@ final class Stager implements StagerInterface
     /**
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
      */
-    private function runCommand(?ProcessOutputCallbackInterface $callback): void
+    private function runCommand(?ProcessOutputCallbackInterface $callback, ?int $timeout): void
     {
         $command = array_merge(
             ['--working-dir=' . $this->stagingDir],
             $this->composerCommand
         );
         try {
-            $this->composerRunner->run($command, $callback);
+            $this->composerRunner->run($command, $callback, $timeout);
         } catch (ExceptionInterface $e) {
             throw new ProcessFailedException($e->getMessage(), (int) $e->getCode(), $e);
         }

--- a/src/Domain/StagerInterface.php
+++ b/src/Domain/StagerInterface.php
@@ -28,6 +28,9 @@ interface StagerInterface
      *   directory (CWD), e.g., "/var/www/staging" or "staging".
      * @param \PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @throws \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
      *   If the staging directory is not found.
@@ -38,5 +41,10 @@ interface StagerInterface
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
      *   If the command process doesn't terminate successfully.
      */
-    public function stage(array $composerCommand, string $stagingDir, ?ProcessOutputCallbackInterface $callback = null): void;
+    public function stage(
+        array $composerCommand,
+        string $stagingDir,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void;
 }

--- a/src/Infrastructure/Filesystem/Filesystem.php
+++ b/src/Infrastructure/Filesystem/Filesystem.php
@@ -40,9 +40,13 @@ final class Filesystem implements FilesystemInterface
         return is_writable($path); // @codeCoverageIgnore
     }
 
-    public function remove(string $path): void
+    public function remove(string $path, ?int $timeout = 120): void
     {
         try {
+            // Symfony Filesystem doesn't have a builtin mechanism for setting a
+            // timeout, so we have to enforce it ourselves.
+            set_time_limit((int) $timeout);
+
             $this->symfonyFilesystem->remove($path);
         } catch (ExceptionInterface $e) {
             throw new IOException($e->getMessage(), (int) $e->getCode(), $e);

--- a/src/Infrastructure/Filesystem/FilesystemInterface.php
+++ b/src/Infrastructure/Filesystem/FilesystemInterface.php
@@ -43,9 +43,12 @@ interface FilesystemInterface
      * @param string $path
      *   A path as absolute or relative to the working directory (CWD), e.g.,
      *   "/var/www/public" or "public".
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @throws \PhpTuf\ComposerStager\Exception\IOException
      *   If removal fails.
      */
-    public function remove(string $path): void;
+    public function remove(string $path, ?int $timeout = 120): void;
 }

--- a/src/Infrastructure/Process/FileCopier/FileCopierInterface.php
+++ b/src/Infrastructure/Process/FileCopier/FileCopierInterface.php
@@ -22,6 +22,9 @@ interface FileCopierInterface
      *   Paths to exclude, relative to the "from" path.
      * @param \PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @throws \PhpTuf\ComposerStager\Exception\DirectoryNotFoundException
      *   If the source ("from") directory is not found.
@@ -32,6 +35,7 @@ interface FileCopierInterface
         string $from,
         string $to,
         array $exclusions = [],
-        ?ProcessOutputCallbackInterface $callback = null
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
     ): void;
 }

--- a/src/Infrastructure/Process/FileCopier/RsyncFileCopier.php
+++ b/src/Infrastructure/Process/FileCopier/RsyncFileCopier.php
@@ -22,8 +22,13 @@ final class RsyncFileCopier implements RsyncFileCopierInterface
         $this->rsync = $rsync;
     }
 
-    public function copy(string $from, string $to, array $exclusions = [], ?ProcessOutputCallbackInterface $callback = null): void
-    {
+    public function copy(
+        string $from,
+        string $to,
+        array $exclusions = [],
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void {
         $command = [
             '--recursive',
             // The "--links" option is added to "copy symlinks as symlinks",

--- a/src/Infrastructure/Process/FileCopier/SymfonyFileCopier.php
+++ b/src/Infrastructure/Process/FileCopier/SymfonyFileCopier.php
@@ -27,9 +27,18 @@ final class SymfonyFileCopier implements SymfonyFileCopierInterface
         $this->filesystem = $filesystem;
     }
 
-    public function copy(string $from, string $to, array $exclusions = [], ?ProcessOutputCallbackInterface $callback = null): void
-    {
+    public function copy(
+        string $from,
+        string $to,
+        array $exclusions = [],
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void {
         try {
+            // Symfony Filesystem doesn't have a builtin mechanism for setting a
+            // timeout, so we have to enforce it ourselves.
+            set_time_limit((int) $timeout);
+
             $iterator = $this->createIterator($from);
             $this->filesystem->mirror($from, $to, $iterator);
         } catch (IOException $e) {

--- a/src/Infrastructure/Process/Runner/AbstractRunner.php
+++ b/src/Infrastructure/Process/Runner/AbstractRunner.php
@@ -22,6 +22,11 @@ abstract class AbstractRunner
     private $executableFinder;
 
     /**
+     * The process timeout in seconds, or NULL to never time out.
+     */
+    protected $timeout = 60;
+
+    /**
      * Returns the executable name, e.g., "composer" or "rsync".
      */
     abstract protected function executableName(): string;
@@ -57,7 +62,8 @@ abstract class AbstractRunner
     public function run(array $command, ?ProcessOutputCallbackInterface $callback = null): void
     {
         array_unshift($command, $this->findExecutable());
-        $process = $this->processFactory->create($command);
+        $process = $this->processFactory->create($command)
+            ->setTimeout($this->timeout);
         try {
             $process->mustRun($callback);
         } catch (SymfonyExceptionInterface $e) {

--- a/src/Infrastructure/Process/Runner/AbstractRunner.php
+++ b/src/Infrastructure/Process/Runner/AbstractRunner.php
@@ -22,11 +22,11 @@ abstract class AbstractRunner
     private $executableFinder;
 
     /**
-     * The process timeout in seconds, or NULL to never time out.
+     * The process timeout in seconds, or null to never time out.
      *
-     * @var int
+     * @var int|null
      */
-    protected $timeout = 60;
+    private $timeout;
 
     /**
      * Returns the executable name, e.g., "composer" or "rsync".
@@ -38,10 +38,11 @@ abstract class AbstractRunner
      */
     private $processFactory;
 
-    public function __construct(ExecutableFinderInterface $executableFinder, ProcessFactoryInterface $processFactory)
+    public function __construct(ExecutableFinderInterface $executableFinder, ProcessFactoryInterface $processFactory, ?int $timeout = 60)
     {
         $this->executableFinder = $executableFinder;
         $this->processFactory = $processFactory;
+        $this->timeout = $timeout;
     }
 
     /**

--- a/src/Infrastructure/Process/Runner/AbstractRunner.php
+++ b/src/Infrastructure/Process/Runner/AbstractRunner.php
@@ -60,6 +60,8 @@ abstract class AbstractRunner
      *   If the command process cannot be created.
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
      *   If the command process doesn't terminate successfully.
+     * @throws \InvalidArgumentException
+     *   If the timeout is negative.
      */
     public function run(array $command, ?ProcessOutputCallbackInterface $callback = null): void
     {

--- a/src/Infrastructure/Process/Runner/AbstractRunner.php
+++ b/src/Infrastructure/Process/Runner/AbstractRunner.php
@@ -66,8 +66,8 @@ abstract class AbstractRunner
     public function run(array $command, ?ProcessOutputCallbackInterface $callback = null): void
     {
         array_unshift($command, $this->findExecutable());
-        $process = $this->processFactory->create($command)
-            ->setTimeout($this->timeout);
+        $process = $this->processFactory->create($command);
+        $process->setTimeout($this->timeout);
         try {
             $process->mustRun($callback);
         } catch (SymfonyExceptionInterface $e) {

--- a/src/Infrastructure/Process/Runner/AbstractRunner.php
+++ b/src/Infrastructure/Process/Runner/AbstractRunner.php
@@ -23,6 +23,8 @@ abstract class AbstractRunner
 
     /**
      * The process timeout in seconds, or NULL to never time out.
+     *
+     * @var int
      */
     protected $timeout = 60;
 

--- a/src/Infrastructure/Process/Runner/ComposerRunnerInterface.php
+++ b/src/Infrastructure/Process/Runner/ComposerRunnerInterface.php
@@ -26,6 +26,9 @@ interface ComposerRunnerInterface
      *
      * @param \PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @see https://symfony.com/doc/current/components/process.html#running-processes-asynchronously
      *
@@ -36,5 +39,9 @@ interface ComposerRunnerInterface
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
      *   If the command process doesn't terminate successfully.
      */
-    public function run(array $command, ?ProcessOutputCallbackInterface $callback = null): void;
+    public function run(
+        array $command,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void;
 }

--- a/src/Infrastructure/Process/Runner/RsyncRunner.php
+++ b/src/Infrastructure/Process/Runner/RsyncRunner.php
@@ -13,6 +13,9 @@ namespace PhpTuf\ComposerStager\Infrastructure\Process\Runner;
  */
 final class RsyncRunner extends AbstractRunner implements RsyncRunnerInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     protected $timeout = 300;
 
     protected function executableName(): string

--- a/src/Infrastructure/Process/Runner/RsyncRunner.php
+++ b/src/Infrastructure/Process/Runner/RsyncRunner.php
@@ -13,11 +13,6 @@ namespace PhpTuf\ComposerStager\Infrastructure\Process\Runner;
  */
 final class RsyncRunner extends AbstractRunner implements RsyncRunnerInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected $timeout = 300;
-
     protected function executableName(): string
     {
         return 'rsync'; // @codeCoverageIgnore

--- a/src/Infrastructure/Process/Runner/RsyncRunner.php
+++ b/src/Infrastructure/Process/Runner/RsyncRunner.php
@@ -13,6 +13,8 @@ namespace PhpTuf\ComposerStager\Infrastructure\Process\Runner;
  */
 final class RsyncRunner extends AbstractRunner implements RsyncRunnerInterface
 {
+    protected $timeout = 300;
+
     protected function executableName(): string
     {
         return 'rsync'; // @codeCoverageIgnore

--- a/src/Infrastructure/Process/Runner/RsyncRunnerInterface.php
+++ b/src/Infrastructure/Process/Runner/RsyncRunnerInterface.php
@@ -26,6 +26,9 @@ interface RsyncRunnerInterface
      *
      * @param \PhpTuf\ComposerStager\Domain\Output\ProcessOutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
+     * @param int|null $timeout
+     *   An optional process timeout (maximum runtime) in seconds. Set to null
+     *   to disable.
      *
      * @see https://symfony.com/doc/current/components/process.html#running-processes-asynchronously
      *
@@ -36,5 +39,9 @@ interface RsyncRunnerInterface
      * @throws \PhpTuf\ComposerStager\Exception\ProcessFailedException
      *   If the command process doesn't terminate successfully.
      */
-    public function run(array $command, ?ProcessOutputCallbackInterface $callback = null): void;
+    public function run(
+        array $command,
+        ?ProcessOutputCallbackInterface $callback = null,
+        ?int $timeout = 120
+    ): void;
 }

--- a/tests/Unit/Domain/BeginnerTest.php
+++ b/tests/Unit/Domain/BeginnerTest.php
@@ -45,7 +45,7 @@ class BeginnerTest extends TestCase
      *
      * @dataProvider providerBeginHappyPath
      */
-    public function testBeginHappyPath($activeDir, $stagingDir, $callback): void
+    public function testBeginHappyPath($activeDir, $stagingDir, $callback, $timeout): void
     {
         $this->filesystem
             ->exists($activeDir)
@@ -58,11 +58,11 @@ class BeginnerTest extends TestCase
             '.git',
         ];
         $this->fileCopier
-            ->copy($activeDir, $stagingDir, $exclusions, $callback)
+            ->copy($activeDir, $stagingDir, $exclusions, $callback, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->begin($activeDir, $stagingDir, $callback);
+        $sut->begin($activeDir, $stagingDir, $callback, $timeout);
     }
 
     public function providerBeginHappyPath(): array
@@ -72,11 +72,13 @@ class BeginnerTest extends TestCase
                 'activeDir' => 'lorem/ipsum',
                 'stagingDir' => 'dolor/sit',
                 'callback' => null,
+                'timeout' => null,
             ],
             [
                 'activeDir' => 'dolor/sit',
                 'stagingDir' => 'lorem/ipsum',
                 'callback' => new TestProcessOutputCallback(),
+                'timeout' => 100,
             ],
         ];
     }

--- a/tests/Unit/Domain/CleanerTest.php
+++ b/tests/Unit/Domain/CleanerTest.php
@@ -24,7 +24,7 @@ class CleanerTest extends TestCase
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
-            ->exists(static::STAGING_DIR_DEFAULT)
+            ->exists(Argument::any())
             ->willReturn(true);
     }
 
@@ -36,15 +36,31 @@ class CleanerTest extends TestCase
 
     /**
      * @covers ::clean
+     *
+     * @dataProvider providerCleanHappyPath
      */
-    public function testCleanHappyPath(): void
+    public function testCleanHappyPath($path, $timeout): void
     {
         $this->filesystem
-            ->remove(static::STAGING_DIR_DEFAULT)
+            ->remove($path, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->clean(static::STAGING_DIR_DEFAULT);
+        $sut->clean($path, $timeout);
+    }
+
+    public function providerCleanHappyPath(): array
+    {
+        return [
+            [
+                'path' => '/lorem/ipsum',
+                'timeout' => null,
+            ],
+            [
+                'path' => '/dolor/sit',
+                'timeout' => 10,
+            ],
+        ];
     }
 
     /**
@@ -100,7 +116,7 @@ class CleanerTest extends TestCase
         $exception = new IOException();
         $this->expectExceptionObject($exception);
         $this->filesystem
-            ->remove(Argument::any())
+            ->remove(Argument::cetera())
             ->shouldBeCalledOnce()
             ->willThrow($exception);
         $sut = $this->createSut();

--- a/tests/Unit/Domain/CommitterTest.php
+++ b/tests/Unit/Domain/CommitterTest.php
@@ -47,7 +47,7 @@ class CommitterTest extends TestCase
     public function testCommitWithMinimumParams(): void
     {
         $this->fileCopier
-            ->copy(self::STAGING_DIR_DEFAULT, self::ACTIVE_DIR_DEFAULT, [], null)
+            ->copy(self::STAGING_DIR_DEFAULT, self::ACTIVE_DIR_DEFAULT, [], Argument::cetera())
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -59,14 +59,14 @@ class CommitterTest extends TestCase
      *
      * @dataProvider providerCommitWithOptionalParams
      */
-    public function testCommitWithOptionalParams($stagingDir, $activeDir, $callback): void
+    public function testCommitWithOptionalParams($stagingDir, $activeDir, $callback, $timeout): void
     {
         $this->fileCopier
-            ->copy($stagingDir, $activeDir, [], $callback)
+            ->copy($stagingDir, $activeDir, [], $callback, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->commit($stagingDir, $activeDir, $callback);
+        $sut->commit($stagingDir, $activeDir, $callback, $timeout);
     }
 
     public function providerCommitWithOptionalParams(): array
@@ -76,11 +76,13 @@ class CommitterTest extends TestCase
                 'stagingDir' => '/lorem/ipsum',
                 'activeDir' => '/dolor/sit',
                 'callback' => null,
+                'timeout' => null,
             ],
             [
                 'stagingDir' => 'amet/consectetur',
                 'activeDir' => 'adipiscing/elit',
                 'callback' => new TestProcessOutputCallback(),
+                'timeout' => 10,
             ],
         ];
     }

--- a/tests/Unit/Domain/StagerTest.php
+++ b/tests/Unit/Domain/StagerTest.php
@@ -51,14 +51,14 @@ class StagerTest extends TestCase
     /**
      * @dataProvider providerHappyPath
      */
-    public function testHappyPath($givenCommand, $expectedCommand, $callback): void
+    public function testHappyPath($givenCommand, $expectedCommand, $callback, $timeout): void
     {
         $this->composerRunner
-            ->run($expectedCommand, $callback)
+            ->run($expectedCommand, $callback, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->stage($givenCommand, static::STAGING_DIR_DEFAULT, $callback);
+        $sut->stage($givenCommand, static::STAGING_DIR_DEFAULT, $callback, $timeout);
     }
 
     public function providerHappyPath(): array
@@ -71,6 +71,7 @@ class StagerTest extends TestCase
                     'update',
                 ],
                 'callback' => null,
+                'timeout' => null,
             ],
             [
                 'givenCommand' => [static::INERT_COMMAND],
@@ -79,6 +80,7 @@ class StagerTest extends TestCase
                     static::INERT_COMMAND,
                 ],
                 'callback' => new TestProcessOutputCallback(),
+                'timeout' => 10,
             ],
         ];
     }

--- a/tests/Unit/Infrastructure/Filesystem/FilesystemTest.php
+++ b/tests/Unit/Infrastructure/Filesystem/FilesystemTest.php
@@ -95,7 +95,7 @@ class FilesystemTest extends TestCase
             [
                 'path' => '/dolor/sit',
                 'givenTimeout' => 10,
-                'expecteTimeout' => 10,
+                'expectedTimeout' => 10,
             ],
         ];
     }

--- a/tests/Unit/Infrastructure/Filesystem/FilesystemTest.php
+++ b/tests/Unit/Infrastructure/Filesystem/FilesystemTest.php
@@ -72,21 +72,31 @@ class FilesystemTest extends TestCase
      *
      * @dataProvider providerRemove
      */
-    public function testRemove($path): void
+    public function testRemove($path, $givenTimeout, $expectedTimeout): void
     {
         $this->symfonyFilesystem
             ->remove($path)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->remove($path);
+        $sut->remove($path, $givenTimeout);
+
+        self::assertSame((string) $expectedTimeout, ini_get('max_execution_time'), 'Correctly set process timeout.');
     }
 
     public function providerRemove(): array
     {
         return [
-            ['path' => '/lorem/ipsum'],
-            ['path' => '/dolor/sit'],
+            [
+                'path' => '/lorem/ipsum',
+                'givenTimeout' => null,
+                'expectedTimeout' => 0,
+            ],
+            [
+                'path' => '/dolor/sit',
+                'givenTimeout' => 10,
+                'expecteTimeout' => 10,
+            ],
         ];
     }
 

--- a/tests/Unit/Infrastructure/Process/FileCopier/SymfonyFileCopierTest.php
+++ b/tests/Unit/Infrastructure/Process/FileCopier/SymfonyFileCopierTest.php
@@ -36,14 +36,16 @@ class SymfonyFileCopierTest extends TestCase
      *
      * @dataProvider providerCopy
      */
-    public function testCopy($from, $to, $exclusions, $callback): void
+    public function testCopy($from, $to, $exclusions, $callback, $givenTimeout, $expectedTimeout): void
     {
         $this->filesystem
             ->mirror($from, $to, Argument::type(RecursiveCallbackFilterIterator::class))
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->copy($from, $to, $exclusions, $callback);
+        $sut->copy($from, $to, $exclusions, $callback, $givenTimeout);
+
+        self::assertSame((string) $expectedTimeout, ini_get('max_execution_time'), 'Correctly set process timeout.');
     }
 
     public function providerCopy(): array
@@ -54,6 +56,8 @@ class SymfonyFileCopierTest extends TestCase
                 'to' => 'ipsum/lorem',
                 'exclusions' => [],
                 'callback' => null,
+                'givenTimeout' => null,
+                'expectedTimeout' => 0,
             ],
             [
                 'from' => '..',
@@ -63,6 +67,8 @@ class SymfonyFileCopierTest extends TestCase
                     'consectetur',
                 ],
                 'callback' => new TestProcessOutputCallback(),
+                'givenTimeout' => 10,
+                'expecteTimeout' => 10,
             ],
         ];
     }

--- a/tests/Unit/Infrastructure/Process/FileCopier/SymfonyFileCopierTest.php
+++ b/tests/Unit/Infrastructure/Process/FileCopier/SymfonyFileCopierTest.php
@@ -68,7 +68,7 @@ class SymfonyFileCopierTest extends TestCase
                 ],
                 'callback' => new TestProcessOutputCallback(),
                 'givenTimeout' => 10,
-                'expecteTimeout' => 10,
+                'expectedTimeout' => 10,
             ],
         ];
     }

--- a/tests/Unit/Infrastructure/Process/Runner/AbstractRunnerTest.php
+++ b/tests/Unit/Infrastructure/Process/Runner/AbstractRunnerTest.php
@@ -77,6 +77,9 @@ class AbstractRunnerTest extends TestCase
             ->willReturnArgument()
             ->shouldBeCalledOnce();
         $this->process
+            ->setTimeout(Argument::type('float'))
+            ->shouldBeCalledOnce();
+        $this->process
             ->mustRun($callback)
             ->shouldBeCalledOnce();
         $this->processFactory
@@ -123,6 +126,9 @@ class AbstractRunnerTest extends TestCase
 
         $exception = $this->prophesize(\Symfony\Component\Process\Exception\ProcessFailedException::class);
         $exception = $exception->reveal();
+        $this->process
+            ->setTimeout(Argument::type('float'))
+            ->shouldBeCalledOnce();
         $this->process
             ->mustRun(Argument::cetera())
             ->willThrow($exception);

--- a/tests/Unit/Infrastructure/Process/Runner/AbstractRunnerTest.php
+++ b/tests/Unit/Infrastructure/Process/Runner/AbstractRunnerTest.php
@@ -32,6 +32,9 @@ class AbstractRunnerTest extends TestCase
             ->willReturnArgument();
         $this->processFactory = $this->prophesize(ProcessFactoryInterface::class);
         $this->process = $this->prophesize(Process::class);
+        $this->process
+            ->setTimeout(Argument::any())
+            ->willReturn($this->process);
     }
 
     protected function createSut($executableName = null)
@@ -70,14 +73,14 @@ class AbstractRunnerTest extends TestCase
      *
      * @dataProvider providerRun
      */
-    public function testRun($executableName, $givenCommand, $expectedCommand, $callback): void
+    public function testRun($executableName, $givenCommand, $expectedCommand, $callback, $timeout): void
     {
         $this->executableFinder
             ->find($executableName)
             ->willReturnArgument()
             ->shouldBeCalledOnce();
         $this->process
-            ->setTimeout(60)
+            ->setTimeout($timeout)
             ->shouldBeCalledOnce();
         $this->process
             ->mustRun($callback)
@@ -89,7 +92,7 @@ class AbstractRunnerTest extends TestCase
 
         $sut = $this->createSut($executableName);
 
-        $sut->run($givenCommand, $callback);
+        $sut->run($givenCommand, $callback, $timeout);
     }
 
     public function providerRun(): array
@@ -100,18 +103,21 @@ class AbstractRunnerTest extends TestCase
                 'givenCommand' => [],
                 'expectedCommand' => ['lorem'],
                 'callback' => null,
+                'timeout' => null,
             ],
             [
                 'executableName' => 'ipsum',
                 'givenCommand' => ['dolor', 'sit'],
                 'expectedCommand' => ['ipsum', 'dolor', 'sit'],
                 'callback' => null,
+                'timeout' => 100,
             ],
             [
                 'executableName' => 'amet',
                 'givenCommand' => [],
                 'expectedCommand' => ['amet'],
                 'callback' => new TestProcessOutputCallback(),
+                'timeout' => 200,
             ],
         ];
     }
@@ -126,9 +132,6 @@ class AbstractRunnerTest extends TestCase
 
         $exception = $this->prophesize(\Symfony\Component\Process\Exception\ProcessFailedException::class);
         $exception = $exception->reveal();
-        $this->process
-            ->setTimeout(60)
-            ->shouldBeCalledOnce();
         $this->process
             ->mustRun(Argument::cetera())
             ->willThrow($exception);

--- a/tests/Unit/Infrastructure/Process/Runner/AbstractRunnerTest.php
+++ b/tests/Unit/Infrastructure/Process/Runner/AbstractRunnerTest.php
@@ -77,7 +77,7 @@ class AbstractRunnerTest extends TestCase
             ->willReturnArgument()
             ->shouldBeCalledOnce();
         $this->process
-            ->setTimeout(Argument::type('float'))
+            ->setTimeout(60)
             ->shouldBeCalledOnce();
         $this->process
             ->mustRun($callback)
@@ -127,7 +127,7 @@ class AbstractRunnerTest extends TestCase
         $exception = $this->prophesize(\Symfony\Component\Process\Exception\ProcessFailedException::class);
         $exception = $exception->reveal();
         $this->process
-            ->setTimeout(Argument::type('float'))
+            ->setTimeout(60)
             ->shouldBeCalledOnce();
         $this->process
             ->mustRun(Argument::cetera())


### PR DESCRIPTION
A Drupal code base can be quite large, so the default process timeout of 60 (or is it 30?) seconds is relatively easy to run into. We should allow the process runners to have a larger timeout if needed (say, 5 minutes), as determined by the calling code.