### PR TITLE
Generalize AbstractLinkIteratingPrecondition as AbstractFileIteratingPrecondition

### DIFF
--- a/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
+++ b/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
@@ -11,7 +11,7 @@ use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
 
-abstract class AbstractLinkIteratingPrecondition extends AbstractPrecondition
+abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
 {
     protected string $defaultUnfulfilledStatusMessage;
 
@@ -23,7 +23,7 @@ abstract class AbstractLinkIteratingPrecondition extends AbstractPrecondition
     abstract protected function getDefaultUnfulfilledStatusMessage(): string;
 
     /** @throws \PhpTuf\ComposerStager\Domain\Exception\IOException */
-    abstract protected function isSupportedLink(PathInterface $file, PathInterface $codebaseRootDir): bool;
+    abstract protected function isSupportedFile(PathInterface $file, PathInterface $codebaseRootDir): bool;
 
     public function __construct(
         protected readonly RecursiveFileFinderInterface $fileFinder,
@@ -57,11 +57,7 @@ abstract class AbstractLinkIteratingPrecondition extends AbstractPrecondition
                 foreach ($files as $file) {
                     $file = $this->pathFactory::create($file);
 
-                    if (!$this->filesystem->isLink($file)) {
-                        continue;
-                    }
-
-                    if (!$this->isSupportedLink($file, $directoryRoot)) {
+                    if (!$this->isSupportedFile($file, $directoryRoot)) {
                         $this->defaultUnfulfilledStatusMessage = sprintf(
                             $this->defaultUnfulfilledStatusMessage,
                             $name,

--- a/src/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExist.php
+++ b/src/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExist.php
@@ -6,7 +6,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\NoAbsoluteSymlinksExistInt
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
 /** phpcs:disable SlevomatCodingStandard.Files.LineLength.LineTooLong */
-final class NoAbsoluteSymlinksExist extends AbstractLinkIteratingPrecondition implements NoAbsoluteSymlinksExistInterface
+final class NoAbsoluteSymlinksExist extends AbstractFileIteratingPrecondition implements NoAbsoluteSymlinksExistInterface
 {
     public function getName(): string
     {
@@ -28,7 +28,7 @@ final class NoAbsoluteSymlinksExist extends AbstractLinkIteratingPrecondition im
         return 'The %s directory at "%s" contains absolute links, which is not supported. The first one is "%s".';
     }
 
-    protected function isSupportedLink(PathInterface $file, PathInterface $codebaseRootDir): bool
+    protected function isSupportedFile(PathInterface $file, PathInterface $codebaseRootDir): bool
     {
         if (!$this->filesystem->isSymlink($file)) {
             return true;

--- a/src/Infrastructure/Service/Precondition/NoHardLinksExist.php
+++ b/src/Infrastructure/Service/Precondition/NoHardLinksExist.php
@@ -5,7 +5,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Precondition;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\NoHardLinksExistInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
-final class NoHardLinksExist extends AbstractLinkIteratingPrecondition implements NoHardLinksExistInterface
+final class NoHardLinksExist extends AbstractFileIteratingPrecondition implements NoHardLinksExistInterface
 {
     public function getName(): string
     {
@@ -27,7 +27,7 @@ final class NoHardLinksExist extends AbstractLinkIteratingPrecondition implement
         return 'The %s directory at "%s" contains hard links, which is not supported. The first one is "%s".';
     }
 
-    protected function isSupportedLink(PathInterface $file, PathInterface $codebaseRootDir): bool
+    protected function isSupportedFile(PathInterface $file, PathInterface $codebaseRootDir): bool
     {
         return !$this->filesystem->isHardLink($file);
     }

--- a/src/Infrastructure/Service/Precondition/NoLinksExistOnWindows.php
+++ b/src/Infrastructure/Service/Precondition/NoLinksExistOnWindows.php
@@ -10,7 +10,7 @@ use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
 
-final class NoLinksExistOnWindows extends AbstractLinkIteratingPrecondition implements NoLinksExistOnWindowsInterface
+final class NoLinksExistOnWindows extends AbstractFileIteratingPrecondition implements NoLinksExistOnWindowsInterface
 {
     public function __construct(
         RecursiveFileFinderInterface $fileFinder,
@@ -50,7 +50,7 @@ final class NoLinksExistOnWindows extends AbstractLinkIteratingPrecondition impl
         return 'The %s directory at "%s" contains links, which is not supported on Windows. The first one is "%s".';
     }
 
-    protected function isSupportedLink(PathInterface $file, PathInterface $codebaseRootDir): bool
+    protected function isSupportedFile(PathInterface $file, PathInterface $codebaseRootDir): bool
     {
         // This code is host-specific, so it shouldn't be counted against code coverage
         // numbers. Nevertheless, it IS covered by tests on Windows-based CI jobs.

--- a/src/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebase.php
+++ b/src/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebase.php
@@ -5,7 +5,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Precondition;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\NoSymlinksPointOutsideTheCodebaseInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
-final class NoSymlinksPointOutsideTheCodebase extends AbstractLinkIteratingPrecondition implements
+final class NoSymlinksPointOutsideTheCodebase extends AbstractFileIteratingPrecondition implements
     NoSymlinksPointOutsideTheCodebaseInterface
 {
     public function getName(): string
@@ -30,7 +30,7 @@ The %s directory at "%s" contains links that point outside the codebase, which i
 EOF;
     }
 
-    protected function isSupportedLink(PathInterface $file, PathInterface $codebaseRootDir): bool
+    protected function isSupportedFile(PathInterface $file, PathInterface $codebaseRootDir): bool
     {
         if (!$this->filesystem->isSymlink($file)) {
             return true;

--- a/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
+++ b/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
@@ -28,7 +28,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\ExecutableFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\ActiveAndStagingDirsAreDifferent
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\ActiveDirExists

--- a/tests/Infrastructure/Service/Precondition/AbstractFileIteratingPreconditionUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/AbstractFileIteratingPreconditionUnitTest.php
@@ -8,11 +8,11 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition;
+use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition;
 use Prophecy\Argument;
 
 /**
- * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  *
  * @covers ::__construct
  * @covers ::findFiles
@@ -28,7 +28,7 @@ use Prophecy\Argument;
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
  * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
-final class AbstractLinkIteratingPreconditionUnitTest extends LinkIteratingPreconditionUnitTestCase
+final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function fulfilledStatusMessage(): string
     {
@@ -58,7 +58,7 @@ final class AbstractLinkIteratingPreconditionUnitTest extends LinkIteratingPreco
 
         // Create a concrete implementation for testing since the SUT in
         // this case, being abstract, can't be instantiated directly.
-        return new class ($fileFinder, $filesystem, $pathFactory) extends AbstractLinkIteratingPrecondition
+        return new class ($fileFinder, $filesystem, $pathFactory) extends AbstractFileIteratingPrecondition
         {
             public bool $exitEarly = false;
 
@@ -67,7 +67,7 @@ final class AbstractLinkIteratingPreconditionUnitTest extends LinkIteratingPreco
                 return '';
             }
 
-            protected function isSupportedLink(PathInterface $file, PathInterface $codebaseRootDir): bool
+            protected function isSupportedFile(PathInterface $file, PathInterface $codebaseRootDir): bool
             {
                 return true;
             }
@@ -97,7 +97,7 @@ final class AbstractLinkIteratingPreconditionUnitTest extends LinkIteratingPreco
         };
     }
 
-    /** @covers \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition::exitEarly */
+    /** @covers \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition::exitEarly */
     public function testExitEarly(): void
     {
         $activeDir = $this->activeDir->reveal();

--- a/tests/Infrastructure/Service/Precondition/FileIteratingPreconditionUnitTestCase.php
+++ b/tests/Infrastructure/Service/Precondition/FileIteratingPreconditionUnitTestCase.php
@@ -11,7 +11,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition;
+use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition;
 use Prophecy\Argument;
 
 /**
@@ -21,7 +21,7 @@ use Prophecy\Argument;
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
  * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
-abstract class LinkIteratingPreconditionUnitTestCase extends PreconditionTestCase
+abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCase
 {
     abstract protected function fulfilledStatusMessage(): string;
 
@@ -40,7 +40,7 @@ abstract class LinkIteratingPreconditionUnitTestCase extends PreconditionTestCas
         parent::setUp();
     }
 
-    /** @covers \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition::exitEarly */
+    /** @covers \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition::exitEarly */
     public function testExitEarly(): void
     {
         $activeDir = $this->activeDir->reveal();
@@ -58,14 +58,14 @@ abstract class LinkIteratingPreconditionUnitTestCase extends PreconditionTestCas
 
         // Create a concrete implementation for testing since the SUT in
         // this case, being abstract, can't be instantiated directly.
-        $sut = new class ($fileFinder, $filesystem, $pathFactory) extends AbstractLinkIteratingPrecondition
+        $sut = new class ($fileFinder, $filesystem, $pathFactory) extends AbstractFileIteratingPrecondition
         {
             protected function getDefaultUnfulfilledStatusMessage(): string
             {
                 return '';
             }
 
-            protected function isSupportedLink(PathInterface $file, PathInterface $codebaseRootDir): bool
+            protected function isSupportedFile(PathInterface $file, PathInterface $codebaseRootDir): bool
             {
                 return true;
             }

--- a/tests/Infrastructure/Service/Precondition/LinkPreconditionsIsolationFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/LinkPreconditionsIsolationFunctionalTest.php
@@ -3,7 +3,7 @@
 namespace PhpTuf\ComposerStager\Tests\Infrastructure\Service\Precondition;
 
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory;
-use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition;
+use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition;
 use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoAbsoluteSymlinksExist;
 use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoHardLinksExist;
 use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoLinksExistOnWindows;
@@ -64,7 +64,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
             }
 
             // Limit to link iterating preconditions.
-            if (!($service instanceof AbstractLinkIteratingPrecondition)) {
+            if (!($service instanceof AbstractFileIteratingPrecondition)) {
                 continue;
             }
 

--- a/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistFunctionalTest.php
@@ -12,12 +12,12 @@ use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
  * @covers ::__construct
  * @covers ::findFiles
  * @covers ::getDefaultUnfulfilledStatusMessage
- * @covers ::isSupportedLink
+ * @covers ::isSupportedFile
  *
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\AbstractPath
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\UnixLikePath
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\WindowsPath
@@ -200,7 +200,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
 
     /**
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      */
     public function testWithHardLink(): void
     {

--- a/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistUnitTest.php
@@ -16,14 +16,14 @@ use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoAbsoluteSymlinks
  * @covers ::isFulfilled
  *
  * @uses \PhpTuf\ComposerStager\Domain\Exception\PreconditionException
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Domain\Value\Path\PathInterface|\Prophecy\Prophecy\ObjectProphecy $activeDir
  * @property \PhpTuf\ComposerStager\Domain\Value\Path\PathInterface|\Prophecy\Prophecy\ObjectProphecy $stagingDir
  */
-final class NoAbsoluteSymlinksExistUnitTest extends LinkIteratingPreconditionUnitTestCase
+final class NoAbsoluteSymlinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function createSut(): NoAbsoluteSymlinksExist
     {

--- a/tests/Infrastructure/Service/Precondition/NoHardLinksExistFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoHardLinksExistFunctionalTest.php
@@ -17,7 +17,7 @@ use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\AbstractPath
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\UnixLikePath
@@ -40,7 +40,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         return $sut;
     }
 
-    /** @covers ::isSupportedLink */
+    /** @covers ::isSupportedFile */
     public function testFulfilledWithNoLinks(): void
     {
         $sut = $this->createSut();
@@ -50,7 +50,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         self::assertTrue($isFulfilled, 'Passed with no links in the codebase.');
     }
 
-    /** @covers ::isSupportedLink */
+    /** @covers ::isSupportedFile */
     public function testFulfilledWithSymlink(): void
     {
         $target = PathFactory::create('target.txt', $this->activeDir)->resolve();
@@ -66,7 +66,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
 
     /**
      * @covers ::getUnfulfilledStatusMessage
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      *
      * @dataProvider providerUnfulfilled
      */
@@ -123,7 +123,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
 
     /**
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      *
      * @dataProvider providerExclusions
      */

--- a/tests/Infrastructure/Service/Precondition/NoHardLinksExistUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoHardLinksExistUnitTest.php
@@ -15,7 +15,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoHardLinksExist;
  * @covers ::isFulfilled
  *
  * @uses \PhpTuf\ComposerStager\Domain\Exception\PreconditionException
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
@@ -24,7 +24,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoHardLinksExist;
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
  * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
-final class NoHardLinksExistUnitTest extends LinkIteratingPreconditionUnitTestCase
+final class NoHardLinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function createSut(): NoHardLinksExist
     {

--- a/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsFunctionalTest.php
@@ -18,7 +18,7 @@ use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\AbstractPath
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\UnixLikePath
@@ -62,7 +62,7 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
      * @covers ::getDefaultUnfulfilledStatusMessage
      * @covers ::getUnfulfilledStatusMessage
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      *
      * @dataProvider providerUnfulfilled
      */

--- a/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsUnitTest.php
@@ -19,7 +19,7 @@ use Prophecy\Argument;
  * @covers ::isFulfilled
  *
  * @uses \PhpTuf\ComposerStager\Domain\Exception\PreconditionException
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
@@ -29,7 +29,7 @@ use Prophecy\Argument;
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
  * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
-final class NoLinksExistOnWindowsUnitTest extends LinkIteratingPreconditionUnitTestCase
+final class NoLinksExistOnWindowsUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
@@ -17,7 +17,7 @@ use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\AbstractPath
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\UnixLikePath
@@ -57,7 +57,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
      * @covers ::getDefaultUnfulfilledStatusMessage
      * @covers ::isDescendant
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      * @covers ::linkPointsOutsidePath
      *
      * @dataProvider providerFulfilledWithValidLink
@@ -111,7 +111,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
      * @covers ::getDefaultUnfulfilledStatusMessage
      * @covers ::isDescendant
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      * @covers ::linkPointsOutsidePath
      *
      * @dataProvider providerUnfulfilled
@@ -172,7 +172,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
 
     /**
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      */
     public function testWithHardLink(): void
     {
@@ -193,7 +193,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
     /**
      * @covers ::isDescendant
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      * @covers ::linkPointsOutsidePath
      */
     public function testWithAbsoluteLink(): void
@@ -217,7 +217,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
      * @covers ::getDefaultUnfulfilledStatusMessage
      * @covers ::isDescendant
      * @covers ::isFulfilled
-     * @covers ::isSupportedLink
+     * @covers ::isSupportedFile
      * @covers ::linkPointsOutsidePath
      *
      * @dataProvider providerExclusions

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseUnitTest.php
@@ -25,7 +25,7 @@ use Prophecy\Argument;
  * @covers ::isFulfilled
  *
  * @uses \PhpTuf\ComposerStager\Domain\Exception\PreconditionException
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractLinkIteratingPrecondition
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem


### PR DESCRIPTION
Emphasis on _Link_ iterating to _File_ iterating. This refactoring improves the semantics of link-related preconditions, effectively answering @wimleers feedback in https://github.com/php-tuf/composer-stager/pull/100, I believe, and preparing the way for future enhancements like https://github.com/php-tuf/composer-stager/issues/67, which will also need to iterate over all files, not just links.