### PR TITLE
Explicitly mark the API surface

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -98,6 +98,7 @@
             <element value="@return"/>
             <element value="@throws"/>
             <element value="@see"/>
+            <element value="@api,@internal,"/>
             <element value="@todo"/>
             <element value="@noinspection,@SuppressWarnings"/>
         </property>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,4 @@
+# https://phpstan.org/config-reference
 parametersSchema:
     gitattributesExportInclude: listOf(string())
     preconditionSystemHash: string()
@@ -19,6 +20,9 @@ parameters:
         -
             message: '#Cannot access offset .(application|name). on mixed.#'
             path: src/Infrastructure/Service/Precondition/ComposerIsAvailable.php
+        -
+            message: '#Concrete class .* be marked "@.*"#'
+            path: src/Infrastructure/Value/PathList/PathList.php
 
         # Test code.
         -
@@ -64,6 +68,7 @@ rules:
     - PhpTuf\ComposerStager\PHPStan\Rules\Methods\ForbiddenConcreteTypeHintRule # Forbids using concrete classes in type hints when an interface is available.
     - PhpTuf\ComposerStager\PHPStan\Rules\Methods\ForbiddenThrowsRule # Forbids throwing third party exceptions from public methods.
     - PhpTuf\ComposerStager\PHPStan\Rules\Methods\SortedRequiredConstructorParametersRule # Requires non-optional constructor parameters to be alphabetized.
+    - PhpTuf\ComposerStager\PHPStan\Rules\PhpDoc\APIAnnotationRule # Enforces "@api" and "@internal" class annotation rules.
     - PhpTuf\ComposerStager\PHPStan\Rules\PhpDoc\CoverageAnnotationHasNoParenthesesRule # Ensures that coverage annotations have no trailing parentheses.
     - PhpTuf\ComposerStager\PHPStan\Rules\PhpDoc\PropertyDataTypePutsObjectProphecyLastRule # Requires "@property" data types to put ObjectProphecy last.
     - PhpTuf\ComposerStager\PHPStan\Rules\PhpDoc\SortedCoversAnnotationsRule # Requires "@covers" annotations to be sorted alphabetically.

--- a/phpstan/Rules/AbstractRule.php
+++ b/phpstan/Rules/AbstractRule.php
@@ -64,7 +64,7 @@ abstract class AbstractRule implements Rule
 
     protected function isInNamespace(string $name, string $namespace): bool
     {
-        return str_starts_with($name, $namespace);
+        return str_starts_with("{$name}\\", $namespace);
     }
 
     protected function getNamespace(string $name): string

--- a/phpstan/Rules/PhpDoc/APIAnnotationRule.php
+++ b/phpstan/Rules/PhpDoc/APIAnnotationRule.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\PHPStan\Rules\PhpDoc;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Interface_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PhpTuf\ComposerStager\PHPStan\Rules\AbstractRule;
+use Throwable;
+
+/** Enforces "@api" and "@internal" class annotation rules. */
+final class APIAnnotationRule extends AbstractRule
+{
+    private const ABSTRACT_CLASS = 'Abstract class';
+    private const EXCEPTION = 'Exception';
+    private const FACTORY = 'Factory';
+    private const CONCRETE_CLASS = 'Concrete class';
+    private const INTERFACE = 'Interface';
+    private const TEST_CLASS = 'Test class';
+
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Only check classes and interfaces.
+        if (!$node instanceof Class_ && !$node instanceof Interface_) {
+            return [];
+        }
+
+        $class = $this->getClassReflection($node);
+
+        if ($class === null) {
+            return [];
+        }
+
+        $type = $this->getType($class);
+
+        // Ignore tests.
+        if ($type === self::TEST_CLASS) {
+            return [];
+        }
+
+        // Define the public API surface.
+        $publicAPI = [
+            self::INTERFACE,
+            self::ABSTRACT_CLASS,
+            self::FACTORY,
+            self::EXCEPTION,
+        ];
+
+        // Require classes in the public API to be annotated with @api.
+        if (in_array($type, $publicAPI, true)) {
+            return $this->getAnnotationErrors($node, $type, '@api', '@internal');
+        }
+
+        // Require everything else to be annotated with @internal.
+        return $this->getAnnotationErrors($node, $type, '@internal', '@api');
+    }
+
+    private function getAnnotationErrors(
+        Class_|Interface_ $node,
+        string $type,
+        string $requiredTag,
+        string $forbiddenTag,
+    ): array {
+        $errors = [];
+
+        // Missing required annotation.
+        if (!$this->hasAnnotation($node, $requiredTag)) {
+            $errors[] = $this->buildErrorMessage(sprintf(
+                '%s must be marked "%s"',
+                $type,
+                $requiredTag,
+            ));
+        }
+
+        // Has forbidden annotation.
+        if ($this->hasAnnotation($node, $forbiddenTag)) {
+            $errors[] = $this->buildErrorMessage(sprintf(
+                '%s cannot be marked "%s"',
+                $type,
+                $forbiddenTag,
+            ));
+        }
+
+        return $errors;
+    }
+
+    private function getType(ClassReflection $class): string
+    {
+        $reflection = $class->getNativeReflection();
+        $namespace = $reflection->getNamespaceName();
+
+        if ($this->isInNamespace($namespace, 'PhpTuf\\ComposerStager\\Tests\\')) {
+            return self::TEST_CLASS;
+        }
+
+        if ($reflection->isInterface()) {
+            return self::INTERFACE;
+        }
+
+        if ($reflection->isAbstract()) {
+            return self::ABSTRACT_CLASS;
+        }
+
+        if ($class->is(Throwable::class)) {
+            return self::EXCEPTION;
+        }
+
+        if ($this->isFactoryClass($class)) {
+            return self::FACTORY;
+        }
+
+        return self::CONCRETE_CLASS;
+    }
+
+    private function hasAnnotation(Class_|Interface_ $node, string $tag): bool
+    {
+        $docComment = $node->getDocComment();
+
+        if ($docComment === null) {
+            return false;
+        }
+
+        return str_contains($docComment->getText(), $tag);
+    }
+}

