### PR TITLE
Normalize exception codes at default values

### DIFF
--- a/src/Domain/Core/Beginner/Beginner.php
+++ b/src/Domain/Core/Beginner/Beginner.php
@@ -31,7 +31,7 @@ final class Beginner implements BeginnerInterface
         try {
             $this->fileSyncer->sync($activeDir, $stagingDir, $exclusions, $callback, $timeout);
         } catch (ExceptionInterface $e) {
-            throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+            throw new RuntimeException($e->getMessage(), 0, $e);
         }
     }
 }

--- a/src/Domain/Core/Cleaner/Cleaner.php
+++ b/src/Domain/Core/Cleaner/Cleaner.php
@@ -29,7 +29,7 @@ final class Cleaner implements CleanerInterface
         try {
             $this->filesystem->remove($stagingDir, $callback, $timeout);
         } catch (IOException $e) {
-            throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+            throw new RuntimeException($e->getMessage(), 0, $e);
         }
     }
 }

--- a/src/Domain/Core/Committer/Committer.php
+++ b/src/Domain/Core/Committer/Committer.php
@@ -31,7 +31,7 @@ final class Committer implements CommitterInterface
         try {
             $this->fileSyncer->sync($stagingDir, $activeDir, $exclusions, $callback, $timeout);
         } catch (ExceptionInterface $e) {
-            throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+            throw new RuntimeException($e->getMessage(), 0, $e);
         }
     }
 }

--- a/src/Domain/Core/Stager/Stager.php
+++ b/src/Domain/Core/Stager/Stager.php
@@ -74,7 +74,7 @@ final class Stager implements StagerInterface
         try {
             $this->composerRunner->run($command, $callback, $timeout);
         } catch (ExceptionInterface $e) {
-            throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+            throw new RuntimeException($e->getMessage(), 0, $e);
         }
     }
 }

--- a/src/Infrastructure/Factory/Process/ProcessFactory.php
+++ b/src/Infrastructure/Factory/Process/ProcessFactory.php
@@ -13,7 +13,7 @@ final class ProcessFactory implements ProcessFactoryInterface
         try {
             return new Process($command);
         } catch (ExceptionInterface $e) { // @codeCoverageIgnore
-            throw new LogicException($e->getMessage(), $e->getCode(), $e); // @codeCoverageIgnore
+            throw new LogicException($e->getMessage(), 0, $e); // @codeCoverageIgnore
         }
     }
 }

--- a/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
+++ b/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
@@ -95,7 +95,7 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
         try {
             $this->rsync->run($command, $callback);
         } catch (ExceptionInterface $e) {
-            throw new IOException($e->getMessage(), $e->getCode(), $e);
+            throw new IOException($e->getMessage(), 0, $e);
         }
     }
 

--- a/src/Infrastructure/Service/Filesystem/Filesystem.php
+++ b/src/Infrastructure/Service/Filesystem/Filesystem.php
@@ -52,13 +52,13 @@ final class Filesystem implements FilesystemInterface
             throw new LogicException(sprintf(
                 'The source file does not exist or is not a file at "%s"',
                 $sourceResolved,
-            ), $e->getCode(), $e);
+            ), 0, $e);
         } catch (SymfonyIOException $e) {
             throw new IOException(sprintf(
                 'Failed to copy "%s" to "%s"',
                 $sourceResolved,
                 $destinationResolved,
-            ), $e->getCode(), $e);
+            ), 0, $e);
         }
     }
 
@@ -110,7 +110,7 @@ final class Filesystem implements FilesystemInterface
             throw new IOException(sprintf(
                 'Failed to create directory at "%s"',
                 $pathResolved,
-            ), $e->getCode(), $e);
+            ), 0, $e);
         }
     }
 
@@ -141,7 +141,7 @@ final class Filesystem implements FilesystemInterface
 
             $this->symfonyFilesystem->remove($path->resolve());
         } catch (SymfonyExceptionInterface $e) {
-            throw new IOException($e->getMessage(), $e->getCode(), $e);
+            throw new IOException($e->getMessage(), 0, $e);
         }
     }
 

--- a/src/Infrastructure/Service/Finder/RecursiveFileFinder.php
+++ b/src/Infrastructure/Service/Finder/RecursiveFileFinder.php
@@ -70,7 +70,7 @@ final class RecursiveFileFinder implements RecursiveFileFinderInterface
                 FilesystemIterator::CURRENT_AS_PATHNAME | FilesystemIterator::SKIP_DOTS,
             );
         } catch (UnexpectedValueException $e) {
-            throw new IOException($e->getMessage(), $e->getCode(), $e);
+            throw new IOException($e->getMessage(), 0, $e);
         }
     }
 }

--- a/src/Infrastructure/Service/ProcessRunner/AbstractRunner.php
+++ b/src/Infrastructure/Service/ProcessRunner/AbstractRunner.php
@@ -51,7 +51,7 @@ abstract class AbstractRunner implements ProcessRunnerInterface
             $process->setTimeout($timeout);
             $process->mustRun($callback);
         } catch (SymfonyExceptionInterface $e) {
-            throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+            throw new RuntimeException($e->getMessage(), 0, $e);
         }
     }
 


### PR DESCRIPTION
When wrapping exceptions in many instances, Composer Stager reuses the exception code of the wrapped exception. This is unnecessary, since the same value is already accessible via `::getPrevious()->getCode()`, and undesirable, since it introduces uncertainty or even indeterminism, as domain exception codes depend on third party code. Use the default values now in lieu of https://github.com/php-tuf/composer-stager/issues/71.