### PR TITLE
Add Composer allow-plugins config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,10 @@
         "roave/security-advisories": "Ensures that your application doesn't have installed dependencies with known security vulnerabilities."
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        },
         "optimize-autoloader": true,
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4333,5 +4333,5 @@
     "platform-dev": {
         "ext-json": "*"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
The Composer 2.2 release includes a new feature for [more secure plugin execution](https://blog.packagist.com/composer-2-2/#:~:text=more%20secure%20plugin%20execution), which requires allowed plugins to be explicitly declared in your `composer.json`:

```
For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins
You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.
```

This PR adds the new config.