--- a/src/Domain/Aggregate/PreconditionsTree/BeginnerPreconditionsInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/BeginnerPreconditionsInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface BeginnerPreconditionsInterface extends PreconditionsTreeInterface
 {

--- a/src/Domain/Aggregate/PreconditionsTree/CleanerPreconditionsInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/CleanerPreconditionsInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface CleanerPreconditionsInterface extends PreconditionsTreeInterface
 {

--- a/src/Domain/Aggregate/PreconditionsTree/CommitterPreconditionsInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/CommitterPreconditionsInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface CommitterPreconditionsInterface extends PreconditionsTreeInterface
 {

--- a/src/Domain/Aggregate/PreconditionsTree/CommonPreconditionsInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/CommonPreconditionsInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface CommonPreconditionsInterface extends PreconditionsTreeInterface
 {

--- a/src/Domain/Aggregate/PreconditionsTree/NoUnsupportedLinksExistInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/NoUnsupportedLinksExistInterface.php
@@ -15,6 +15,8 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface NoUnsupportedLinksExistInterface extends PreconditionsTreeInterface
 {

--- a/src/Domain/Aggregate/PreconditionsTree/PreconditionsTreeInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/PreconditionsTreeInterface.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
 
 use PhpTuf\ComposerStager\Domain\Service\Precondition\PreconditionInterface;
 
-/** Contains a set of preconditions for a domain operation. */
+/**
+ * Contains a set of preconditions for a domain operation.
+ *
+ * @api
+ */
 interface PreconditionsTreeInterface extends PreconditionInterface
 {
     /**

--- a/src/Domain/Aggregate/PreconditionsTree/StagerPreconditionsInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/StagerPreconditionsInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface StagerPreconditionsInterface extends PreconditionsTreeInterface
 {

--- a/src/Domain/Aggregate/PreconditionsTree/StagingDirIsReadyInterface.php
+++ b/src/Domain/Aggregate/PreconditionsTree/StagingDirIsReadyInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface StagingDirIsReadyInterface extends PreconditionsTreeInterface
 {

--- a/src/Domain/Core/Beginner/Beginner.php
+++ b/src/Domain/Core/Beginner/Beginner.php
@@ -11,6 +11,7 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class Beginner implements BeginnerInterface
 {
     public function __construct(

--- a/src/Domain/Core/Beginner/BeginnerInterface.php
+++ b/src/Domain/Core/Beginner/BeginnerInterface.php
@@ -7,7 +7,11 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
-/** Begins the staging process by copying the active directory to the staging directory. */
+/**
+ * Begins the staging process by copying the active directory to the staging directory.
+ *
+ * @api
+ */
 interface BeginnerInterface
 {
     /**

--- a/src/Domain/Core/Cleaner/Cleaner.php
+++ b/src/Domain/Core/Cleaner/Cleaner.php
@@ -10,6 +10,7 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCall
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class Cleaner implements CleanerInterface
 {
     public function __construct(

--- a/src/Domain/Core/Cleaner/CleanerInterface.php
+++ b/src/Domain/Core/Cleaner/CleanerInterface.php
@@ -6,7 +6,11 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCall
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
-/** Removes the staging directory. */
+/**
+ * Removes the staging directory.
+ *
+ * @api
+ */
 interface CleanerInterface
 {
     /**

--- a/src/Domain/Core/Committer/Committer.php
+++ b/src/Domain/Core/Committer/Committer.php
@@ -11,6 +11,7 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class Committer implements CommitterInterface
 {
     public function __construct(

--- a/src/Domain/Core/Committer/CommitterInterface.php
+++ b/src/Domain/Core/Committer/CommitterInterface.php
@@ -7,7 +7,11 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
-/** Makes the staged changes live by syncing the active directory with the staging directory. */
+/**
+ * Makes the staged changes live by syncing the active directory with the staging directory.
+ *
+ * @api
+ */
 interface CommitterInterface
 {
     /**

--- a/src/Domain/Core/Stager/Stager.php
+++ b/src/Domain/Core/Stager/Stager.php
@@ -11,6 +11,7 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ComposerRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class Stager implements StagerInterface
 {
     public function __construct(

--- a/src/Domain/Core/Stager/StagerInterface.php
+++ b/src/Domain/Core/Stager/StagerInterface.php
@@ -6,7 +6,11 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCall
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
-/** Executes a Composer command in the staging directory. */
+/**
+ * Executes a Composer command in the staging directory.
+ *
+ * @api
+ */
 interface StagerInterface
 {
     /**

--- a/src/Domain/Exception/ExceptionInterface.php
+++ b/src/Domain/Exception/ExceptionInterface.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Exception;
 
 use Throwable;
 
-/** An interface that all concrete exceptions must implement. */
+/**
+ * An interface that all concrete exceptions must implement.
+ *
+ * @api
+ */
 interface ExceptionInterface extends Throwable
 {
 }

--- a/src/Domain/Exception/IOException.php
+++ b/src/Domain/Exception/IOException.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Exception;
 
 use Exception;
 
-/** This exception represents a device error, such as a failed filesystem operation. */
+/**
+ * This exception represents a device error, such as a failed filesystem operation.
+ *
+ * @api
+ */
 class IOException extends Exception implements ExceptionInterface
 {
 }

--- a/src/Domain/Exception/InvalidArgumentException.php
+++ b/src/Domain/Exception/InvalidArgumentException.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Exception;
 
 use InvalidArgumentException as PHPInvalidArgumentException;
 
-/** This exception is thrown when an argument doesn't satisfy validation rules. */
+/**
+ * This exception is thrown when an argument doesn't satisfy validation rules.
+ *
+ * @api
+ */
 class InvalidArgumentException extends PHPInvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Domain/Exception/LogicException.php
+++ b/src/Domain/Exception/LogicException.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Exception;
 
 use LogicException as PHPLogicException;
 
-/** This exception represents an error in the program logic and should lead to a fix in your code. */
+/**
+ * This exception represents an error in the program logic and should lead to a fix in your code.
+ *
+ * @api
+ */
 class LogicException extends PHPLogicException implements ExceptionInterface
 {
 }

--- a/src/Domain/Exception/PreconditionException.php
+++ b/src/Domain/Exception/PreconditionException.php
@@ -10,6 +10,8 @@ use Throwable;
  * This exception is thrown when a domain operation has an unfulfilled precondition.
  *
  * @see :/src/Domain/Service/Precondition/README.md
+ *
+ * @api
  */
 class PreconditionException extends RuntimeException implements ExceptionInterface
 {

--- a/src/Domain/Exception/RuntimeException.php
+++ b/src/Domain/Exception/RuntimeException.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Exception;
 
 use RuntimeException as PHPRuntimeException;
 
-/** This exception is thrown if an error occurs that can only be found at runtime. */
+/**
+ * This exception is thrown if an error occurs that can only be found at runtime.
+ *
+ * @api
+ */
 class RuntimeException extends PHPRuntimeException implements ExceptionInterface
 {
 }

--- a/src/Domain/Service/FileSyncer/FileSyncerInterface.php
+++ b/src/Domain/Service/FileSyncer/FileSyncerInterface.php
@@ -7,7 +7,11 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
-/** Recursively syncs files from one directory to another. */
+/**
+ * Recursively syncs files from one directory to another.
+ *
+ * @api
+ */
 interface FileSyncerInterface
 {
     /**

--- a/src/Domain/Service/Filesystem/FilesystemInterface.php
+++ b/src/Domain/Service/Filesystem/FilesystemInterface.php
@@ -6,7 +6,11 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCall
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
-/** Provides basic utilities for interacting with the file system. */
+/**
+ * Provides basic utilities for interacting with the file system.
+ *
+ * @api
+ */
 interface FilesystemInterface
 {
     /**

--- a/src/Domain/Service/Host/HostInterface.php
+++ b/src/Domain/Service/Host/HostInterface.php
@@ -2,7 +2,11 @@
 
 namespace PhpTuf\ComposerStager\Domain\Service\Host;
 
-/** Provides basic utilities for interacting with the host. */
+/**
+ * Provides basic utilities for interacting with the host.
+ *
+ * @api
+ */
 interface HostInterface
 {
     /** Determines whether the operating system is Windows. */

--- a/src/Domain/Service/Precondition/ActiveAndStagingDirsAreDifferentInterface.php
+++ b/src/Domain/Service/Precondition/ActiveAndStagingDirsAreDifferentInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface ActiveAndStagingDirsAreDifferentInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/ActiveDirExistsInterface.php
+++ b/src/Domain/Service/Precondition/ActiveDirExistsInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface ActiveDirExistsInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/ActiveDirIsWritableInterface.php
+++ b/src/Domain/Service/Precondition/ActiveDirIsWritableInterface.php
@@ -10,6 +10,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface ActiveDirIsWritableInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/ComposerIsAvailableInterface.php
+++ b/src/Domain/Service/Precondition/ComposerIsAvailableInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface ComposerIsAvailableInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/NoAbsoluteSymlinksExistInterface.php
+++ b/src/Domain/Service/Precondition/NoAbsoluteSymlinksExistInterface.php
@@ -15,6 +15,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface NoAbsoluteSymlinksExistInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/NoHardLinksExistInterface.php
+++ b/src/Domain/Service/Precondition/NoHardLinksExistInterface.php
@@ -19,6 +19,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface NoHardLinksExistInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/NoLinksExistOnWindowsInterface.php
+++ b/src/Domain/Service/Precondition/NoLinksExistOnWindowsInterface.php
@@ -17,6 +17,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface NoLinksExistOnWindowsInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/NoSymlinksPointOutsideTheCodebaseInterface.php
+++ b/src/Domain/Service/Precondition/NoSymlinksPointOutsideTheCodebaseInterface.php
@@ -15,6 +15,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface NoSymlinksPointOutsideTheCodebaseInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/NoSymlinksPointToADirectoryInterface.php
+++ b/src/Domain/Service/Precondition/NoSymlinksPointToADirectoryInterface.php
@@ -21,6 +21,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  *
  * @see https://github.com/php-tuf/composer-stager/issues/99
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface NoSymlinksPointToADirectoryInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/PreconditionInterface.php
+++ b/src/Domain/Service/Precondition/PreconditionInterface.php
@@ -5,7 +5,11 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
-/** Defines a precondition for a domain operation and how to verify it. */
+/**
+ * Defines a precondition for a domain operation and how to verify it.
+ *
+ * @api
+ */
 interface PreconditionInterface
 {
     /**

--- a/src/Domain/Service/Precondition/StagingDirDoesNotExistInterface.php
+++ b/src/Domain/Service/Precondition/StagingDirDoesNotExistInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface StagingDirDoesNotExistInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/StagingDirExistsInterface.php
+++ b/src/Domain/Service/Precondition/StagingDirExistsInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface StagingDirExistsInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/Precondition/StagingDirIsWritableInterface.php
+++ b/src/Domain/Service/Precondition/StagingDirIsWritableInterface.php
@@ -10,6 +10,8 @@ namespace PhpTuf\ComposerStager\Domain\Service\Precondition;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface StagingDirIsWritableInterface extends PreconditionInterface
 {

--- a/src/Domain/Service/ProcessOutputCallback/ProcessOutputCallbackInterface.php
+++ b/src/Domain/Service/ProcessOutputCallback/ProcessOutputCallbackInterface.php
@@ -12,6 +12,8 @@ use Symfony\Component\Process\Process;
  *
  * @see https://symfony.com/doc/current/components/process.html#running-processes-asynchronously
  *
+ * @api
+ *
  * @noinspection PhpUnused
  */
 interface ProcessOutputCallbackInterface

--- a/src/Domain/Service/ProcessRunner/ComposerRunnerInterface.php
+++ b/src/Domain/Service/ProcessRunner/ComposerRunnerInterface.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Service\ProcessRunner;
 
 use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCallbackInterface;
 
-/** Runs Composer commands. */
+/**
+ * Runs Composer commands.
+ *
+ * @api
+ */
 interface ComposerRunnerInterface extends ProcessRunnerInterface
 {
     /**

--- a/src/Domain/Service/ProcessRunner/ProcessRunnerInterface.php
+++ b/src/Domain/Service/ProcessRunner/ProcessRunnerInterface.php
@@ -2,7 +2,11 @@
 
 namespace PhpTuf\ComposerStager\Domain\Service\ProcessRunner;
 
-/** Runs shell processes. */
+/**
+ * Runs shell processes.
+ *
+ * @api
+ */
 interface ProcessRunnerInterface
 {
     /** The default process timeout. */

--- a/src/Domain/Service/ProcessRunner/RsyncRunnerInterface.php
+++ b/src/Domain/Service/ProcessRunner/RsyncRunnerInterface.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Domain\Service\ProcessRunner;
 
 use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCallbackInterface;
 
-/** Runs rsync commands. */
+/**
+ * Runs rsync commands.
+ *
+ * @api
+ */
 interface RsyncRunnerInterface extends ProcessRunnerInterface
 {
     /**

--- a/src/Domain/Value/Path/PathInterface.php
+++ b/src/Domain/Value/Path/PathInterface.php
@@ -8,6 +8,8 @@ namespace PhpTuf\ComposerStager\Domain\Value\Path;
  * The path string may be absolute or relative to the current working directory
  * as returned by `getcwd()` at runtime, e.g., "/var/www/example" or "example".
  * Nothing needs to actually exist at the path.
+ *
+ * @api
  */
 interface PathInterface
 {

--- a/src/Domain/Value/PathList/PathListInterface.php
+++ b/src/Domain/Value/PathList/PathListInterface.php
@@ -2,7 +2,11 @@
 
 namespace PhpTuf\ComposerStager\Domain\Value\PathList;
 
-/** Handles a list of path strings. */
+/**
+ * Handles a list of path strings.
+ *
+ * @api
+ */
 interface PathListInterface
 {
     /**

--- a/src/Infrastructure/Aggregate/PreconditionsTree/AbstractPreconditionsTree.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/AbstractPreconditionsTree.php
@@ -8,6 +8,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\PreconditionInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @api */
 abstract class AbstractPreconditionsTree implements PreconditionsTreeInterface
 {
     /** @var array<\PhpTuf\ComposerStager\Domain\Service\Precondition\PreconditionInterface> */

--- a/src/Infrastructure/Aggregate/PreconditionsTree/BeginnerPreconditions.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/BeginnerPreconditions.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\CommonPreconditions
 use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\NoUnsupportedLinksExistInterface;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\StagingDirDoesNotExistInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class BeginnerPreconditions extends AbstractPreconditionsTree implements BeginnerPreconditionsInterface
 {
     public function __construct(

--- a/src/Infrastructure/Aggregate/PreconditionsTree/CleanerPreconditions.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/CleanerPreconditions.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\CleanerPrecondition
 use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\StagingDirIsReadyInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class CleanerPreconditions extends AbstractPreconditionsTree implements CleanerPreconditionsInterface
 {
     public function __construct(

--- a/src/Infrastructure/Aggregate/PreconditionsTree/CommitterPreconditions.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/CommitterPreconditions.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\CommonPreconditions
 use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\NoUnsupportedLinksExistInterface;
 use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\StagingDirIsReadyInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class CommitterPreconditions extends AbstractPreconditionsTree implements CommitterPreconditionsInterface
 {
     public function __construct(

--- a/src/Infrastructure/Aggregate/PreconditionsTree/CommonPreconditions.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/CommonPreconditions.php
@@ -8,6 +8,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\ActiveDirExistsInterface;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\ActiveDirIsWritableInterface;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\ComposerIsAvailableInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class CommonPreconditions extends AbstractPreconditionsTree implements CommonPreconditionsInterface
 {
     public function __construct(

--- a/src/Infrastructure/Aggregate/PreconditionsTree/NoUnsupportedLinksExist.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/NoUnsupportedLinksExist.php
@@ -9,6 +9,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\NoLinksExistOnWindowsInter
 use PhpTuf\ComposerStager\Domain\Service\Precondition\NoSymlinksPointOutsideTheCodebaseInterface;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\NoSymlinksPointToADirectoryInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class NoUnsupportedLinksExist extends AbstractPreconditionsTree implements NoUnsupportedLinksExistInterface
 {
     public function __construct(

--- a/src/Infrastructure/Aggregate/PreconditionsTree/StagerPreconditions.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/StagerPreconditions.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\CommonPreconditions
 use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\StagerPreconditionsInterface;
 use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\StagingDirIsReadyInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class StagerPreconditions extends AbstractPreconditionsTree implements StagerPreconditionsInterface
 {
     public function __construct(

--- a/src/Infrastructure/Aggregate/PreconditionsTree/StagingDirIsReady.php
+++ b/src/Infrastructure/Aggregate/PreconditionsTree/StagingDirIsReady.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Domain\Aggregate\PreconditionsTree\StagingDirIsReadyIn
 use PhpTuf\ComposerStager\Domain\Service\Precondition\StagingDirExistsInterface;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\StagingDirIsWritableInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class StagingDirIsReady extends AbstractPreconditionsTree implements StagingDirIsReadyInterface
 {
     public function __construct(

--- a/src/Infrastructure/Factory/FileSyncer/FileSyncerFactory.php
+++ b/src/Infrastructure/Factory/FileSyncer/FileSyncerFactory.php
@@ -7,7 +7,11 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncerInterfa
 use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncerInterface;
 use Symfony\Component\Process\ExecutableFinder;
 
-/** Selects and creates the appropriate file syncer for the host. */
+/**
+ * Selects and creates the appropriate file syncer for the host.
+ *
+ * @api
+ */
 final class FileSyncerFactory
 {
     public function __construct(

--- a/src/Infrastructure/Factory/Path/PathFactory.php
+++ b/src/Infrastructure/Factory/Path/PathFactory.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Infrastructure\Value\Path\UnixLikePath;
 use PhpTuf\ComposerStager\Infrastructure\Value\Path\WindowsPath;
 
+/** @api */
 final class PathFactory implements PathFactoryInterface
 {
     public static function create(string $path, ?PathInterface $cwd = null): PathInterface

--- a/src/Infrastructure/Factory/Path/PathFactoryInterface.php
+++ b/src/Infrastructure/Factory/Path/PathFactoryInterface.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Infrastructure\Factory\Path;
 
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
-/** Creates path value objects. */
+/**
+ * Creates path value objects.
+ *
+ * @api
+ */
 interface PathFactoryInterface
 {
     /**

--- a/src/Infrastructure/Factory/Process/ProcessFactory.php
+++ b/src/Infrastructure/Factory/Process/ProcessFactory.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Domain\Exception\LogicException;
 use Symfony\Component\Process\Exception\ExceptionInterface;
 use Symfony\Component\Process\Process;
 
+/** @api */
 final class ProcessFactory implements ProcessFactoryInterface
 {
     public function create(array $command): Process

--- a/src/Infrastructure/Factory/Process/ProcessFactoryInterface.php
+++ b/src/Infrastructure/Factory/Process/ProcessFactoryInterface.php
@@ -4,7 +4,11 @@ namespace PhpTuf\ComposerStager\Infrastructure\Factory\Process;
 
 use Symfony\Component\Process\Process;
 
-/** Creates Symfony Process objects. */
+/**
+ * Creates Symfony Process objects.
+ *
+ * @api
+ */
 interface ProcessFactoryInterface
 {
     /**

--- a/src/Infrastructure/Service/FileSyncer/PhpFileSyncer.php
+++ b/src/Infrastructure/Service/FileSyncer/PhpFileSyncer.php
@@ -12,6 +12,7 @@ use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class PhpFileSyncer implements PhpFileSyncerInterface
 {
     public function __construct(

--- a/src/Infrastructure/Service/FileSyncer/PhpFileSyncerInterface.php
+++ b/src/Infrastructure/Service/FileSyncer/PhpFileSyncerInterface.php
@@ -10,6 +10,8 @@ use PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface PhpFileSyncerInterface extends FileSyncerInterface
 {

--- a/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
+++ b/src/Infrastructure/Service/FileSyncer/RsyncFileSyncer.php
@@ -13,6 +13,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class RsyncFileSyncer implements RsyncFileSyncerInterface
 {
     public function __construct(

--- a/src/Infrastructure/Service/FileSyncer/RsyncFileSyncerInterface.php
+++ b/src/Infrastructure/Service/FileSyncer/RsyncFileSyncerInterface.php
@@ -10,6 +10,8 @@ use PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface;
  * This interface exists solely to facilitate autowiring dependencies through type hinting.
  *
  * @see https://symfony.com/doc/current/service_container/autowiring.html
+ *
+ * @api
  */
 interface RsyncFileSyncerInterface extends FileSyncerInterface
 {

--- a/src/Infrastructure/Service/Filesystem/Filesystem.php
+++ b/src/Infrastructure/Service/Filesystem/Filesystem.php
@@ -14,6 +14,7 @@ use Symfony\Component\Filesystem\Exception\FileNotFoundException as SymfonyFileN
 use Symfony\Component\Filesystem\Exception\IOException as SymfonyIOException;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class Filesystem implements FilesystemInterface
 {
     private const PATH_DOES_NOT_EXIST = 'PATH_DOES_NOT_EXIST';

--- a/src/Infrastructure/Service/Finder/ExecutableFinder.php
+++ b/src/Infrastructure/Service/Finder/ExecutableFinder.php
@@ -5,6 +5,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Finder;
 use PhpTuf\ComposerStager\Domain\Exception\LogicException;
 use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class ExecutableFinder implements ExecutableFinderInterface
 {
     public function __construct(private readonly SymfonyExecutableFinder $symfonyExecutableFinder)

--- a/src/Infrastructure/Service/Finder/ExecutableFinderInterface.php
+++ b/src/Infrastructure/Service/Finder/ExecutableFinderInterface.php
@@ -2,7 +2,11 @@
 
 namespace PhpTuf\ComposerStager\Infrastructure\Service\Finder;
 
-/** Finds executables. */
+/**
+ * Finds executables.
+ *
+ * @api
+ */
 interface ExecutableFinderInterface
 {
     /**

--- a/src/Infrastructure/Service/Finder/RecursiveFileFinder.php
+++ b/src/Infrastructure/Service/Finder/RecursiveFileFinder.php
@@ -13,6 +13,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use UnexpectedValueException;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class RecursiveFileFinder implements RecursiveFileFinderInterface
 {
     public function __construct(private readonly PathFactoryInterface $pathFactory)

--- a/src/Infrastructure/Service/Finder/RecursiveFileFinderInterface.php
+++ b/src/Infrastructure/Service/Finder/RecursiveFileFinderInterface.php
@@ -5,7 +5,11 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Finder;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
-/** Recursively finds all files "underneath" or "inside" a directory. */
+/**
+ * Recursively finds all files "underneath" or "inside" a directory.
+ *
+ * @api
+ */
 interface RecursiveFileFinderInterface
 {
     /**

--- a/src/Infrastructure/Service/Host/Host.php
+++ b/src/Infrastructure/Service/Host/Host.php
@@ -4,6 +4,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Host;
 
 use PhpTuf\ComposerStager\Domain\Service\Host\HostInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class Host implements HostInterface
 {
     public function isWindows(): bool

--- a/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
+++ b/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
@@ -11,6 +11,7 @@ use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Value\PathList\PathList;
 
+/** @api */
 abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
 {
     protected string $defaultUnfulfilledStatusMessage;

--- a/src/Infrastructure/Service/Precondition/AbstractPrecondition.php
+++ b/src/Infrastructure/Service/Precondition/AbstractPrecondition.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\PreconditionInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @api */
 abstract class AbstractPrecondition implements PreconditionInterface
 {
     final public function assertIsFulfilled(

--- a/src/Infrastructure/Service/Precondition/ActiveAndStagingDirsAreDifferent.php
+++ b/src/Infrastructure/Service/Precondition/ActiveAndStagingDirsAreDifferent.php
@@ -6,7 +6,11 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\ActiveAndStagingDirsAreDif
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
-/** phpcs:disable SlevomatCodingStandard.Files.LineLength.LineTooLong */
+/**
+ * @internal Don't instantiate this class directly. Get it from the service container via its interface.
+ *
+ * phpcs:disable SlevomatCodingStandard.Files.LineLength.LineTooLong
+ */
 final class ActiveAndStagingDirsAreDifferent extends AbstractPrecondition implements ActiveAndStagingDirsAreDifferentInterface
 {
     public function getName(): string

--- a/src/Infrastructure/Service/Precondition/ActiveDirExists.php
+++ b/src/Infrastructure/Service/Precondition/ActiveDirExists.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\ActiveDirExistsInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class ActiveDirExists extends AbstractPrecondition implements ActiveDirExistsInterface
 {
     public function __construct(private readonly FilesystemInterface $filesystem)

--- a/src/Infrastructure/Service/Precondition/ActiveDirIsWritable.php
+++ b/src/Infrastructure/Service/Precondition/ActiveDirIsWritable.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\ActiveDirIsWritableInterfa
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class ActiveDirIsWritable extends AbstractPrecondition implements ActiveDirIsWritableInterface
 {
     public function __construct(private readonly FilesystemInterface $filesystem)

--- a/src/Infrastructure/Service/Precondition/ComposerIsAvailable.php
+++ b/src/Infrastructure/Service/Precondition/ComposerIsAvailable.php
@@ -13,6 +13,7 @@ use Symfony\Component\Process\Exception\LogicException as SymfonyLogicException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class ComposerIsAvailable extends AbstractPrecondition implements ComposerIsAvailableInterface
 {
     private string $unfulfilledStatusMessage = '';

--- a/src/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExist.php
+++ b/src/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExist.php
@@ -5,7 +5,11 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Precondition;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\NoAbsoluteSymlinksExistInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
-/** phpcs:disable SlevomatCodingStandard.Files.LineLength.LineTooLong */
+/**
+ * @internal Don't instantiate this class directly. Get it from the service container via its interface.
+ *
+ * phpcs:disable SlevomatCodingStandard.Files.LineLength.LineTooLong
+ */
 final class NoAbsoluteSymlinksExist extends AbstractFileIteratingPrecondition implements NoAbsoluteSymlinksExistInterface
 {
     public function getName(): string

--- a/src/Infrastructure/Service/Precondition/NoHardLinksExist.php
+++ b/src/Infrastructure/Service/Precondition/NoHardLinksExist.php
@@ -5,6 +5,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Precondition;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\NoHardLinksExistInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class NoHardLinksExist extends AbstractFileIteratingPrecondition implements NoHardLinksExistInterface
 {
     public function getName(): string

--- a/src/Infrastructure/Service/Precondition/NoLinksExistOnWindows.php
+++ b/src/Infrastructure/Service/Precondition/NoLinksExistOnWindows.php
@@ -10,6 +10,7 @@ use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class NoLinksExistOnWindows extends AbstractFileIteratingPrecondition implements NoLinksExistOnWindowsInterface
 {
     public function __construct(

--- a/src/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebase.php
+++ b/src/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebase.php
@@ -5,6 +5,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\Precondition;
 use PhpTuf\ComposerStager\Domain\Service\Precondition\NoSymlinksPointOutsideTheCodebaseInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class NoSymlinksPointOutsideTheCodebase extends AbstractFileIteratingPrecondition implements
     NoSymlinksPointOutsideTheCodebaseInterface
 {

--- a/src/Infrastructure/Service/Precondition/NoSymlinksPointToADirectory.php
+++ b/src/Infrastructure/Service/Precondition/NoSymlinksPointToADirectory.php
@@ -11,6 +11,7 @@ use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncerInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class NoSymlinksPointToADirectory extends AbstractFileIteratingPrecondition implements
     NoSymlinksPointToADirectoryInterface
 {

--- a/src/Infrastructure/Service/Precondition/StagingDirDoesNotExist.php
+++ b/src/Infrastructure/Service/Precondition/StagingDirDoesNotExist.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\StagingDirDoesNotExistInte
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class StagingDirDoesNotExist extends AbstractPrecondition implements StagingDirDoesNotExistInterface
 {
     public function __construct(private readonly FilesystemInterface $filesystem)

--- a/src/Infrastructure/Service/Precondition/StagingDirExists.php
+++ b/src/Infrastructure/Service/Precondition/StagingDirExists.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\StagingDirExistsInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class StagingDirExists extends AbstractPrecondition implements StagingDirExistsInterface
 {
     public function __construct(private readonly FilesystemInterface $filesystem)

--- a/src/Infrastructure/Service/Precondition/StagingDirIsWritable.php
+++ b/src/Infrastructure/Service/Precondition/StagingDirIsWritable.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\Domain\Service\Precondition\StagingDirIsWritableInterf
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class StagingDirIsWritable extends AbstractPrecondition implements StagingDirIsWritableInterface
 {
     public function __construct(private readonly FilesystemInterface $filesystem)

--- a/src/Infrastructure/Service/ProcessRunner/AbstractRunner.php
+++ b/src/Infrastructure/Service/ProcessRunner/AbstractRunner.php
@@ -12,6 +12,8 @@ use Symfony\Component\Process\Exception\ExceptionInterface as SymfonyExceptionIn
 /**
  * Provides a base for process runners for consistent process creation and
  * exception-handling.
+ *
+ * @api
  */
 abstract class AbstractRunner implements ProcessRunnerInterface
 {

--- a/src/Infrastructure/Service/ProcessRunner/ComposerRunner.php
+++ b/src/Infrastructure/Service/ProcessRunner/ComposerRunner.php
@@ -4,6 +4,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Service\ProcessRunner;
 
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ComposerRunnerInterface;
 
+/** @internal Don't instantiate this class directly. Get it from the service container via its interface. */
 final class ComposerRunner extends AbstractRunner implements ComposerRunnerInterface
 {
     protected function executableName(): string

--- a/src/Infrastructure/Service/ProcessRunner/RsyncRunner.php
+++ b/src/Infrastructure/Service/ProcessRunner/RsyncRunner.php
@@ -10,6 +10,8 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\RsyncRunnerInterface;
  *
  * @see \PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerFactoryInterface
  * @see \PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface
+ *
+ * @internal Don't instantiate this class directly. Get it from the service container via its interface.
  */
 final class RsyncRunner extends AbstractRunner implements RsyncRunnerInterface
 {

--- a/src/Infrastructure/Value/Path/AbstractPath.php
+++ b/src/Infrastructure/Value/Path/AbstractPath.php
@@ -4,6 +4,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Value\Path;
 
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 
+/** @api */
 abstract class AbstractPath implements PathInterface
 {
     protected string $cwd;

--- a/src/Infrastructure/Value/Path/UnixLikePath.php
+++ b/src/Infrastructure/Value/Path/UnixLikePath.php
@@ -7,10 +7,10 @@ namespace PhpTuf\ComposerStager\Infrastructure\Value\Path;
  *
  * For all practical purposes, that means anything but Windows.
  *
- * Don't instantiate this class directory--use the path factory.
- *
  * @see \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @see https://en.wikipedia.org/wiki/Unix-like
+ *
+ * @internal Don't instantiate this class directly. Use the path factory above.
  */
 final class UnixLikePath extends AbstractPath
 {

--- a/src/Infrastructure/Value/Path/WindowsPath.php
+++ b/src/Infrastructure/Value/Path/WindowsPath.php
@@ -5,9 +5,9 @@ namespace PhpTuf\ComposerStager\Infrastructure\Value\Path;
 /**
  * Handles a Windows filesystem path string.
  *
- * Don't instantiate this class directory--use the path factory.
- *
  * @see \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
+ *
+ * @internal Don't instantiate this class directly. Use the path factory above.
  */
 final class WindowsPath extends AbstractPath
 {

--- a/src/Infrastructure/Value/PathList/PathList.php
+++ b/src/Infrastructure/Value/PathList/PathList.php
@@ -5,6 +5,7 @@ namespace PhpTuf\ComposerStager\Infrastructure\Value\PathList;
 use PhpTuf\ComposerStager\Domain\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\Domain\Value\PathList\PathListInterface;
 
+/** @api This class may be instantiated directly gotten from the service container via its interface. */
 final class PathList implements PathListInterface
 {
     /** @var array<string> */


### PR DESCRIPTION
Annotate all classes in `src/` with either `@api` or `@internal`.