### PR TITLE
Include "previous" exception details in thrown exception in Filesystem::copy()

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -83,7 +83,7 @@ parameters:
         - docs
         - LICENSE
         - src
-    preconditionSystemHash: 2c92499c4a50b3a29657e6785f775f03
+    preconditionSystemHash: 7322daf04d2ffcd3af9aa12aae30f080
 
 # https://phpstan.org/developing-extensions/extension-types
 rules:

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -65,10 +65,11 @@ final class Filesystem implements FilesystemInterface
             ), 0, $e);
         } catch (SymfonyIOException $e) {
             throw new IOException($this->t(
-                'Failed to copy %source to %destination',
+                'Failed to copy %source to %destination: %details',
                 $this->p([
                     '%source' => $sourceResolved,
                     '%destination' => $destinationResolved,
+                    '%details' => $e->getMessage(),
                 ]),
             ), 0, $e);
         }

--- a/src/Internal/Precondition/Service/ComposerIsAvailable.php
+++ b/src/Internal/Precondition/Service/ComposerIsAvailable.php
@@ -95,8 +95,8 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
             throw new PreconditionException(
                 $this,
                 $this->t(
-                    'Cannot check for Composer due to a host configuration problem: %problem',
-                    $this->p(['%problem' => $e->getMessage()]),
+                    'Cannot check for Composer due to a host configuration problem: %details',
+                    $this->p(['%details' => $e->getMessage()]),
                 ),
                 0,
                 $e,

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -83,8 +83,9 @@ final class FilesystemUnitTest extends TestCase
     /** @covers ::copy */
     public function testCopyFailure(): void
     {
-        $message = 'Failed to copy active-dir to staging-dir';
-        $previous = new SymfonyIOException($message);
+        $previousMessage = 'Something went wrong';
+        $message = sprintf('Failed to copy active-dir to staging-dir: %s', $previousMessage);
+        $previous = new SymfonyIOException($previousMessage);
         $this->symfonyFilesystem
             ->copy(Argument::cetera())
             ->shouldBeCalled()


### PR DESCRIPTION
A little debugging data is helpful if `Filesystem::copy()` fails. This passes along whatever detail Symfony Filesystem provides.