### PR TITLE
Rename RecursiveFileFinderInterface to FileFinderInterface

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -90,7 +90,7 @@ parameters:
         - docs
         - LICENSE
         - src
-    preconditionSystemHash: 83b365193518485f9d936ec93c8f4792
+    preconditionSystemHash: 9bf9532a7e0b9c763fd68d7c12c982ce
 
 # https://phpstan.org/developing-extensions/extension-types
 rules:

--- a/src/Infrastructure/Service/FileSyncer/PhpFileSyncer.php
+++ b/src/Infrastructure/Service/FileSyncer/PhpFileSyncer.php
@@ -11,7 +11,7 @@ use PhpTuf\ComposerStager\Domain\Service\ProcessRunner\ProcessRunnerInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
 
 /**
@@ -24,7 +24,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
     use TranslatableAwareTrait;
 
     public function __construct(
-        private readonly RecursiveFileFinderInterface $fileFinder,
+        private readonly FileFinderInterface $fileFinder,
         private readonly FilesystemInterface $filesystem,
         private readonly PathFactoryInterface $pathFactory,
         TranslatableFactoryInterface $translatableFactory,

--- a/src/Infrastructure/Service/Finder/FileFinder.php
+++ b/src/Infrastructure/Service/Finder/FileFinder.php
@@ -20,7 +20,7 @@ use UnexpectedValueException;
  *
  * @internal Don't instantiate this class directly. Get it from the service container via its interface.
  */
