### PR TITLE
Rename PathInterface::resolve() and ::resolveRelativeTo()

### DIFF
--- a/src/Domain/Core/Stager/Stager.php
+++ b/src/Domain/Core/Stager/Stager.php
@@ -67,7 +67,7 @@ final class Stager implements StagerInterface
         ?int $timeout,
     ): void {
         $command = array_merge(
-            ['--working-dir=' . $stagingDir->resolve()],
+            ['--working-dir=' . $stagingDir->resolved()],
             $composerCommand,
         );
 

--- a/src/Domain/Value/Path/PathInterface.php
+++ b/src/Domain/Value/Path/PathInterface.php
@@ -24,7 +24,7 @@ interface PathInterface
      * by `getcwd()` at runtime, e.g., "/var/www/example" given a path of
      * "example" and a working directory of "/var/www".
      */
-    public function resolve(): string;
+    public function resolved(): string;
 
     /**
      * Gets the fully resolved, absolute path string without trailing slash, relative to another given path.
@@ -36,5 +36,5 @@ interface PathInterface
      * "/var/one/two/three" relative to "/var/four/five/six" would return
      * "/var/one/two/three".
      */
-    public function resolveRelativeTo(PathInterface $path): string;
+    public function resolvedRelativeTo(PathInterface $path): string;
 }

--- a/src/Infrastructure/Service/FileSyncer/PhpFileSyncer.php
+++ b/src/Infrastructure/Service/FileSyncer/PhpFileSyncer.php
@@ -42,9 +42,9 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
     /** @throws \PhpTuf\ComposerStager\Domain\Exception\LogicException */
     private function assertSourceAndDestinationAreDifferent(PathInterface $source, PathInterface $destination): void
     {
-        if ($source->resolve() === $destination->resolve()) {
+        if ($source->resolved() === $destination->resolved()) {
             throw new LogicException(
-                sprintf('The source and destination directories cannot be the same at "%s"', $source->resolve()),
+                sprintf('The source and destination directories cannot be the same at "%s"', $source->resolved()),
             );
         }
     }
@@ -55,7 +55,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
         if (!$this->filesystem->exists($source)) {
             throw new LogicException(sprintf(
                 'The source directory does not exist at "%s"',
-                $source->resolve(),
+                $source->resolved(),
             ));
         }
     }
@@ -83,8 +83,8 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
 
         $destinationFiles = $this->fileFinder->find($destination, $exclusions);
 
