### PR TITLE
Move core domain classes up a namespace level

### DIFF
--- a/src/Domain/Core/Beginner.php
+++ b/src/Domain/Core/Beginner.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Beginner;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\Domain\Exception\RuntimeException;

--- a/src/Domain/Core/BeginnerInterface.php
+++ b/src/Domain/Core/BeginnerInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Beginner;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;

--- a/src/Domain/Core/BeginnerInterface.php
+++ b/src/Domain/Core/BeginnerInterface.php
@@ -46,7 +46,7 @@ interface BeginnerInterface
      * @throws \PhpTuf\ComposerStager\Domain\Exception\RuntimeException
      *   If the operation fails.
      *
-     * @see \PhpTuf\ComposerStager\Domain\Core\Committer\CommitterInterface::commit
+     * @see \PhpTuf\ComposerStager\Domain\Core\CommitterInterface::commit
      */
     public function begin(
         PathInterface $activeDir,

--- a/src/Domain/Core/Cleaner.php
+++ b/src/Domain/Core/Cleaner.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Cleaner;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Exception\IOException;
 use PhpTuf\ComposerStager\Domain\Exception\RuntimeException;

--- a/src/Domain/Core/CleanerInterface.php
+++ b/src/Domain/Core/CleanerInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Cleaner;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;

--- a/src/Domain/Core/Committer.php
+++ b/src/Domain/Core/Committer.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Committer;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\Domain\Exception\RuntimeException;

--- a/src/Domain/Core/Committer/CommitterInterface.php
+++ b/src/Domain/Core/Committer/CommitterInterface.php
@@ -35,7 +35,7 @@ interface CommitterInterface
      * @throws \PhpTuf\ComposerStager\Domain\Exception\RuntimeException
      *   If the operation fails.
      *
-     * @see \PhpTuf\ComposerStager\Domain\Core\Beginner\BeginnerInterface::begin
+     * @see \PhpTuf\ComposerStager\Domain\Core\BeginnerInterface::begin
      */
     public function commit(
         PathInterface $stagingDir,

--- a/src/Domain/Core/CommitterInterface.php
+++ b/src/Domain/Core/CommitterInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Committer;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;

--- a/src/Domain/Core/Stager.php
+++ b/src/Domain/Core/Stager.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Stager;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\Domain\Exception\InvalidArgumentException;

--- a/src/Domain/Core/StagerInterface.php
+++ b/src/Domain/Core/StagerInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Domain\Core\Stager;
+namespace PhpTuf\ComposerStager\Domain\Core;
 
 use PhpTuf\ComposerStager\Domain\Service\ProcessOutputCallback\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;

--- a/tests/Domain/Core/BeginnerUnitTest.php
+++ b/tests/Domain/Core/BeginnerUnitTest.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Tests\Domain\Core\Beginner;
+namespace PhpTuf\ComposerStager\Tests\Domain\Core;
 
-use PhpTuf\ComposerStager\Domain\Core\Beginner\Beginner;
+use PhpTuf\ComposerStager\Domain\Core\Beginner;
 use PhpTuf\ComposerStager\Domain\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\Domain\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\Domain\Exception\IOException;
@@ -20,9 +20,9 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use Prophecy\Argument;
 
 /**
- * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Beginner\Beginner
+ * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Beginner
  *
- * @covers \PhpTuf\ComposerStager\Domain\Core\Beginner\Beginner::__construct
+ * @covers \PhpTuf\ComposerStager\Domain\Core\Beginner::__construct
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $fileSyncer
  * @property \PhpTuf\ComposerStager\Domain\Service\Precondition\BeginnerPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions

--- a/tests/Domain/Core/CleanerUnitTest.php
+++ b/tests/Domain/Core/CleanerUnitTest.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Tests\Domain\Core\Cleaner;
+namespace PhpTuf\ComposerStager\Tests\Domain\Core;
 
-use PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner;
+use PhpTuf\ComposerStager\Domain\Core\Cleaner;
 use PhpTuf\ComposerStager\Domain\Exception\IOException;
 use PhpTuf\ComposerStager\Domain\Exception\PreconditionException;
 use PhpTuf\ComposerStager\Domain\Exception\RuntimeException;
@@ -16,9 +16,9 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use Prophecy\Argument;
 
 /**
- * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner
+ * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Cleaner
  *
- * @covers \PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner::__construct
+ * @covers \PhpTuf\ComposerStager\Domain\Core\Cleaner::__construct
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Domain\Service\Precondition\CleanerPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions

--- a/tests/Domain/Core/CommitterUnitTest.php
+++ b/tests/Domain/Core/CommitterUnitTest.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Tests\Domain\Core\Committer;
+namespace PhpTuf\ComposerStager\Tests\Domain\Core;
 
-use PhpTuf\ComposerStager\Domain\Core\Committer\Committer;
+use PhpTuf\ComposerStager\Domain\Core\Committer;
 use PhpTuf\ComposerStager\Domain\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\Domain\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\Domain\Exception\IOException;
@@ -20,9 +20,9 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use Prophecy\Argument;
 
 /**
- * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Committer\Committer
+ * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Committer
  *
- * @covers \PhpTuf\ComposerStager\Domain\Core\Committer\Committer::__construct
+ * @covers \PhpTuf\ComposerStager\Domain\Core\Committer::__construct
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $fileSyncer
  * @property \PhpTuf\ComposerStager\Domain\Service\Precondition\CommitterPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions

--- a/tests/Domain/Core/StagerUnitTest.php
+++ b/tests/Domain/Core/StagerUnitTest.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace PhpTuf\ComposerStager\Tests\Domain\Core\Stager;
+namespace PhpTuf\ComposerStager\Tests\Domain\Core;
 
-use PhpTuf\ComposerStager\Domain\Core\Stager\Stager;
+use PhpTuf\ComposerStager\Domain\Core\Stager;
 use PhpTuf\ComposerStager\Domain\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\Domain\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\Domain\Exception\IOException;
@@ -19,9 +19,9 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use Prophecy\Argument;
 
 /**
- * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Stager\Stager
+ * @coversDefaultClass \PhpTuf\ComposerStager\Domain\Core\Stager
  *
- * @covers \PhpTuf\ComposerStager\Domain\Core\Stager\Stager
+ * @covers \PhpTuf\ComposerStager\Domain\Core\Stager
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Precondition\StagerPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions
  * @property \PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ComposerRunnerInterface|\Prophecy\Prophecy\ObjectProphecy $composerRunner

--- a/tests/EndToEnd/EndToEndFunctionalTestCase.php
+++ b/tests/EndToEnd/EndToEndFunctionalTestCase.php
@@ -4,7 +4,7 @@ namespace PhpTuf\ComposerStager\Tests\EndToEnd;
 
 use PhpTuf\ComposerStager\Domain\Core\Beginner;
 use PhpTuf\ComposerStager\Domain\Core\Cleaner;
-use PhpTuf\ComposerStager\Domain\Core\Committer\Committer;
+use PhpTuf\ComposerStager\Domain\Core\Committer;
 use PhpTuf\ComposerStager\Domain\Core\Stager\Stager;
 use PhpTuf\ComposerStager\Domain\Exception\PreconditionException;
 use PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface;
@@ -20,7 +20,7 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  *
  * @property \PhpTuf\ComposerStager\Domain\Core\Beginner $beginner
  * @property \PhpTuf\ComposerStager\Domain\Core\Cleaner $cleaner
- * @property \PhpTuf\ComposerStager\Domain\Core\Committer\Committer $committer
+ * @property \PhpTuf\ComposerStager\Domain\Core\Committer $committer
  * @property \PhpTuf\ComposerStager\Domain\Core\Stager\Stager $stager
  */
 abstract class EndToEndFunctionalTestCase extends TestCase

--- a/tests/EndToEnd/EndToEndFunctionalTestCase.php
+++ b/tests/EndToEnd/EndToEndFunctionalTestCase.php
@@ -3,7 +3,7 @@
 namespace PhpTuf\ComposerStager\Tests\EndToEnd;
 
 use PhpTuf\ComposerStager\Domain\Core\Beginner;
-use PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner;
+use PhpTuf\ComposerStager\Domain\Core\Cleaner;
 use PhpTuf\ComposerStager\Domain\Core\Committer\Committer;
 use PhpTuf\ComposerStager\Domain\Core\Stager\Stager;
 use PhpTuf\ComposerStager\Domain\Exception\PreconditionException;
@@ -19,7 +19,7 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * Subclasses specify the file syncer to use via ::fileSyncerClass().
  *
  * @property \PhpTuf\ComposerStager\Domain\Core\Beginner $beginner
- * @property \PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner $cleaner
+ * @property \PhpTuf\ComposerStager\Domain\Core\Cleaner $cleaner
  * @property \PhpTuf\ComposerStager\Domain\Core\Committer\Committer $committer
  * @property \PhpTuf\ComposerStager\Domain\Core\Stager\Stager $stager
  */

--- a/tests/EndToEnd/EndToEndFunctionalTestCase.php
+++ b/tests/EndToEnd/EndToEndFunctionalTestCase.php
@@ -2,7 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Tests\EndToEnd;
 
-use PhpTuf\ComposerStager\Domain\Core\Beginner\Beginner;
+use PhpTuf\ComposerStager\Domain\Core\Beginner;
 use PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner;
 use PhpTuf\ComposerStager\Domain\Core\Committer\Committer;
 use PhpTuf\ComposerStager\Domain\Core\Stager\Stager;
@@ -18,7 +18,7 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * infrastructure layers. The test cases themselves are supplied by this class.
  * Subclasses specify the file syncer to use via ::fileSyncerClass().
  *
- * @property \PhpTuf\ComposerStager\Domain\Core\Beginner\Beginner $beginner
+ * @property \PhpTuf\ComposerStager\Domain\Core\Beginner $beginner
  * @property \PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner $cleaner
  * @property \PhpTuf\ComposerStager\Domain\Core\Committer\Committer $committer
  * @property \PhpTuf\ComposerStager\Domain\Core\Stager\Stager $stager

--- a/tests/EndToEnd/EndToEndFunctionalTestCase.php
+++ b/tests/EndToEnd/EndToEndFunctionalTestCase.php
@@ -5,7 +5,7 @@ namespace PhpTuf\ComposerStager\Tests\EndToEnd;
 use PhpTuf\ComposerStager\Domain\Core\Beginner;
 use PhpTuf\ComposerStager\Domain\Core\Cleaner;
 use PhpTuf\ComposerStager\Domain\Core\Committer;
-use PhpTuf\ComposerStager\Domain\Core\Stager\Stager;
+use PhpTuf\ComposerStager\Domain\Core\Stager;
 use PhpTuf\ComposerStager\Domain\Exception\PreconditionException;
 use PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory;
@@ -21,7 +21,7 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * @property \PhpTuf\ComposerStager\Domain\Core\Beginner $beginner
  * @property \PhpTuf\ComposerStager\Domain\Core\Cleaner $cleaner
  * @property \PhpTuf\ComposerStager\Domain\Core\Committer $committer
- * @property \PhpTuf\ComposerStager\Domain\Core\Stager\Stager $stager
+ * @property \PhpTuf\ComposerStager\Domain\Core\Stager $stager
  */
 abstract class EndToEndFunctionalTestCase extends TestCase
 {

--- a/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
+++ b/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
@@ -11,7 +11,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
  *
  * @uses \PhpTuf\ComposerStager\Domain\Core\Beginner
  * @uses \PhpTuf\ComposerStager\Domain\Core\Cleaner
- * @uses \PhpTuf\ComposerStager\Domain\Core\Committer\Committer
+ * @uses \PhpTuf\ComposerStager\Domain\Core\Committer
  * @uses \PhpTuf\ComposerStager\Domain\Core\Stager\Stager
  * @uses \PhpTuf\ComposerStager\Domain\Exception\PreconditionException
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory

--- a/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
+++ b/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
@@ -12,7 +12,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
  * @uses \PhpTuf\ComposerStager\Domain\Core\Beginner
  * @uses \PhpTuf\ComposerStager\Domain\Core\Cleaner
  * @uses \PhpTuf\ComposerStager\Domain\Core\Committer
- * @uses \PhpTuf\ComposerStager\Domain\Core\Stager\Stager
+ * @uses \PhpTuf\ComposerStager\Domain\Core\Stager
  * @uses \PhpTuf\ComposerStager\Domain\Exception\PreconditionException
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Process\ProcessFactory

--- a/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
+++ b/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
@@ -9,7 +9,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
  *
  * @covers \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer
  *
- * @uses \PhpTuf\ComposerStager\Domain\Core\Beginner\Beginner
+ * @uses \PhpTuf\ComposerStager\Domain\Core\Beginner
  * @uses \PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner
  * @uses \PhpTuf\ComposerStager\Domain\Core\Committer\Committer
  * @uses \PhpTuf\ComposerStager\Domain\Core\Stager\Stager

--- a/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
+++ b/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
@@ -10,7 +10,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
  * @covers \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer
  *
  * @uses \PhpTuf\ComposerStager\Domain\Core\Beginner
- * @uses \PhpTuf\ComposerStager\Domain\Core\Cleaner\Cleaner
+ * @uses \PhpTuf\ComposerStager\Domain\Core\Cleaner
  * @uses \PhpTuf\ComposerStager\Domain\Core\Committer\Committer
  * @uses \PhpTuf\ComposerStager\Domain\Core\Stager\Stager
  * @uses \PhpTuf\ComposerStager\Domain\Exception\PreconditionException


### PR DESCRIPTION
There's no need for each core domain class to have it's own namespace, since it will only ever have one class in it. This moves the four of them up a level together into `Domain\Core`.

```
src/Domain/Core/{Beginner => }/Beginner.php
src/Domain/Core/{Beginner => }/BeginnerInterface.php
src/Domain/Core/{Cleaner => }/Cleaner.php
src/Domain/Core/{Cleaner => }/CleanerInterface.php
src/Domain/Core/{Committer => }/Committer.php
src/Domain/Core/{Committer => }/CommitterInterface.php
src/Domain/Core/{Stager => }/Stager.php
src/Domain/Core/{Stager => }/StagerInterface.php
```