-final class RecursiveFileFinder implements RecursiveFileFinderInterface
+final class FileFinder implements FileFinderInterface
 {
     use TranslatableAwareTrait;
 

--- a/src/Infrastructure/Service/Finder/FileFinderInterface.php
+++ b/src/Infrastructure/Service/Finder/FileFinderInterface.php
@@ -12,7 +12,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
  *
  * @api
  */
-interface RecursiveFileFinderInterface
+interface FileFinderInterface
 {
     /**
      * Recursively finds all files "underneath" or "inside" a given directory.

--- a/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
+++ b/src/Infrastructure/Service/Precondition/AbstractFileIteratingPrecondition.php
@@ -10,7 +10,7 @@ use PhpTuf\ComposerStager\Domain\Service\Translation\TranslatorInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
 
 /**
@@ -38,7 +38,7 @@ abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
     ): void;
 
     public function __construct(
-        protected readonly RecursiveFileFinderInterface $fileFinder,
+        protected readonly FileFinderInterface $fileFinder,
         protected readonly FilesystemInterface $filesystem,
         protected readonly PathFactoryInterface $pathFactory,
         TranslatableFactoryInterface $translatableFactory,

--- a/src/Infrastructure/Service/Precondition/NoLinksExistOnWindows.php
+++ b/src/Infrastructure/Service/Precondition/NoLinksExistOnWindows.php
@@ -11,7 +11,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Domain\Value\Translation\TranslatableInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Host\HostInterface;
 
 /**
@@ -22,7 +22,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\Host\HostInterface;
 final class NoLinksExistOnWindows extends AbstractFileIteratingPrecondition implements NoLinksExistOnWindowsInterface
 {
     public function __construct(
-        RecursiveFileFinderInterface $fileFinder,
+        FileFinderInterface $fileFinder,
         FilesystemInterface $filesystem,
         private readonly HostInterface $host,
         PathFactoryInterface $pathFactory,

--- a/src/Infrastructure/Service/Precondition/NoSymlinksPointToADirectory.php
+++ b/src/Infrastructure/Service/Precondition/NoSymlinksPointToADirectory.php
@@ -13,7 +13,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Domain\Value\Translation\TranslatableInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncerInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 
 /**
  * @package Precondition
@@ -24,7 +24,7 @@ final class NoSymlinksPointToADirectory extends AbstractFileIteratingPreconditio
     NoSymlinksPointToADirectoryInterface
 {
     public function __construct(
-        RecursiveFileFinderInterface $fileFinder,
+        FileFinderInterface $fileFinder,
         private readonly FileSyncerInterface $fileSyncer,
         FilesystemInterface $filesystem,
         PathFactoryInterface $pathFactory,

--- a/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
+++ b/tests/EndToEnd/PhpFileSyncerEndToEndFunctionalTest.php
@@ -19,7 +19,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Translation\TranslatableFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\ExecutableFinder
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition

--- a/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerFunctionalTest.php
+++ b/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerFunctionalTest.php
@@ -10,7 +10,7 @@ use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Translation\Translator
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\AbstractPath

--- a/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerUnitTest.php
+++ b/tests/Infrastructure/Service/FileSyncer/PhpFileSyncerUnitTest.php
@@ -9,7 +9,7 @@ use PhpTuf\ComposerStager\Domain\Exception\LogicException;
 use PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncer;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Host\Host;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Factory\Translation\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath;
@@ -29,7 +29,7 @@ use ReflectionClass;
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Factory\Translation\TestTranslatableFactory $translatableFactory
  * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $destination
  * @property \PhpTuf\ComposerStager\Tests\Infrastructure\Value\Path\TestPath $source
@@ -40,7 +40,7 @@ final class PhpFileSyncerUnitTest extends TestCase
     {
         $this->source = new TestPath(self::ACTIVE_DIR);
         $this->destination = new TestPath(self::STAGING_DIR);
-        $this->fileFinder = $this->prophesize(RecursiveFileFinderInterface::class);
+        $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
             ->exists(Argument::any())

--- a/tests/Infrastructure/Service/Finder/FileFinderFunctionalTest.php
+++ b/tests/Infrastructure/Service/Finder/FileFinderFunctionalTest.php
@@ -4,12 +4,12 @@ namespace PhpTuf\ComposerStager\Tests\Infrastructure\Service\Finder;
 
 use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder;
 use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
 use PhpTuf\ComposerStager\Tests\TestCase;
 
 /**
- * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @coversDefaultClass \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  *
  * @covers ::__construct
  *
@@ -22,9 +22,9 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\UnixLikePath
  * @uses \PhpTuf\ComposerStager\Infrastructure\Value\Path\WindowsPath
  *
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder $fileFinder
  */
-final class RecursiveFileFinderFunctionalTest extends TestCase
+final class FileFinderFunctionalTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -36,13 +36,13 @@ final class RecursiveFileFinderFunctionalTest extends TestCase
         self::removeTestEnvironment();
     }
 
-    private function createSut(): RecursiveFileFinder
+    private function createSut(): FileFinder
     {
         $container = $this->getContainer();
         $container->compile();
 
-        /** @var \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder $fileFinder */
-        $fileFinder = $container->get(RecursiveFileFinder::class);
+        /** @var \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder $fileFinder */
+        $fileFinder = $container->get(FileFinder::class);
 
         return $fileFinder;
     }

--- a/tests/Infrastructure/Service/Precondition/AbstractFileIteratingPreconditionUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/AbstractFileIteratingPreconditionUnitTest.php
@@ -8,7 +8,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Domain\Value\Translation\TranslatableInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Factory\Translation\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Service\Translation\TestTranslator;
@@ -29,7 +29,7 @@ use Prophecy\Argument;
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreconditionUnitTestCase
 {
@@ -40,7 +40,7 @@ final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreco
 
     protected function setUp(): void
     {
-        $this->fileFinder = $this->prophesize(RecursiveFileFinderInterface::class);
+        $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->fileFinder
             ->find(Argument::type(PathInterface::class), Argument::type(PathListInterface::class))
             ->willReturn([]);

--- a/tests/Infrastructure/Service/Precondition/FileIteratingPreconditionUnitTestCase.php
+++ b/tests/Infrastructure/Service/Precondition/FileIteratingPreconditionUnitTestCase.php
@@ -11,7 +11,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Domain\Value\Translation\TranslatableInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Factory\Translation\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Service\Translation\TestTranslator;
@@ -22,7 +22,7 @@ use Throwable;
 /**
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCase
 {
@@ -30,7 +30,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
 
     protected function setUp(): void
     {
-        $this->fileFinder = $this->prophesize(RecursiveFileFinderInterface::class);
+        $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->fileFinder
             ->find(Argument::type(PathInterface::class), Argument::type(PathListInterface::class))
             ->willReturn([]);

--- a/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoAbsoluteSymlinksExistFunctionalTest.php
@@ -18,7 +18,7 @@ use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Translation\TranslatableFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition

--- a/tests/Infrastructure/Service/Precondition/NoHardLinksExistFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoHardLinksExistFunctionalTest.php
@@ -16,7 +16,7 @@ use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Translation\TranslatableFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition

--- a/tests/Infrastructure/Service/Precondition/NoHardLinksExistUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoHardLinksExistUnitTest.php
@@ -22,7 +22,7 @@ use PhpTuf\ComposerStager\Tests\Infrastructure\Service\Translation\TestTranslato
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class NoHardLinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {

--- a/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsFunctionalTest.php
@@ -16,8 +16,8 @@ use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Translation\TranslatableFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition

--- a/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoLinksExistOnWindowsUnitTest.php
@@ -27,7 +27,7 @@ use Prophecy\Argument;
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  * @property \PhpTuf\ComposerStager\Infrastructure\Service\Host\HostInterface $host
  */
 final class NoLinksExistOnWindowsUnitTest extends FileIteratingPreconditionUnitTestCase

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
@@ -17,7 +17,7 @@ use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Factory\Translation\TranslatableFactory
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointOutsideTheCodebaseUnitTest.php
@@ -6,7 +6,7 @@ use PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathInterface;
 use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoSymlinksPointOutsideTheCodebase;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Factory\Translation\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Service\Translation\TestTranslator;
@@ -29,13 +29,13 @@ use Prophecy\Argument;
  *
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class NoSymlinksPointOutsideTheCodebaseUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function setUp(): void
     {
-        $this->fileFinder = $this->prophesize(RecursiveFileFinderInterface::class);
+        $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->fileFinder
             ->find(Argument::type(PathInterface::class), Argument::type(PathListInterface::class))
             ->willReturn([]);

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointToADirectoryFunctionalTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointToADirectoryFunctionalTest.php
@@ -23,7 +23,7 @@ use PhpTuf\ComposerStager\Infrastructure\Value\Path\PathList;
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncer
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Filesystem\Filesystem
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\ExecutableFinder
- * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinder
+ * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinder
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Host\Host
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractFileIteratingPrecondition
  * @uses \PhpTuf\ComposerStager\Infrastructure\Service\Precondition\AbstractPrecondition

--- a/tests/Infrastructure/Service/Precondition/NoSymlinksPointToADirectoryUnitTest.php
+++ b/tests/Infrastructure/Service/Precondition/NoSymlinksPointToADirectoryUnitTest.php
@@ -8,7 +8,7 @@ use PhpTuf\ComposerStager\Domain\Value\Path\PathListInterface;
 use PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\PhpFileSyncerInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\FileSyncer\RsyncFileSyncerInterface;
-use PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface;
+use PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface;
 use PhpTuf\ComposerStager\Infrastructure\Service\Precondition\NoSymlinksPointToADirectory;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Factory\Translation\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Infrastructure\Service\Translation\TestTranslator;
@@ -33,13 +33,13 @@ use Prophecy\Argument;
  * @property \PhpTuf\ComposerStager\Domain\Service\FileSyncer\FileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $fileSyncer
  * @property \PhpTuf\ComposerStager\Domain\Service\Filesystem\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  * @property \PhpTuf\ComposerStager\Infrastructure\Factory\Path\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\RecursiveFileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
+ * @property \PhpTuf\ComposerStager\Infrastructure\Service\Finder\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class NoSymlinksPointToADirectoryUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function setUp(): void
     {
-        $this->fileFinder = $this->prophesize(RecursiveFileFinderInterface::class);
+        $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->fileFinder
             ->find(Argument::type(PathInterface::class), Argument::type(PathListInterface::class))
             ->willReturn([]);


### PR DESCRIPTION
`RecursiveFileFinderInterface` is needlessly specific and could cause confusion when other implementations or similar interfaces are added... which is likely.