-        $sourceResolved = $source->resolve();
-        $destinationResolved = $destination->resolve();
+        $sourceResolved = $source->resolved();
+        $destinationResolved = $destination->resolved();
 
         foreach ($destinationFiles as $destinationFilePathname) {
             $relativePathname = self::getRelativePath($destinationResolved, $destinationFilePathname);
@@ -105,7 +105,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
 
     private function destinationIsEmpty(PathInterface $destination): bool
     {
-        return scandir($destination->resolve()) === ['.', '..'];
+        return scandir($destination->resolved()) === ['.', '..'];
     }
 
     /**
@@ -120,8 +120,8 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
     ): void {
         $sourceFiles = $this->fileFinder->find($source, $exclusions);
 
-        $sourceResolved = $source->resolve();
-        $destinationResolved = $destination->resolve();
+        $sourceResolved = $source->resolved();
+        $destinationResolved = $destination->resolved();
 
         foreach ($sourceFiles as $sourceFilePathname) {
             // Once support for Symfony 4 is dropped, see if any of this logic can be

--- a/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
+++ b/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
@@ -36,8 +36,8 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
         ?ProcessOutputCallbackInterface $callback = null,
         ?int $timeout = ProcessRunnerInterface::DEFAULT_TIMEOUT,
     ): void {
-        $sourceResolved = $source->resolve();
-        $destinationResolved = $destination->resolve();
+        $sourceResolved = $source->resolved();
+        $destinationResolved = $destination->resolved();
 
         set_time_limit((int) $timeout);
 

--- a/src/Infrastructure/Service/Filesystem/Filesystem.php
+++ b/src/Infrastructure/Service/Filesystem/Filesystem.php
@@ -36,8 +36,8 @@ final class Filesystem implements FilesystemInterface
 
     public function copy(PathInterface $source, PathInterface $destination): void
     {
-        $sourceResolved = $source->resolve();
-        $destinationResolved = $destination->resolve();
+        $sourceResolved = $source->resolved();
+        $destinationResolved = $destination->resolved();
 
         if ($sourceResolved === $destinationResolved) {
             throw new LogicException(sprintf(
@@ -97,12 +97,12 @@ final class Filesystem implements FilesystemInterface
 
     public function isWritable(PathInterface $path): bool
     {
-        return is_writable($path->resolve()); // @codeCoverageIgnore
+        return is_writable($path->resolved()); // @codeCoverageIgnore
     }
 
     public function mkdir(PathInterface $path): void
     {
-        $pathResolved = $path->resolve();
+        $pathResolved = $path->resolved();
 
         try {
             $this->symfonyFilesystem->mkdir($pathResolved);
@@ -117,10 +117,10 @@ final class Filesystem implements FilesystemInterface
     public function readLink(PathInterface $path): PathInterface
     {
         if (!$this->isSymlink($path)) {
-            throw new IOException(sprintf('The path does not exist or is not a symlink at "%s"', $path->resolve()));
+            throw new IOException(sprintf('The path does not exist or is not a symlink at "%s"', $path->resolved()));
         }
 
-        $target = readlink($path->resolve());
+        $target = readlink($path->resolved());
         assert(is_string($target));
 
         // Resolve the target relative to the link's parent directory, not the CWD of the PHP process at runtime.
@@ -139,7 +139,7 @@ final class Filesystem implements FilesystemInterface
             // timeout, so we have to enforce it ourselves.
             set_time_limit((int) $timeout);
 
-            $this->symfonyFilesystem->remove($path->resolve());
+            $this->symfonyFilesystem->remove($path->resolved());
         } catch (SymfonyExceptionInterface $e) {
             throw new IOException($e->getMessage(), 0, $e);
         }
@@ -155,7 +155,7 @@ final class Filesystem implements FilesystemInterface
         // and `is_link()`, etc., not to mention being the only way to detect hard links at all.
         // Error reporting is suppressed because using `lstat()` on a non-link emits E_WARNING,
         // which may or may not throw an exception depending on error_reporting configuration.
-        $lstat = @lstat($path->resolve());
+        $lstat = @lstat($path->resolved());
 
         if ($lstat === false) {
             return self::PATH_DOES_NOT_EXIST;

--- a/src/Infrastructure/Service/Finder/RecursiveFileFinder.php
+++ b/src/Infrastructure/Service/Finder/RecursiveFileFinder.php
@@ -23,11 +23,11 @@ final class RecursiveFileFinder implements RecursiveFileFinderInterface
     {
         $exclusions ??= new PathList([]);
 
-        $directoryIterator = $this->getRecursiveDirectoryIterator($directory->resolve());
+        $directoryIterator = $this->getRecursiveDirectoryIterator($directory->resolved());
 
         // Resolve the exclusions relative to the search directory.
         $exclusions = array_map(fn ($path): string => $this->pathFactory::create($path)
-            ->resolveRelativeTo($directory), $exclusions->getAll());
+            ->resolvedRelativeTo($directory), $exclusions->getAll());
 
         // Apply exclusions. On the surface, it may look like individual descendants
         // of an excluded directory, i.e., files "underneath" or "inside" it, won't

--- a/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
+++ b/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
@@ -40,7 +40,7 @@ abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
     ): bool {
         try {
             $exclusions ??= new PathList([]);
-            $exclusions->add([$stagingDir->resolve()]);
+            $exclusions->add([$stagingDir->resolved()]);
 
             if ($this->exitEarly($activeDir, $stagingDir, $exclusions)) {
                 return true;
@@ -61,8 +61,8 @@ abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
                         $this->defaultUnfulfilledStatusMessage = sprintf(
                             $this->defaultUnfulfilledStatusMessage,
                             $name,
-                            $directoryRoot->resolve(),
-                            $file->resolve(),
+                            $directoryRoot->resolved(),
+                            $file->resolved(),
                         );
 
                         return false;

--- a/src/Infrastructure/Service/Precondition/ActiveAndStagingDirsAreDifferent.php
+++ b/src/Infrastructure/Service/Precondition/ActiveAndStagingDirsAreDifferent.php
@@ -24,7 +24,7 @@ final class ActiveAndStagingDirsAreDifferent extends AbstractPrecondition implem
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
     ): bool {
-        return $activeDir->resolve() !== $stagingDir->resolve();
+        return $activeDir->resolved() !== $stagingDir->resolved();
     }
 
     protected function getFulfilledStatusMessage(): string

--- a/src/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebase.php
+++ b/src/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebase.php
@@ -44,7 +44,7 @@ EOF;
     {
         $target = $this->filesystem->readLink($link);
 
-        return !$this->isDescendant($target->resolve(), $path->resolve());
+        return !$this->isDescendant($target->resolved(), $path->resolved());
     }
 
     private function isDescendant(string $descendant, string $ancestor): bool

--- a/src/Infrastructure/Value/Path/AbstractPath.php
+++ b/src/Infrastructure/Value/Path/AbstractPath.php
@@ -27,7 +27,7 @@ abstract class AbstractPath implements PathInterface
         // object should be immune to environmental details like the current
         // working directory. Cache the CWD at time of creation.
         $this->cwd = $cwd instanceof PathInterface
-            ? $cwd->resolve()
+            ? $cwd->resolved()
             : $this->getcwd();
     }
 
@@ -36,14 +36,14 @@ abstract class AbstractPath implements PathInterface
         return $this->path;
     }
 
-    public function resolve(): string
+    public function resolved(): string
     {
         return $this->doResolve($this->cwd);
     }
 
-    public function resolveRelativeTo(PathInterface $path): string
+    public function resolvedRelativeTo(PathInterface $path): string
     {
-        $basePath = $path->resolve();
+        $basePath = $path->resolved();
 
         return $this->doResolve($basePath);
     }

--- a/tests/EndToEnd/EndToEndFunctionalTestCase.php
+++ b/tests/EndToEnd/EndToEndFunctionalTestCase.php
@@ -95,7 +95,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
         ]);
 
         $arbitrarySymlinkTarget = 'file_in_active_dir_root_NEVER_CHANGED_anywhere.txt';
-        self::createSymlinks($activeDirPath->resolve(), [
+        self::createSymlinks($activeDirPath->resolved(), [
             'EXCLUDED_symlink_in_active_dir_root.txt' => $arbitrarySymlinkTarget,
             'EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt' => $arbitrarySymlinkTarget,
         ]);
@@ -139,7 +139,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             $preconditionMet = false;
             self::assertEquals(NoAbsoluteSymlinksExist::class, $failedPrecondition::class, 'Correct "codebase contains symlinks" unmet.');
         } finally {
-            assert(filetype($activeDirPath->resolve() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
+            assert(filetype($activeDirPath->resolved() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
             self::assertFalse($preconditionMet, 'Beginner fails with symlinks present in the codebase.');
         }
 
@@ -157,7 +157,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             'very/deeply/nested/file/that/is/CHANGED/in/the/staging/directory/before/syncing/back/to/the/active/directory.txt',
             'long_filename_NEVER_CHANGED_one_two_three_four_five_six_seven_eight_nine_ten_eleven_twelve_thirteen_fourteen_fifteen.txt',
         ];
-        self::assertDirectoryListing($stagingDirPath->resolve(), $expectedStagingDirListing, '', sprintf('Synced correct files from active directory to new staging directory:%s- From: %s%s- To:   %s', PHP_EOL, $activeDir, PHP_EOL, $stagingDir));
+        self::assertDirectoryListing($stagingDirPath->resolved(), $expectedStagingDirListing, '', sprintf('Synced correct files from active directory to new staging directory:%s- From: %s%s- To:   %s', PHP_EOL, $activeDir, PHP_EOL, $stagingDir));
 
         // Stage: Execute a Composer command (that doesn't make any HTTP requests).
         $newComposerName = 'new/name';
@@ -184,12 +184,12 @@ abstract class EndToEndFunctionalTestCase extends TestCase
         self::createFile($stagingDir, 'another_subdir/CREATE_in_staging_dir.txt');
 
         // Create symlink.
-        self::createSymlink($stagingDirPath->resolve(), 'EXCLUDED_dir/symlink_CREATED_in_staging_dir.txt', $arbitrarySymlinkTarget);
+        self::createSymlink($stagingDirPath->resolved(), 'EXCLUDED_dir/symlink_CREATED_in_staging_dir.txt', $arbitrarySymlinkTarget);
 
         // Sanity check to ensure that the expected changes were made.
         $deletion = array_search('DELETE_from_staging_dir_before_syncing_back_to_active_dir.txt', $expectedStagingDirListing, true);
         unset($expectedStagingDirListing[$deletion]);
-        self::assertDirectoryListing($stagingDirPath->resolve(), array_merge($expectedStagingDirListing, [
+        self::assertDirectoryListing($stagingDirPath->resolved(), array_merge($expectedStagingDirListing, [
             // Additions.
             'CREATE_in_staging_dir.txt',
             'EXCLUDED_dir/but_create_file_in_it_in_the_staging_dir.txt',
@@ -209,14 +209,14 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             $preconditionMet = false;
             self::assertEquals(NoAbsoluteSymlinksExist::class, $failedPrecondition::class, 'Correct "codebase contains symlinks" unmet.');
         } finally {
-            assert(filetype($activeDirPath->resolve() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
+            assert(filetype($activeDirPath->resolved() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
             self::assertFalse($preconditionMet, 'Beginner fails with symlinks present in the codebase.');
         }
 
         // Commit: Sync files from the staging directory back to the directory.
         $this->committer->commit($stagingDirPath, $activeDirPath, $exclusions);
 
-        self::assertDirectoryListing($activeDirPath->resolve(), [
+        self::assertDirectoryListing($activeDirPath->resolved(), [
             'composer.json',
             // Unchanged files are left alone.
             'file_in_active_dir_root_NEVER_CHANGED_anywhere.txt',
@@ -250,7 +250,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             // Files deleted from either side are absent from the active directory.
             // - another_EXCLUDED_dir/DELETE_file_from_active_dir_after_syncing_to_staging_dir.txt
             // - DELETE_from_staging_dir_before_syncing_back_to_active_dir
-        ], $stagingDirPath->resolve(), sprintf('Synced correct files from staging directory back to active directory:%s%s ->%s%s"', PHP_EOL, $stagingDir, PHP_EOL, $activeDir));
+        ], $stagingDirPath->resolved(), sprintf('Synced correct files from staging directory back to active directory:%s%s ->%s%s"', PHP_EOL, $stagingDir, PHP_EOL, $activeDir));
 
         // Unchanged file contents.
         self::assertFileNotChanged($activeDir, 'file_in_active_dir_root_NEVER_CHANGED_anywhere.txt');
@@ -283,7 +283,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
         // Clean: Remove the staging directory.
         $this->cleaner->clean($activeDirPath, $stagingDirPath);
 
-        self::assertFileDoesNotExist($stagingDirPath->resolve(), 'Staging directory was completely removed.');
+        self::assertFileDoesNotExist($stagingDirPath->resolved(), 'Staging directory was completely removed.');
     }
 
     public function providerDirectories(): array

--- a/tests/Infrastructure/Service/FileSyncer/FileSyncerFunctionalTestCase.php
+++ b/tests/Infrastructure/Service/FileSyncer/FileSyncerFunctionalTestCase.php
@@ -28,8 +28,8 @@ abstract class FileSyncerFunctionalTestCase extends TestCase
         $this->filesystem->mkdir(self::TEST_WORKING_DIR);
         chdir(self::TEST_WORKING_DIR);
 
-        $this->filesystem->mkdir($this->source->resolve());
-        $this->filesystem->mkdir($this->destination->resolve());
+        $this->filesystem->mkdir($this->source->resolved());
+        $this->filesystem->mkdir($this->destination->resolved());
     }
 
     protected function tearDown(): void
@@ -83,15 +83,15 @@ abstract class FileSyncerFunctionalTestCase extends TestCase
     {
         $link = PathFactory::create('link', $this->source);
         $target = PathFactory::create('directory', $this->source);
-        $this->filesystem->mkdir($target->resolve());
-        $file = PathFactory::create('directory/file.txt', $this->source)->resolve();
+        $this->filesystem->mkdir($target->resolved());
+        $file = PathFactory::create('directory/file.txt', $this->source)->resolved();
         $this->filesystem->touch($file);
-        symlink($target->resolve(), $link->resolve());
+        symlink($target->resolved(), $link->resolved());
         $sut = $this->createSut();
 
         $sut->sync($this->source, $this->destination);
 
-        self::assertDirectoryListing($this->destination->resolve(), [
+        self::assertDirectoryListing($this->destination->resolved(), [
             'link',
             'directory/file.txt',
         ], '', 'Correctly synced files, including a symlink to a directory.');

--- a/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerUnitTest.php
+++ b/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerUnitTest.php
@@ -54,7 +54,7 @@ final class PhpFileSyncerUnitTest extends TestCase
     public function testSyncSourceNotFound(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(sprintf('The source directory does not exist at "%s"', $this->source->resolve()));
+        $this->expectExceptionMessage(sprintf('The source directory does not exist at "%s"', $this->source->resolved()));
 
         $this->filesystem
             ->exists($this->source)
@@ -71,7 +71,7 @@ final class PhpFileSyncerUnitTest extends TestCase
         $destination = $source;
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(sprintf('The source and destination directories cannot be the same at "%s"', $source->resolve()));
+        $this->expectExceptionMessage(sprintf('The source and destination directories cannot be the same at "%s"', $source->resolved()));
 
         $sut = $this->createSut();
 

--- a/tests/Infrastructure/Service/FileSyncer/RsyncFileSyncerUnitTest.php
+++ b/tests/Infrastructure/Service/FileSyncer/RsyncFileSyncerUnitTest.php
@@ -200,7 +200,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
     public function testSyncSourceDirectoryNotFound(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(sprintf('The source directory does not exist at "%s"', $this->source->resolve()));
+        $this->expectExceptionMessage(sprintf('The source directory does not exist at "%s"', $this->source->resolved()));
 
         $this->filesystem
             ->exists(Argument::any())
@@ -216,7 +216,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
         $destination = $source;
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(sprintf('The source and destination directories cannot be the same at "%s"', $source->resolve()));
+        $this->expectExceptionMessage(sprintf('The source and destination directories cannot be the same at "%s"', $source->resolved()));
 
         $sut = $this->createSut();
 

--- a/tests/Infrastructure/Service/Filesystem/FilesystemFunctionalTest.php
+++ b/tests/Infrastructure/Service/Filesystem/FilesystemFunctionalTest.php
@@ -208,10 +208,10 @@ final class FilesystemFunctionalTest extends TestCase
         $symlinkPath = PathFactory::create('symlink.txt', $baseDir);
         $hardLinkPath = PathFactory::create('hard_link.txt', $baseDir);
         $targetPath = PathFactory::create($given, $baseDir);
-        chdir($baseDir->resolve());
-        touch($targetPath->resolve());
-        symlink($given, $symlinkPath->resolve());
-        link($given, $hardLinkPath->resolve());
+        chdir($baseDir->resolved());
+        touch($targetPath->resolved());
+        symlink($given, $symlinkPath->resolved());
+        link($given, $hardLinkPath->resolved());
         $sut = $this->createSut();
 
         // Change directory to make sure the result isn't affected by the CWD at runtime.
@@ -220,10 +220,10 @@ final class FilesystemFunctionalTest extends TestCase
         $symlinkTarget = $sut->readLink($symlinkPath);
 
         self::assertEquals($expectedRaw, $symlinkTarget->raw(), 'Got the correct raw target value.');
-        self::assertEquals($expectedResolved, $symlinkTarget->resolve(), 'Got the correct resolved target value.');
+        self::assertEquals($expectedResolved, $symlinkTarget->resolved(), 'Got the correct resolved target value.');
 
         $this->expectException(IOException::class);
-        $message = sprintf('The path does not exist or is not a symlink at "%s"', $hardLinkPath->resolve());
+        $message = sprintf('The path does not exist or is not a symlink at "%s"', $hardLinkPath->resolved());
         $this->expectExceptionMessage($message);
         $sut->readLink($hardLinkPath);
     }
@@ -233,7 +233,7 @@ final class FilesystemFunctionalTest extends TestCase
         $absolute = static function ($path): string {
             $baseDir = PathFactory::create(self::SOURCE_DIR);
 
-            return PathFactory::create($path, $baseDir)->resolve();
+            return PathFactory::create($path, $baseDir)->resolved();
         };
 
         // Note: relative links cannot be distinguished from absolute links on Windows,
@@ -260,7 +260,7 @@ final class FilesystemFunctionalTest extends TestCase
         $file = PathFactory::create(self::SOURCE_DIR . '/file.txt');
 
         $this->expectException(IOException::class);
-        $this->expectExceptionMessage(sprintf('The path does not exist or is not a symlink at "%s"', $file->resolve()));
+        $this->expectExceptionMessage(sprintf('The path does not exist or is not a symlink at "%s"', $file->resolved()));
 
         $sut = $this->createSut();
 
@@ -274,7 +274,7 @@ final class FilesystemFunctionalTest extends TestCase
         $path = PathFactory::create($path);
 
         $this->expectException(IOException::class);
-        $this->expectExceptionMessage(sprintf('The path does not exist or is not a symlink at "%s"', $path->resolve()));
+        $this->expectExceptionMessage(sprintf('The path does not exist or is not a symlink at "%s"', $path->resolved()));
 
         $sut = $this->createSut();
 

--- a/tests/Infrastructure/Service/Filesystem/FilesystemUnitTest.php
+++ b/tests/Infrastructure/Service/Filesystem/FilesystemUnitTest.php
@@ -53,7 +53,7 @@ final class FilesystemUnitTest extends TestCase
         $source = new TestPath($source);
         $destination = new TestPath($destination);
         $this->symfonyFilesystem
-            ->copy($source->resolve(), $destination->resolve(), true)
+            ->copy($source->resolved(), $destination->resolved(), true)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -92,7 +92,7 @@ final class FilesystemUnitTest extends TestCase
     public function testCopySourceDirectoryNotFound(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(sprintf('The source file does not exist or is not a file at "%s"', $this->activeDir->resolve()));
+        $this->expectExceptionMessage(sprintf('The source file does not exist or is not a file at "%s"', $this->activeDir->resolved()));
 
         /** @noinspection PhpParamsInspection */
         $this->symfonyFilesystem
@@ -110,7 +110,7 @@ final class FilesystemUnitTest extends TestCase
         $destination = $source;
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage(sprintf('The source and destination files cannot be the same at "%s"', $source->resolve()));
+        $this->expectExceptionMessage(sprintf('The source and destination files cannot be the same at "%s"', $source->resolved()));
 
         $sut = $this->createSut();
 

--- a/tests/Infrastructure/Service/Finder/RecursiveFileFinderFunctionalTest.php
+++ b/tests/Infrastructure/Service/Finder/RecursiveFileFinderFunctionalTest.php
@@ -52,7 +52,7 @@ final class RecursiveFileFinderFunctionalTest extends TestCase
     public function testFind(array $files, ?PathListInterface $exclusions, array $expected): void
     {
         $directory = PathFactory::create(self::ACTIVE_DIR);
-        self::createFiles($directory->resolve(), $files);
+        self::createFiles($directory->resolved(), $files);
         $sut = $this->createSut();
 
         $actual = $sut->find($directory, $exclusions);
@@ -171,7 +171,7 @@ final class RecursiveFileFinderFunctionalTest extends TestCase
                 ],
             );
 
