### PR TITLE
Filesystem::readLink() resolves links relative to the PHP process' CWD instead of the link directory

### DIFF
--- a/src/Infrastructure/Service/Filesystem/Filesystem.php
+++ b/src/Infrastructure/Service/Filesystem/Filesystem.php
@@ -123,7 +123,10 @@ final class Filesystem implements FilesystemInterface
         $target = readlink($path->resolve());
         assert(is_string($target));
 
-        return $this->pathFactory::create($target);
+        // Resolve the target relative to the link's parent directory, not the CWD of the PHP process at runtime.
+        $cwd = $this->pathFactory::create('..', $path);
+
+        return $this->pathFactory::create($target, $cwd);
     }
 
     public function remove(

--- a/tests/Infrastructure/Service/Filesystem/FilesystemFunctionalTest.php
+++ b/tests/Infrastructure/Service/Filesystem/FilesystemFunctionalTest.php
@@ -214,6 +214,9 @@ final class FilesystemFunctionalTest extends TestCase
         link($given, $hardLinkPath->resolve());
         $sut = $this->createSut();
 
+        // Change directory to make sure the result isn't affected by the CWD at runtime.
+        chdir(__DIR__);
+
         $symlinkTarget = $sut->readLink($symlinkPath);
 
         self::assertEquals($expectedRaw, $symlinkTarget->raw(), 'Got the correct raw target value.');


### PR DESCRIPTION
As discovered at https://www.drupal.org/project/automatic_updates/issues/3319507#comment-14972129, `Infrastructure\Service\Filesystem\Filesystem::readLink()` resolves symlinks relative to the CWD of the running PHP process, not the directory the link is in, like it should.