### PR TITLE
Infrastructure\Service\Finder\ExecutableFinder incorrectly caches exception backtraces

### DIFF
--- a/src/Infrastructure/Service/Finder/ExecutableFinder.php
+++ b/src/Infrastructure/Service/Finder/ExecutableFinder.php
@@ -7,9 +7,6 @@ use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
 
 final class ExecutableFinder implements ExecutableFinderInterface
 {
-    /** @var array<\PhpTuf\ComposerStager\Domain\Exception\LogicException|string|null> */
-    private array $caches = [];
-
     private SymfonyExecutableFinder $symfonyExecutableFinder;
 
     public function __construct(SymfonyExecutableFinder $symfonyExecutableFinder)
@@ -19,47 +16,17 @@ final class ExecutableFinder implements ExecutableFinderInterface
 
     public function find(string $name): string
     {
-        $cache = $this->getCache($name);
-
-        // Throw cached exception.
-        if ($cache instanceof LogicException) {
-            throw $cache;
-        }
-
-        // Return cached path.
-        if ($cache !== null) {
-            return $cache;
-        }
-
         // Look for executable.
         $this->symfonyExecutableFinder->addSuffix('.phar');
         $path = $this->symfonyExecutableFinder->find($name);
 
         // Cache and throw exception if not found.
         if ($path === null) {
-            $cache = new LogicException(
+            throw new LogicException(
                 sprintf('The "%s" executable cannot be found. Make sure it\'s installed and in the $PATH.', $name),
             );
-            $this->setCache($name, $cache);
-
-            throw $cache;
         }
 
-        // Cache and return path if found.
-        $this->setCache($name, $path);
-
         return $path;
-    }
-
-    /** @return \PhpTuf\ComposerStager\Domain\Exception\LogicException|string|null */
-    private function getCache(string $commandName)
-    {
-        return $this->caches[$commandName] ?? null;
-    }
-
-    /** @param string|\PhpTuf\ComposerStager\Domain\Exception\LogicException $value */
-    private function setCache(string $commandName, $value): void
-    {
-        $this->caches[$commandName] = $value;
     }
 }

--- a/tests/PHPUnit/Infrastructure/Service/Finder/ExecutableFinderUnitTest.php
+++ b/tests/PHPUnit/Infrastructure/Service/Finder/ExecutableFinderUnitTest.php
@@ -14,8 +14,6 @@ use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
  *
  * @covers ::__construct
  * @covers ::find
- * @covers ::getCache
- * @covers ::setCache
  *
  * @property \Symfony\Component\Process\ExecutableFinder|\Prophecy\Prophecy\ObjectProphecy $symfonyExecutableFinder
  */
@@ -51,8 +49,6 @@ final class ExecutableFinderUnitTest extends TestCase
         $sut = $this->createSut();
 
         $firstExpected = $sut->find($firstCommandName);
-        // Call again to test result caching.
-        $sut->find($firstCommandName);
         // Find something else to test cache isolation.
         $secondPath = $sut->find($secondCommandName);
 
@@ -106,26 +102,17 @@ final class ExecutableFinderUnitTest extends TestCase
     /** Make sure ::find caches result when Composer is not found. */
     public function testFindNotFoundCaching(): void
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "composer" executable cannot be found. Make sure it\'s installed and in the $PATH.');
+
         $this->symfonyExecutableFinder
             ->addSuffix('.phar')
-            ->shouldBeCalledOnce()
             ->willReturn(null);
         $this->symfonyExecutableFinder
             ->find('composer')
-            ->shouldBeCalledOnce()
             ->willReturn(null);
         $sut = $this->createSut();
 
-        try {
-            $sut->find('composer');
-        } catch (LogicException $e) {
-            // @ignoreException
-        }
-
-        try {
-            $sut->find('composer');
-        } catch (LogicException $e) {
-            // @ignoreException
-        }
+        $sut->find('composer');
     }
 }


### PR DESCRIPTION
`Infrastructure\Service\Finder\ExecutableFinder` caches not only an executable path when it's found but the exception thrown when it's not, resulting in an incorrect backtrace if it called more than once via different code paths in the same process.

This caching was premature optimization to begin with. Just remove it.