-            return PathFactory::create($path)->resolve();
+            return PathFactory::create($path)->resolved();
         }, $paths);
 
         sort($paths);

--- a/tests/Infrastructure/Service/Precondition/ActiveAndStagingDirsAreDifferentUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/ActiveAndStagingDirsAreDifferentUnitTest.php
@@ -28,11 +28,11 @@ final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionTestCas
     public function testFulfilled(): void
     {
         $this->activeDir
-            ->resolve()
+            ->resolved()
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn('/one/different');
         $this->stagingDir
-            ->resolve()
+            ->resolved()
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn('/two/different');
 
@@ -42,11 +42,11 @@ final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionTestCas
     public function testUnfulfilled(): void
     {
         $this->activeDir
-            ->resolve()
+            ->resolved()
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn('/same');
         $this->stagingDir
-            ->resolve()
+            ->resolved()
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn('/same');
 

--- a/tests/Infrastructure/Service/Precondition/LinkPreconditionsIsolationFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/LinkPreconditionsIsolationFunctionalTest.php
@@ -47,7 +47,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
         $this->activeDir = PathFactory::create(self::ACTIVE_DIR);
         $this->stagingDir = PathFactory::create(self::STAGING_DIR);
 
-        chdir($this->activeDir->resolve());
+        chdir($this->activeDir->resolved());
     }
 
     /** A NoUnsupportedLinksExist object can't be created directly because some preconditions need to be excluded. */
@@ -104,8 +104,8 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     public function testNoAbsoluteSymlinksExist(): void
     {
         $activeDir = $this->activeDir;
-        $source = PathFactory::create('source.txt', $activeDir)->resolve();
-        $target = PathFactory::create('target.txt', $activeDir)->resolve();
+        $source = PathFactory::create('source.txt', $activeDir)->resolved();
+        $target = PathFactory::create('target.txt', $activeDir)->resolved();
         touch($target);
         symlink($target, $source);
 
@@ -121,7 +121,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     public function testNoSymlinksPointOutsideTheCodebase(): void
     {
         $activeDir = $this->activeDir;
-        $source = PathFactory::create('source.txt', $activeDir)->resolve();
+        $source = PathFactory::create('source.txt', $activeDir)->resolved();
         $target = PathFactory::create('../target.txt', $activeDir)->raw();
         touch($target);
         symlink($target, $source);
@@ -132,7 +132,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     public function testNoSymlinksPointToADirectory(): void
     {
         $activeDir = $this->activeDir;
-        $source = PathFactory::create('link', $activeDir)->resolve();
+        $source = PathFactory::create('link', $activeDir)->resolved();
         $target = PathFactory::create('directory', $activeDir)->raw();
         mkdir($target);
         symlink($target, $source);
@@ -143,8 +143,8 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     public function testNoHardLinksExistExist(): void
     {
         $activeDir = $this->activeDir;
-        $source = PathFactory::create('source.txt', $activeDir)->resolve();
-        $target = PathFactory::create('target.txt', $activeDir)->resolve();
+        $source = PathFactory::create('source.txt', $activeDir)->resolved();
+        $target = PathFactory::create('target.txt', $activeDir)->resolved();
         touch($target);
         link($target, $source);
 

--- a/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistFunctionalTest.php
@@ -100,11 +100,11 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         $dirPath = PathFactory::create($dirPath);
         $link = PathFactory::create($link, $dirPath);
         $target = PathFactory::create('target.txt', $dirPath);
-        $parentDir = dirname($link->resolve());
+        $parentDir = dirname($link->resolved());
         @mkdir($parentDir, 0777, true);
-        touch($target->resolve());
+        touch($target->resolved());
         // Point at the resolved target, i.e., its absolute path.
-        symlink($target->resolve(), $link->resolve());
+        symlink($target->resolved(), $link->resolved());
         $sut = $this->createSut();
 
         $isFulfilled = $sut->isFulfilled($this->activeDir, $this->stagingDir);
@@ -114,8 +114,8 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         $pattern = sprintf(
             'The %s directory at "%s" contains absolute links, which is not supported. The first one is "%s".',
             $dirName,
-            $dirPath->resolve(),
-            $link->resolve(),
+            $dirPath->resolved(),
+            $link->resolved(),
         );
         self::assertSame($pattern, $statusMessage, 'Returned correct status message.');
     }
@@ -135,12 +135,12 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         $dirPath = PathFactory::create($dirPath);
         $link = PathFactory::create($link, $dirPath);
         $target = PathFactory::create('target.txt', $dirPath);
-        $parentDir = dirname($link->resolve());
+        $parentDir = dirname($link->resolved());
         @mkdir($parentDir, 0777, true);
-        touch($target->resolve());
+        touch($target->resolved());
         chdir($parentDir);
         // Point at the raw target, i.e., its relative path.
-        symlink($target->raw(), $link->resolve());
+        symlink($target->raw(), $link->resolved());
         $sut = $this->createSut();
 
         $isFulfilled = $sut->isFulfilled($this->activeDir, $this->stagingDir);
@@ -205,8 +205,8 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
     public function testWithHardLink(): void
     {
         $dirPath = PathFactory::create(self::ACTIVE_DIR);
-        $link = PathFactory::create('link.txt', $dirPath)->resolve();
-        $target = PathFactory::create('target.txt', $dirPath)->resolve();
+        $link = PathFactory::create('link.txt', $dirPath)->resolved();
+        $target = PathFactory::create('target.txt', $dirPath)->resolved();
         $parentDir = dirname($link);
         @mkdir($parentDir, 0777, true);
         touch($target);
@@ -228,7 +228,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         $targetFile = 'target.txt';
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList($exclusions);
-        $dirPath = $this->activeDir->resolve();
+        $dirPath = $this->activeDir->resolved();
         self::createFile($dirPath, $targetFile);
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();

--- a/tests/Infrastructure/Service/Precondition/NoHardLinksExistFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoHardLinksExistFunctionalTest.php
@@ -53,8 +53,8 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
     /** @covers ::isSupportedFile */
     public function testFulfilledWithSymlink(): void
     {
-        $target = PathFactory::create('target.txt', $this->activeDir)->resolve();
-        $link = PathFactory::create('link.txt', $this->activeDir)->resolve();
+        $target = PathFactory::create('target.txt', $this->activeDir)->resolved();
+        $link = PathFactory::create('link.txt', $this->activeDir)->resolved();
         touch($target);
         symlink($target, $link);
         $sut = $this->createSut();
@@ -72,14 +72,14 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
      */
     public function testUnfulfilled(string $directory, string $dirName): void
     {
-        $target = PathFactory::create($directory . '/target.txt')->resolve();
-        $link = PathFactory::create($directory . '/link.txt')->resolve();
+        $target = PathFactory::create($directory . '/target.txt')->resolved();
+        $link = PathFactory::create($directory . '/link.txt')->resolved();
 
         $this->expectException(PreconditionException::class);
         $this->expectExceptionMessage(sprintf(
             'The %s directory at "%s" contains hard links, which is not supported. The first one is "%s".',
             $dirName,
-            PathFactory::create($directory)->resolve(),
+            PathFactory::create($directory)->resolved(),
             $link,
         ));
 
@@ -137,7 +137,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
 
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList($exclusions);
-        $dirPath = $this->activeDir->resolve();
+        $dirPath = $this->activeDir->resolved();
         self::createFile($dirPath, $targetFile);
         self::createHardlinks($dirPath, $links);
         $sut = $this->createSut();

--- a/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsFunctionalTest.php
@@ -76,19 +76,19 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
         }
 
         $baseDir = PathFactory::create(self::ACTIVE_DIR);
-        $link = PathFactory::create('link.txt', $baseDir)->resolve();
-        $target = PathFactory::create('target.txt', $baseDir)->resolve();
+        $link = PathFactory::create('link.txt', $baseDir)->resolved();
+        $target = PathFactory::create('target.txt', $baseDir)->resolved();
 
         $this->expectException(PreconditionException::class);
         $this->expectExceptionMessage(sprintf(
             'The active directory at "%s" contains links, which is not supported on Windows. The first one is "%s".',
-            $baseDir->resolve(),
+            $baseDir->resolved(),
             $link,
         ));
 
         touch($target);
-        self::createSymlinks($baseDir->resolve(), $symlinks);
-        self::createHardlinks($baseDir->resolve(), $hardLinks);
+        self::createSymlinks($baseDir->resolved(), $symlinks);
+        self::createHardlinks($baseDir->resolved(), $hardLinks);
         $sut = $this->createSut();
 
         $isFulfilled = $sut->isFulfilled($this->activeDir, $this->stagingDir);
@@ -147,7 +147,7 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
         $targetFile = 'target.txt';
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList($exclusions);
-        $dirPath = $this->activeDir->resolve();
+        $dirPath = $this->activeDir->resolved();
         self::createFile($dirPath, $targetFile);
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
@@ -51,9 +51,9 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
      */
     public function testFulfilledWithValidLink(string $link, string $target): void
     {
-        $link = PathFactory::create($link, $this->activeDir)->resolve();
+        $link = PathFactory::create($link, $this->activeDir)->resolved();
         self::ensureParentDirectory($link);
-        $target = PathFactory::create($target, $this->activeDir)->resolve();
+        $target = PathFactory::create($target, $this->activeDir)->resolved();
         self::ensureParentDirectory($target);
         touch($target);
         symlink($target, $link);
@@ -105,14 +105,14 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
      */
     public function testUnfulfilled(string $targetDir, string $linkDir, string $linkDirName): void
     {
-        $target = PathFactory::create($targetDir . '/target.txt')->resolve();
-        $link = PathFactory::create($linkDir . '/link.txt')->resolve();
+        $target = PathFactory::create($targetDir . '/target.txt')->resolved();
+        $link = PathFactory::create($linkDir . '/link.txt')->resolved();
 
         $this->expectException(PreconditionException::class);
         $this->expectExceptionMessage(sprintf(
             'The %s directory at "%s" contains links that point outside the codebase, which is not supported. The first one is "%s".',
             $linkDirName,
-            PathFactory::create($linkDir)->resolve(),
+            PathFactory::create($linkDir)->resolved(),
             $link,
         ));
 
@@ -164,8 +164,8 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
     public function testWithHardLink(): void
     {
         $dirPath = PathFactory::create(self::ACTIVE_DIR);
-        $link = PathFactory::create('link.txt', $dirPath)->resolve();
-        $target = PathFactory::create('target.txt', $dirPath)->resolve();
+        $link = PathFactory::create('link.txt', $dirPath)->resolved();
+        $target = PathFactory::create('target.txt', $dirPath)->resolved();
         $parentDir = dirname($link);
         @mkdir($parentDir, 0777, true);
         touch($target);
@@ -186,8 +186,8 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
     public function testWithAbsoluteLink(): void
     {
         $dirPath = PathFactory::create(self::ACTIVE_DIR);
-        $link = PathFactory::create('link.txt', $dirPath)->resolve();
-        $target = PathFactory::create('target.txt', $dirPath)->resolve();
+        $link = PathFactory::create('link.txt', $dirPath)->resolved();
+        $target = PathFactory::create('target.txt', $dirPath)->resolved();
         $parentDir = dirname($link);
         @mkdir($parentDir, 0777, true);
         touch($target);
@@ -214,7 +214,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         $targetFile = '../';
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList($exclusions);
-        $dirPath = $this->activeDir->resolve();
+        $dirPath = $this->activeDir->resolved();
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();
 

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointToADirectoryFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointToADirectoryFunctionalTest.php
@@ -62,9 +62,9 @@ final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsF
      */
     public function testFulfilledWithValidLink(): void
     {
-        $link = PathFactory::create('link.txt', $this->activeDir)->resolve();
+        $link = PathFactory::create('link.txt', $this->activeDir)->resolved();
         self::ensureParentDirectory($link);
-        $target = PathFactory::create('target.txt', $this->activeDir)->resolve();
+        $target = PathFactory::create('target.txt', $this->activeDir)->resolved();
         self::ensureParentDirectory($target);
         touch($target);
         symlink($target, $link);
@@ -84,14 +84,14 @@ final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsF
      */
     public function testUnfulfilled(string $targetDir, string $linkDir, string $linkDirName): void
     {
-        $target = PathFactory::create($targetDir . '/target_directory')->resolve();
-        $link = PathFactory::create($linkDir . '/directory_link')->resolve();
+        $target = PathFactory::create($targetDir . '/target_directory')->resolved();
+        $link = PathFactory::create($linkDir . '/directory_link')->resolved();
 
         $this->expectException(PreconditionException::class);
         $this->expectExceptionMessage(sprintf(
             'The %s directory at "%s" contains symlinks that point to a directory, which is not supported. The first one is "%s".',
             $linkDirName,
-            PathFactory::create($linkDir)->resolve(),
+            PathFactory::create($linkDir)->resolved(),
             $link,
         ));
 
@@ -132,10 +132,10 @@ final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsF
     public function testFulfilledExclusions(array $links, array $exclusions, bool $shouldBeFulfilled): void
     {
         $targetDir = './target_directory';
-        mkdir(PathFactory::create($targetDir, $this->activeDir)->resolve());
+        mkdir(PathFactory::create($targetDir, $this->activeDir)->resolved());
         $links = array_fill_keys($links, $targetDir);
         $exclusions = new PathList($exclusions);
-        $dirPath = $this->activeDir->resolve();
+        $dirPath = $this->activeDir->resolved();
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();
 

--- a/tests/Infrastructure/Service/Precondition/PreconditionTestCase.php
+++ b/tests/Infrastructure/Service/Precondition/PreconditionTestCase.php
@@ -23,11 +23,11 @@ abstract class PreconditionTestCase extends TestCase
     {
         $this->activeDir = $this->prophesize(PathInterface::class);
         $this->activeDir
-            ->resolve()
+            ->resolved()
             ->willReturn(self::ACTIVE_DIR);
         $this->stagingDir = $this->prophesize(PathInterface::class);
         $this->stagingDir
-            ->resolve()
+            ->resolved()
             ->willReturn(self::STAGING_DIR);
         $this->exclusions = new TestPathList();
     }

--- a/tests/Infrastructure/Value/Path/TestPath.php
+++ b/tests/Infrastructure/Value/Path/TestPath.php
@@ -20,12 +20,12 @@ final class TestPath implements PathInterface
         return $this->path;
     }
 
-    public function resolve(): string
+    public function resolved(): string
     {
         return $this->path;
     }
 
-    public function resolveRelativeTo(PathInterface $path): string
+    public function resolvedRelativeTo(PathInterface $path): string
     {
         return $this->path;
     }

--- a/tests/Infrastructure/Value/Path/UnixLikePathUnitTest.php
+++ b/tests/Infrastructure/Value/Path/UnixLikePathUnitTest.php
@@ -15,8 +15,8 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * @covers ::makeAbsolute
  * @covers ::normalize
  * @covers ::raw
- * @covers ::resolve
- * @covers ::resolveRelativeTo
+ * @covers ::resolved
+ * @covers ::resolvedRelativeTo
  * @covers \PhpTuf\ComposerStager\Infrastructure\Value\Path\AbstractPath::getcwd
  */
 final class UnixLikePathUnitTest extends TestCase
@@ -52,18 +52,18 @@ final class UnixLikePathUnitTest extends TestCase
         $setCwd->call($sut, $cwd);
         $setCwd->call($equalInstance, $cwd);
 
-        self::assertEquals($resolved, $sut->resolve(), 'Got correct value via explicit method call.');
+        self::assertEquals($resolved, $sut->resolved(), 'Got correct value via explicit method call.');
 
         self::assertEquals($isAbsolute, $sut->isAbsolute(), 'Correctly determined whether given path was relative.');
         self::assertEquals($given, $sut->raw(), 'Correctly returned raw path.');
-        self::assertEquals($resolved, $sut->resolve(), 'Correctly resolved path.');
-        self::assertEquals($resolvedRelativeTo, $sut->resolveRelativeTo($relativeBase), 'Correctly resolved path relative to another given path.');
+        self::assertEquals($resolved, $sut->resolved(), 'Correctly resolved path.');
+        self::assertEquals($resolvedRelativeTo, $sut->resolvedRelativeTo($relativeBase), 'Correctly resolved path relative to another given path.');
         self::assertEquals($sut, $equalInstance, 'Path value considered equal to another instance with the same input.');
         self::assertNotEquals($sut, $unequalInstance, 'Path value considered unequal to another instance with different input.');
 
         // Make sure object is truly immutable.
         chdir(__DIR__);
-        self::assertEquals($resolved, $sut->resolve(), 'Retained correct value after changing working directory.');
+        self::assertEquals($resolved, $sut->resolved(), 'Retained correct value after changing working directory.');
         self::assertEquals($sut, $equalInstance, 'Path value still considered equal to another instance with the same input after changing working directory.');
         self::assertNotEquals($sut, $unequalInstance, 'Path value considered unequal to another instance with different input.');
     }
@@ -210,7 +210,7 @@ final class UnixLikePathUnitTest extends TestCase
     {
         $sut = new UnixLikePath($path, $cwd);
 
-        self::assertEquals($resolved, $sut->resolve(), 'Correctly resolved path.');
+        self::assertEquals($resolved, $sut->resolved(), 'Correctly resolved path.');
     }
 
     public function providerCwdArgument(): array

--- a/tests/Infrastructure/Value/Path/WindowsPathUnitTest.php
+++ b/tests/Infrastructure/Value/Path/WindowsPathUnitTest.php
@@ -19,8 +19,8 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * @covers ::normalizeAbsoluteFromCurrentDrive
  * @covers ::normalizeAbsoluteFromSpecificDrive
  * @covers ::raw
- * @covers ::resolve
- * @covers ::resolveRelativeTo
+ * @covers ::resolved
+ * @covers ::resolvedRelativeTo
  * @covers \PhpTuf\ComposerStager\Infrastructure\Value\Path\AbstractPath::getcwd
  */
 final class WindowsPathUnitTest extends TestCase
@@ -51,14 +51,14 @@ final class WindowsPathUnitTest extends TestCase
 
         self::assertEquals($isAbsolute, $sut->isAbsolute(), 'Correctly determined whether given path was relative.');
         self::assertEquals($given, $sut->raw(), 'Correctly returned raw path.');
-        self::assertEquals($resolved, $sut->resolve(), 'Correctly resolved path.');
-        self::assertEquals($resolvedRelativeTo, $sut->resolveRelativeTo($relativeBase), 'Correctly resolved path relative to another given path.');
+        self::assertEquals($resolved, $sut->resolved(), 'Correctly resolved path.');
+        self::assertEquals($resolvedRelativeTo, $sut->resolvedRelativeTo($relativeBase), 'Correctly resolved path relative to another given path.');
         self::assertEquals($sut, $equalInstance, 'Path value considered equal to another instance with the same input.');
         self::assertNotEquals($sut, $unequalInstance, 'Path value considered unequal to another instance with different input.');
 
         // Make sure object is truly immutable.
         chdir(__DIR__);
-        self::assertEquals($resolved, $sut->resolve(), 'Retained correct value after changing working directory.');
+        self::assertEquals($resolved, $sut->resolved(), 'Retained correct value after changing working directory.');
         self::assertEquals($sut, $equalInstance, 'Path value still considered equal to another instance with the same input after changing working directory.');
         self::assertNotEquals($sut, $unequalInstance, 'Path value considered unequal to another instance with different input.');
     }
@@ -245,7 +245,7 @@ final class WindowsPathUnitTest extends TestCase
 
         $sut = new WindowsPath($path, $cwd);
 
-        self::assertEquals($resolved, $sut->resolve(), 'Correctly resolved path.');
+        self::assertEquals($resolved, $sut->resolved(), 'Correctly resolved path.');
     }
 
     public function providerCwdArgument(): array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -84,7 +84,7 @@ abstract class TestCase extends PHPUnitTestCase
 
     protected static function createFile(string $baseDir, string $filename): void
     {
-        $filename = PathFactory::create("{$baseDir}/{$filename}")->resolve();
+        $filename = PathFactory::create("{$baseDir}/{$filename}")->resolved();
         static::ensureParentDirectory($filename);
 
         $touchResult = touch($filename);
@@ -103,7 +103,7 @@ abstract class TestCase extends PHPUnitTestCase
 
     protected static function createDirectory(string $baseDir, string $dirname): void
     {
-        $dirname = PathFactory::create("{$baseDir}/{$dirname}")->resolve();
+        $dirname = PathFactory::create("{$baseDir}/{$dirname}")->resolved();
         static::ensureParentDirectory($dirname);
 
         $touchResult = mkdir($dirname);
@@ -127,7 +127,7 @@ abstract class TestCase extends PHPUnitTestCase
 
         self::prepareForLink($link, $target);
 
-        symlink($target->resolve(), $link->resolve());
+        symlink($target->resolved(), $link->resolved());
     }
 
     protected static function createHardlinks(string $baseDir, array $symlinks): void
@@ -144,17 +144,17 @@ abstract class TestCase extends PHPUnitTestCase
 
         self::prepareForLink($link, $target);
 
-        link($target->resolve(), $link->resolve());
+        link($target->resolved(), $link->resolved());
     }
 
     private static function prepareForLink(PathInterface $link, PathInterface $target): void
     {
-        static::ensureParentDirectory($link->resolve());
+        static::ensureParentDirectory($link->resolved());
 
         // If the symlink target doesn't exist, the tests will pass on Unix-like
         // systems but fail on Windows. Avoid hard-to-debug problems by making
         // sure it fails everywhere in that case.
-        assert(file_exists($target->resolve()), 'Symlink target exists.');
+        assert(file_exists($target->resolved()), 'Symlink target exists.');
     }
 
     protected static function ensureParentDirectory(string $filename): void


### PR DESCRIPTION
`Domain\Value\Path\PathInterface::resolve()` and `::resolveRelativeTo()` sound like mutators, but they are, in fact, pure functions. Rename them to make this clearer:

```diff
-::resolve()
+::resolved()

-::resolveRelativeTo()
+::resolvedRelativeTo()
```