### PR TITLE
Explicitly contract that CodebaseContainsNoSymlinksInterface will ignore non-existent directories

### DIFF
--- a/src/Domain/Service/Precondition/CodebaseContainsNoSymlinksInterface.php
+++ b/src/Domain/Service/Precondition/CodebaseContainsNoSymlinksInterface.php
@@ -5,7 +5,11 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
 /**
  * Asserts that the codebase contains no symlinks.
  *
- * This includes the active directory and, if it exists, the staging directory.
+ * This includes both the active and staging directories.
+ *
+ * It doesn't matter whether the given directories actually exist. In order to isolate failures and avoid redundancy,
+ * that question is left to its own preconditions. Except in the event of an IO error (which will throw an exception
+ * according to the interface), this one cares about literally nothing else if it doesn't actually find a symlink.
  *
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *

--- a/src/Infrastructure/Service/Precondition/CodeBaseContainsNoSymlinks.php
+++ b/src/Infrastructure/Service/Precondition/CodeBaseContainsNoSymlinks.php
@@ -86,12 +86,13 @@ final class CodeBaseContainsNoSymlinks extends AbstractPrecondition implements C
      * @throws \PhpTuf\ComposerStager\Domain\Exception\InvalidArgumentException
      * @throws \PhpTuf\ComposerStager\Domain\Exception\IOException
      */
-    private function findFiles(PathInterface $activeDir): array
+    private function findFiles(PathInterface $path): array
     {
-        if (!$this->filesystem->exists($activeDir)) {
+        // Ignore non-existent directories.
+        if (!$this->filesystem->exists($path)) {
             return [];
         }
 
-        return $this->fileFinder->find($activeDir);
+        return $this->fileFinder->find($path);
     }
 }

--- a/tests/PHPUnit/Infrastructure/Service/Precondition/CodeBaseContainsNoSymlinksFunctionalTest.php
+++ b/tests/PHPUnit/Infrastructure/Service/Precondition/CodeBaseContainsNoSymlinksFunctionalTest.php
@@ -152,4 +152,40 @@ final class CodeBaseContainsNoSymlinksFunctionalTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @covers ::findFiles
+     * @covers ::isFulfilled
+     *
+     * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
+     * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition
+     *
+     * @dataProvider providerDirectoryDoesNotExist
+     */
+    public function testDirectoryDoesNotExist($activeDir, $stagingDir): void
+    {
+        $activeDir = PathFactory::create($activeDir);
+        $stagingDir = PathFactory::create($stagingDir);
+        $sut = $this->createSut();
+
+        $isFulfilled = $sut->isFulfilled($activeDir, $stagingDir);
+
+        self::assertTrue($isFulfilled, 'Silently ignored non-existent directory');
+    }
+
+    public function providerDirectoryDoesNotExist(): array
+    {
+        $nonexistentDir = self::TEST_WORKING_DIR . '/65eb69a274470dd84e9b5371f7e1e8c8';
+
+        return [
+            'Active directory' => [
+                'activeDir' => $nonexistentDir,
+                'stagingDir' => self::STAGING_DIR,
+            ],
+            'Staging directory' => [
+                'activeDir' => self::ACTIVE_DIR,
+                'stagingDir' => $nonexistentDir,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
…and expand existing test coverage.