### PR TITLE
Make Infrastructure\Service\FileSyncer\RsyncFileSyncer::sync() respect $timeout

### DIFF
--- a/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
+++ b/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
@@ -39,6 +39,8 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
         $sourceResolved = $source->resolve();
         $destinationResolved = $destination->resolve();
 
+        set_time_limit((int) $timeout);
+
         $exclusions ??= new PathList([]);
         $exclusions = $exclusions->getAll();
 

--- a/tests/Infrastructure/Service/FileSyncer/FileSyncerFunctionalTestCase.php
+++ b/tests/Infrastructure/Service/FileSyncer/FileSyncerFunctionalTestCase.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Tests\Infrastructure\Service\FileSyncer;
+
+use PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface;
+use PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath;
+use PhpTuf\ComposerStager\Tests\TestCase;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+
+/**
+ * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $destination
+ * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $source
+ */
+abstract class FileSyncerFunctionalTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->source = new TestPath(self::ACTIVE_DIR);
+        $this->destination = new TestPath(self::STAGING_DIR);
+
+        $filesystem = new SymfonyFilesystem();
+
+        $filesystem->mkdir(self::TEST_WORKING_DIR);
+        chdir(self::TEST_WORKING_DIR);
+
+        $filesystem->mkdir($this->source->resolve());
+        $filesystem->mkdir($this->destination->resolve());
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeTestEnvironment();
+    }
+
+    final protected function createSut(): FileSyncerInterface
+    {
+        $container = $this->getContainer();
+        $container->compile();
+
+        /** @var \PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface $sut */
+        $sut = $container->get($this->fileSyncerClass());
+
+        return $sut;
+    }
+
+    abstract protected function fileSyncerClass(): string;
+
+    /**
+     * @covers ::sync
+     *
+     * @dataProvider providerSyncTimeout
+     */
+    public function testSyncTimeout(?int $givenTimeout, int $expectedTimeout): void
+    {
+        $sut = $this->createSut();
+
+        $sut->sync($this->source, $this->destination, null, null, $givenTimeout);
+
+        self::assertSame((string) $expectedTimeout, ini_get('max_execution_time'), 'Correctly set process timeout.');
+    }
+
+    public function providerSyncTimeout(): array
+    {
+        return [
+            [
+                'givenTimeout' => null,
+                'expectedTimeout' => 0,
+            ],
+            [
+                'givenTimeout' => 10,
+                'expectedTimeout' => 10,
+            ],
+        ];
+    }
+}

--- a/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerFunctionalTest.php
+++ b/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerFunctionalTest.php
@@ -3,9 +3,6 @@
 namespace PhpTuf\ComposerStager\Tests\Infrastructure\Service\FileSyncer;
 
 use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
-use PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath;
-use PhpTuf\ComposerStager\Tests\TestCase;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer
@@ -21,63 +18,10 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
  * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $destination
  * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $source
  */
-final class PhpFileSyncerFunctionalTest extends TestCase
+final class PhpFileSyncerFunctionalTest extends FileSyncerFunctionalTestCase
 {
-    protected function setUp(): void
+    protected function fileSyncerClass(): string
     {
-        $this->source = new TestPath(self::ACTIVE_DIR);
-        $this->destination = new TestPath(self::STAGING_DIR);
-
-        $filesystem = new SymfonyFilesystem();
-
-        $filesystem->mkdir(self::TEST_WORKING_DIR);
-        chdir(self::TEST_WORKING_DIR);
-
-        $filesystem->mkdir($this->source->resolve());
-        $filesystem->mkdir($this->destination->resolve());
-    }
-
-    protected function tearDown(): void
-    {
-        self::removeTestEnvironment();
-    }
-
-    protected function createSut(): PhpFileSyncer
-    {
-        $container = $this->getContainer();
-        $container->compile();
-
-        /** @var \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer $sut */
-        $sut = $container->get(PhpFileSyncer::class);
-
-        return $sut;
-    }
-
-    /**
-     * @covers ::sync
-     *
-     * @dataProvider providerSyncTimeout
-     */
-    public function testSyncTimeout(?int $givenTimeout, int $expectedTimeout): void
-    {
-        $sut = $this->createSut();
-
-        $sut->sync($this->source, $this->destination, null, null, $givenTimeout);
-
-        self::assertSame((string) $expectedTimeout, ini_get('max_execution_time'), 'Correctly set process timeout.');
-    }
-
-    public function providerSyncTimeout(): array
-    {
-        return [
-            [
-                'givenTimeout' => null,
-                'expectedTimeout' => 0,
-            ],
-            [
-                'givenTimeout' => 10,
-                'expectedTimeout' => 10,
-            ],
-        ];
+        return PhpFileSyncer::class;
     }
 }

--- a/tests/Infrastructure/Service/FileSyncer/RsyncFileSyncerFunctionalTest.php
+++ b/tests/Infrastructure/Service/FileSyncer/RsyncFileSyncerFunctionalTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Tests\Infrastructure\Service\FileSyncer;
+
+use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncer;
+
+/**
+ * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncer
+ *
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Process\ProcessFactory
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncer
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\ExecutableFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\ProcessRunner\AbstractRunner
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList
+ *
+ * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $destination
+ * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $source
+ */
+final class RsyncFileSyncerFunctionalTest extends FileSyncerFunctionalTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (self::isRsyncAvailable()) {
+            return;
+        }
+
+        self::markTestSkipped('Rsync is not available for testing.');
+    }
+
+    protected function fileSyncerClass(): string
+    {
+        return RsyncFileSyncer::class;
+    }
+}


### PR DESCRIPTION
The `Infrastructure\Service\FileSyncer\RsyncFileSyncer::sync()` method currently ignores the `$timeout` argument.