### PR TITLE
Eliminate dynamic properties for PHP 8.2 compatibility

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,7 +17,7 @@ parameters:
         - tests
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: 861a8efc7cfc0621f968748a0508877d
+    preconditionSystemHash: 97325f4cf3677a373069e8c30791da15
     translationSystemHash: 4cdd5c3311aad88434c524a5b3998f2f
     gitattributesExportInclude:
         - composer.json
@@ -69,7 +69,7 @@ parameters:
             message: '#Cannot call .*TranslatableFactory::create.*\(\) directly.*#'
             path: tests
         -
-            message: '#Cannot call method .*\(\) on .*MethodProphecy\|.*.#'
+            message: '#Cannot call method .*\(\) on .*MethodProphecy.#'
             path: tests
         -
             message: '#Cannot instantiate .*\\.*tableMessage directly.*#'
@@ -90,7 +90,7 @@ parameters:
             message: '#Method .* throws checked exception .* but it''s missing from the PHPDoc @throws tag.#'
             path: tests
         -
-            message: '#Parameter .* of (static )?method .* expects .* given.#'
+            message: '#Parameter .* of (static )?(class|method) .* expects .* given.#'
             path: tests
         -
             message: '#Property .* does not accept .*.#'

--- a/src/Internal/Precondition/Service/AbstractPreconditionsTree.php
+++ b/src/Internal/Precondition/Service/AbstractPreconditionsTree.php
@@ -20,6 +20,9 @@ abstract class AbstractPreconditionsTree implements PreconditionInterface
     // This isn't used directly in this class--it's for children.
     use TranslatableAwareTrait;
 
+    // @phpcs:ignore SlevomatCodingStandard.Classes.ForbiddenPublicProperty.ForbiddenPublicProperty
+    public string $unfulfilledStatusMessage;
+
     /** @var array<\PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface> */
     private readonly array $children;
 

--- a/tests/Core/BeginnerUnitTest.php
+++ b/tests/Core/BeginnerUnitTest.php
@@ -19,19 +19,18 @@ use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Beginner
  *
  * @covers \PhpTuf\ComposerStager\Internal\Core\Beginner::__construct
- *
- * @property \PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $fileSyncer
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\BeginnerPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $activeDir
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $stagingDir
  */
 final class BeginnerUnitTest extends TestCase
 {
+    private BeginnerPreconditionsInterface|ObjectProphecy $preconditions;
+    private FileSyncerInterface|ObjectProphecy $fileSyncer;
+
     protected function setUp(): void
     {
         $this->activeDir = new TestPath(self::ACTIVE_DIR);

--- a/tests/Core/CleanerUnitTest.php
+++ b/tests/Core/CleanerUnitTest.php
@@ -15,19 +15,18 @@ use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Cleaner
  *
  * @covers \PhpTuf\ComposerStager\Internal\Core\Cleaner::__construct
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\CleanerPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $activeDir
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $stagingDir
  */
 final class CleanerUnitTest extends TestCase
 {
+    private CleanerPreconditionsInterface|ObjectProphecy $preconditions;
+    private FilesystemInterface|ObjectProphecy $filesystem;
+
     public function setUp(): void
     {
         $this->activeDir = new TestPath(self::ACTIVE_DIR);

--- a/tests/Core/CommitterUnitTest.php
+++ b/tests/Core/CommitterUnitTest.php
@@ -19,19 +19,18 @@ use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Committer
  *
  * @covers \PhpTuf\ComposerStager\Internal\Core\Committer::__construct
- *
- * @property \PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $fileSyncer
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\CommitterPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $activeDir
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $stagingDir
  */
 final class CommitterUnitTest extends TestCase
 {
+    private CommitterPreconditionsInterface|ObjectProphecy $preconditions;
+    private FileSyncerInterface|ObjectProphecy $fileSyncer;
+
     protected function setUp(): void
     {
         $this->activeDir = new TestPath(self::ACTIVE_DIR);

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -20,21 +20,19 @@ use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Stager
  *
  * @covers \PhpTuf\ComposerStager\Internal\Core\Stager
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\StagerPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $preconditions
- * @property \PhpTuf\ComposerStager\API\Translation\Service\DomainOptionsInterface|\Prophecy\Prophecy\ObjectProphecy $domainOptions
- * @property \PhpTuf\ComposerStager\Internal\Process\Service\ComposerProcessRunnerInterface|\Prophecy\Prophecy\ObjectProphecy $composerRunner
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $activeDir
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $stagingDir
  */
 final class StagerUnitTest extends TestCase
 {
     private const INERT_COMMAND = 'about';
+
+    private ComposerProcessRunnerInterface|ObjectProphecy $composerRunner;
+    private StagerPreconditionsInterface|ObjectProphecy $preconditions;
 
     protected function setUp(): void
     {

--- a/tests/EndToEnd/EndToEndFunctionalTestCase.php
+++ b/tests/EndToEnd/EndToEndFunctionalTestCase.php
@@ -2,6 +2,10 @@
 
 namespace PhpTuf\ComposerStager\Tests\EndToEnd;
 
+use PhpTuf\ComposerStager\API\Core\BeginnerInterface;
+use PhpTuf\ComposerStager\API\Core\CleanerInterface;
+use PhpTuf\ComposerStager\API\Core\CommitterInterface;
+use PhpTuf\ComposerStager\API\Core\StagerInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathList;
@@ -18,15 +22,15 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * internal layers. The test cases themselves are supplied by this class.
  * Subclasses specify the file syncer to use via ::fileSyncerClass().
  *
- * @property \PhpTuf\ComposerStager\Internal\Core\Beginner $beginner
- * @property \PhpTuf\ComposerStager\Internal\Core\Cleaner $cleaner
- * @property \PhpTuf\ComposerStager\Internal\Core\Committer $committer
- * @property \PhpTuf\ComposerStager\Internal\Core\Stager $stager
- *
  * @group slow
  */
 abstract class EndToEndFunctionalTestCase extends TestCase
 {
+    private BeginnerInterface $beginner;
+    private CleanerInterface $cleaner;
+    private CommitterInterface $committer;
+    private StagerInterface $stager;
+
     protected function setUp(): void
     {
         $container = $this->getContainer();

--- a/tests/FileSyncer/Factory/FileSyncerFactoryUnitTest.php
+++ b/tests/FileSyncer/Factory/FileSyncerFactoryUnitTest.php
@@ -7,22 +7,23 @@ use PhpTuf\ComposerStager\API\FileSyncer\Service\RsyncFileSyncerInterface;
 use PhpTuf\ComposerStager\Internal\FileSyncer\Factory\FileSyncerFactory;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use Prophecy\Argument;
-use Symfony\Component\Process\ExecutableFinder;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Factory\FileSyncerFactory
  *
  * @covers ::__construct
- *
- * @property \PhpTuf\ComposerStager\API\FileSyncer\Service\PhpFileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $phpFileSyncer
- * @property \PhpTuf\ComposerStager\API\FileSyncer\Service\RsyncFileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $rsyncFileSyncer
- * @property \Symfony\Component\Process\ExecutableFinder|\Prophecy\Prophecy\ObjectProphecy $executableFinder
  */
 final class FileSyncerFactoryUnitTest extends TestCase
 {
+    private PhpFileSyncerInterface|ObjectProphecy $phpFileSyncer;
+    private RsyncFileSyncerInterface|ObjectProphecy $rsyncFileSyncer;
+    private SymfonyExecutableFinder|ObjectProphecy $executableFinder;
+
     public function setUp(): void
     {
-        $this->executableFinder = $this->prophesize(ExecutableFinder::class);
+        $this->executableFinder = $this->prophesize(SymfonyExecutableFinder::class);
         $this->executableFinder
             ->find(Argument::any())
             ->willReturn(null);

--- a/tests/FileSyncer/Service/FileSyncerFunctionalTestCase.php
+++ b/tests/FileSyncer/Service/FileSyncerFunctionalTestCase.php
@@ -3,17 +3,17 @@
 namespace PhpTuf\ComposerStager\Tests\FileSyncer\Service;
 
 use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\Internal\Path\Factory\PathFactory;
 use PhpTuf\ComposerStager\Tests\TestCase;
 
-/**
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $destination
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $source
- */
 abstract class FileSyncerFunctionalTestCase extends TestCase
 {
     private const SOURCE_DIR = self::TEST_ENV . DIRECTORY_SEPARATOR . 'source';
     private const DESTINATION_DIR = self::TEST_ENV . DIRECTORY_SEPARATOR . 'destination';
+
+    private PathInterface $destination;
+    private PathInterface $source;
 
     protected function setUp(): void
     {

--- a/tests/FileSyncer/Service/PhpFileSyncerFunctionalTest.php
+++ b/tests/FileSyncer/Service/PhpFileSyncerFunctionalTest.php
@@ -4,12 +4,7 @@ namespace PhpTuf\ComposerStager\Tests\FileSyncer\Service;
 
 use PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer
- *
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $destination
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $source
- */
+/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer */
 final class PhpFileSyncerFunctionalTest extends FileSyncerFunctionalTestCase
 {
     protected function fileSyncerClass(): string

--- a/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
@@ -7,6 +7,7 @@ use Closure;
 use PhpTuf\ComposerStager\API\Exception\IOException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer;
 use PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface;
@@ -16,22 +17,22 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionClass;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer
  *
  * @covers \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer
- *
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $destination
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $source
- * @property \PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory $translatableFactory
  */
 final class PhpFileSyncerUnitTest extends TestCase
 {
+    private FileFinderInterface|ObjectProphecy $fileFinder;
+    private FilesystemInterface|ObjectProphecy $filesystem;
+    private PathFactoryInterface|ObjectProphecy $pathFactory;
+    private PathInterface $destination;
+    private PathInterface $source;
+
     public function setUp(): void
     {
         $this->source = new TestPath(self::ACTIVE_DIR);

--- a/tests/FileSyncer/Service/RsyncFileSyncerFunctionalTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerFunctionalTest.php
@@ -7,9 +7,6 @@ use PhpTuf\ComposerStager\Internal\FileSyncer\Service\RsyncFileSyncer;
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Service\RsyncFileSyncer
  *
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $destination
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $source
- *
  * @group no_windows
  */
 final class RsyncFileSyncerFunctionalTest extends FileSyncerFunctionalTestCase

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Exception\IOException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathList;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
@@ -18,6 +19,7 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Service\RsyncFileSyncer
@@ -32,15 +34,15 @@ use Prophecy\Argument;
  * @covers ::runCommand
  * @covers ::sync
  *
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Process\Service\RsyncProcessRunnerInterface|\Prophecy\Prophecy\ObjectProphecy $rsync
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $destination
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $source
- *
  * @group no_windows
  */
 final class RsyncFileSyncerUnitTest extends TestCase
 {
+    private FilesystemInterface|ObjectProphecy $filesystem;
+    private PathInterface $destination;
+    private PathInterface $source;
+    private RsyncProcessRunnerInterface|ObjectProphecy $rsync;
+
     public function setUp(): void
     {
         $this->source = new TestPath(self::ACTIVE_DIR);

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -12,6 +12,7 @@ use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException as SymfonyFileNotFoundException;
 use Symfony\Component\Filesystem\Exception\IOException as SymfonyIOException;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
@@ -20,14 +21,12 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Filesystem\Service\Filesystem
  *
  * @covers \PhpTuf\ComposerStager\Internal\Filesystem\Service\Filesystem::__construct
- *
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $activeDir
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $stagingDir
- * @property \Symfony\Component\Filesystem\Filesystem|\Prophecy\Prophecy\ObjectProphecy $symfonyFilesystem
  */
 final class FilesystemUnitTest extends TestCase
 {
+    private PathFactoryInterface|ObjectProphecy $pathFactory;
+    private SymfonyFilesystem|ObjectProphecy $symfonyFilesystem;
+
     protected function setUp(): void
     {
         $this->activeDir = new TestPath(self::ACTIVE_DIR);

--- a/tests/Finder/Service/ExecutableFinderUnitTest.php
+++ b/tests/Finder/Service/ExecutableFinderUnitTest.php
@@ -8,6 +8,7 @@ use PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
 
 /**
@@ -15,11 +16,11 @@ use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
  *
  * @covers ::__construct
  * @covers ::find
- *
- * @property \Symfony\Component\Process\ExecutableFinder|\Prophecy\Prophecy\ObjectProphecy $symfonyExecutableFinder
  */
 final class ExecutableFinderUnitTest extends TestCase
 {
+    private SymfonyExecutableFinder|ObjectProphecy $symfonyExecutableFinder;
+
     protected function setUp(): void
     {
         $this->symfonyExecutableFinder = $this->prophesize(SymfonyExecutableFinder::class);

--- a/tests/Finder/Service/FileFinderFunctionalTest.php
+++ b/tests/Finder/Service/FileFinderFunctionalTest.php
@@ -12,8 +12,6 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinder
  *
  * @covers ::__construct
- *
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinder $fileFinder
  */
 final class FileFinderFunctionalTest extends TestCase
 {

--- a/tests/Path/Value/UnixLikePathUnitTest.php
+++ b/tests/Path/Value/UnixLikePathUnitTest.php
@@ -23,6 +23,8 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  */
 final class UnixLikePathUnitTest extends TestCase
 {
+    public string $cwd;
+
     /** @dataProvider providerBasicFunctionality */
     public function testBasicFunctionality(
         string $given,
@@ -39,7 +41,6 @@ final class UnixLikePathUnitTest extends TestCase
 
         // Dynamically override CWD.
         $setCwd = function ($cwd): void {
-            /** @phpstan-ignore-next-line */
             $this->cwd = $cwd;
         };
         $setCwd->call($sut, $cwd);

--- a/tests/Path/Value/WindowsPathUnitTest.php
+++ b/tests/Path/Value/WindowsPathUnitTest.php
@@ -25,6 +25,8 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  */
 final class WindowsPathUnitTest extends TestCase
 {
+    public string $cwd;
+
     /** @dataProvider providerBasicFunctionality */
     public function testBasicFunctionality(
         string $given,
@@ -43,7 +45,6 @@ final class WindowsPathUnitTest extends TestCase
 
         // Dynamically override CWD.
         $setCwd = function ($cwd): void {
-            /** @phpstan-ignore-next-line */
             $this->cwd = $cwd;
         };
         $setCwd->call($sut, $cwd);

--- a/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
+++ b/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
@@ -13,6 +13,7 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPre
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition
@@ -20,13 +21,13 @@ use Prophecy\Argument;
  * @covers ::__construct
  * @covers ::findFiles
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreconditionUnitTestCase
 {
+    protected FileFinderInterface|ObjectProphecy $fileFinder;
+    protected FilesystemInterface|ObjectProphecy $filesystem;
+    protected PathFactoryInterface|ObjectProphecy $pathFactory;
+
     protected function fulfilledStatusMessage(): string
     {
         return '';

--- a/tests/Precondition/Service/AbstractPreconditionUnitTest.php
+++ b/tests/Precondition/Service/AbstractPreconditionUnitTest.php
@@ -15,14 +15,13 @@ use PhpTuf\ComposerStager\Tests\TestSpyInterface;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition
- *
- * @property \PhpTuf\ComposerStager\Tests\TestSpyInterface|\Prophecy\Prophecy\ObjectProphecy $spy
- */
+/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition */
 final class AbstractPreconditionUnitTest extends PreconditionTestCase
 {
+    private TestSpyInterface|ObjectProphecy $spy;
+    
     protected function setUp(): void
     {
         $this->spy = $this->prophesize(TestSpyInterface::class);

--- a/tests/Precondition/Service/AbstractPreconditionsTreeUnitTest.php
+++ b/tests/Precondition/Service/AbstractPreconditionsTreeUnitTest.php
@@ -21,11 +21,12 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
  * @covers ::__construct
  * @covers ::assertIsFulfilled
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathListInterface $exclusions
  */
 final class AbstractPreconditionsTreeUnitTest extends PreconditionTestCase
 {
+    // @phpcs:ignore SlevomatCodingStandard.Classes.ForbiddenPublicProperty.ForbiddenPublicProperty
+    public PathListInterface $exclusions;
+
     protected function createSut(...$children): AbstractPreconditionsTree
     {
         $translatableFactory = new TestTranslatableFactory();

--- a/tests/Precondition/Service/ActiveAndStagingDirsAreDifferentUnitTest.php
+++ b/tests/Precondition/Service/ActiveAndStagingDirsAreDifferentUnitTest.php
@@ -15,8 +15,6 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $translatableFactory
  */
 final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionTestCase
 {

--- a/tests/Precondition/Service/ActiveDirExistsUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirExistsUnitTest.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirExists;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirExists
@@ -15,12 +16,11 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $translatableFactory
  */
 final class ActiveDirExistsUnitTest extends PreconditionTestCase
 {
+    private FilesystemInterface|ObjectProphecy $filesystem;
+
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);

--- a/tests/Precondition/Service/ActiveDirIsReadyUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirIsReadyUnitTest.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsWritableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsReady;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsReady
@@ -15,12 +16,12 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::assertIsFulfilled
  * @covers ::getFulfilledStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirExistsInterface|\Prophecy\Prophecy\ObjectProphecy $activeDirExists
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsWritableInterface|\Prophecy\Prophecy\ObjectProphecy $activeDirIsWritable
  */
 final class ActiveDirIsReadyUnitTest extends PreconditionTestCase
 {
+    private ActiveDirExistsInterface|ObjectProphecy $activeDirExists;
+    private ActiveDirIsWritableInterface|ObjectProphecy $activeDirIsWritable;
+
     protected function setUp(): void
     {
         $this->activeDirExists = $this->prophesize(ActiveDirExistsInterface::class);

--- a/tests/Precondition/Service/ActiveDirIsWritableUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirIsWritableUnitTest.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsWritable;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsWritable
@@ -15,11 +16,11 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  */
 final class ActiveDirIsWritableUnitTest extends PreconditionTestCase
 {
+    private FilesystemInterface|ObjectProphecy $filesystem;
+
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);

--- a/tests/Precondition/Service/BeginnerPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/BeginnerPreconditionsUnitTest.php
@@ -8,6 +8,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirDoesNotExistInterfa
 use PhpTuf\ComposerStager\Internal\Precondition\Service\BeginnerPreconditions;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\BeginnerPreconditions
@@ -17,13 +18,13 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $commonPreconditions
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\NoUnsupportedLinksExistInterface|\Prophecy\Prophecy\ObjectProphecy $noUnsupportedLinksExist
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\StagingDirDoesNotExistInterface|\Prophecy\Prophecy\ObjectProphecy $stagingDirDoesNotExist
  */
 final class BeginnerPreconditionsUnitTest extends PreconditionTestCase
 {
+    private CommonPreconditionsInterface|ObjectProphecy $commonPreconditions;
+    private NoUnsupportedLinksExistInterface|ObjectProphecy $noUnsupportedLinksExist;
+    private StagingDirDoesNotExistInterface|ObjectProphecy $stagingDirDoesNotExist;
+
     protected function setUp(): void
     {
         $this->commonPreconditions = $this->prophesize(CommonPreconditionsInterface::class);

--- a/tests/Precondition/Service/CleanerPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/CleanerPreconditionsUnitTest.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\CleanerPreconditions;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\CleanerPreconditions
@@ -16,13 +17,12 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathListInterface $exclusions
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $commonPreconditions
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface|\Prophecy\Prophecy\ObjectProphecy $stagingDirIsReady
  */
 final class CleanerPreconditionsUnitTest extends PreconditionTestCase
 {
+    private CommonPreconditionsInterface|ObjectProphecy $commonPreconditions;
+    private StagingDirIsReadyInterface|ObjectProphecy $stagingDirIsReady;
+
     protected function setUp(): void
     {
         $this->commonPreconditions = $this->prophesize(CommonPreconditionsInterface::class);

--- a/tests/Precondition/Service/CommitterPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/CommitterPreconditionsUnitTest.php
@@ -8,6 +8,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\CommitterPreconditions;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\CommitterPreconditions
@@ -17,13 +18,13 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $commonPreconditions
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\NoUnsupportedLinksExistInterface|\Prophecy\Prophecy\ObjectProphecy $noUnsupportedLinksExist
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface|\Prophecy\Prophecy\ObjectProphecy $stagingDirIsReady
  */
 final class CommitterPreconditionsUnitTest extends PreconditionTestCase
 {
+    private CommonPreconditionsInterface|ObjectProphecy $commonPreconditions;
+    private NoUnsupportedLinksExistInterface|ObjectProphecy $noUnsupportedLinksExist;
+    private StagingDirIsReadyInterface|ObjectProphecy $stagingDirIsReady;
+
     protected function setUp(): void
     {
         $this->commonPreconditions = $this->prophesize(CommonPreconditionsInterface::class);

--- a/tests/Precondition/Service/CommonPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/CommonPreconditionsUnitTest.php
@@ -9,6 +9,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\HostSupportsRunningProcessesI
 use PhpTuf\ComposerStager\Internal\Precondition\Service\CommonPreconditions;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\CommonPreconditions
@@ -18,14 +19,14 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\ActiveAndStagingDirsAreDifferentInterface|\Prophecy\Prophecy\ObjectProphecy $activeAndStagingDirsAreDifferent
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsReadyInterface|\Prophecy\Prophecy\ObjectProphecy $activeDirIsReady
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\ComposerIsAvailableInterface|\Prophecy\Prophecy\ObjectProphecy $composerIsAvailable
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\HostSupportsRunningProcessesInterface|\Prophecy\Prophecy\ObjectProphecy $hostSupportsRunningProcesses
  */
 final class CommonPreconditionsUnitTest extends PreconditionTestCase
 {
+    private ActiveAndStagingDirsAreDifferentInterface|ObjectProphecy $activeAndStagingDirsAreDifferent;
+    private ActiveDirIsReadyInterface|ObjectProphecy $activeDirIsReady;
+    private ComposerIsAvailableInterface|ObjectProphecy $composerIsAvailable;
+    private HostSupportsRunningProcessesInterface|ObjectProphecy $hostSupportsRunningProcesses;
+
     protected function setUp(): void
     {
         $this->activeAndStagingDirsAreDifferent = $this->prophesize(ActiveAndStagingDirsAreDifferentInterface::class);

--- a/tests/Precondition/Service/ComposerIsAvailableFunctionalTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableFunctionalTest.php
@@ -12,15 +12,11 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 use Symfony\Component\DependencyInjection\Definition;
 
-/**
- * @coversNothing
- *
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $activeDir
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
- * @property string $executableFinderClass
- */
+/** @coversNothing */
 final class ComposerIsAvailableFunctionalTest extends TestCase
 {
+    private string $executableFinderClass;
+
     protected function setUp(): void
     {
         self::createTestEnvironment();

--- a/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
@@ -12,9 +12,10 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslationParameters;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Process\Exception\LogicException as SymfonyLogicException;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException as SymfonyProcessFailedException;
+use Symfony\Component\Process\Process as SymfonyProcess;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ComposerIsAvailable
@@ -28,14 +29,14 @@ use Symfony\Component\Process\Process;
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
  * @covers ::isValidExecutable
- *
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinderInterface|\Prophecy\Prophecy\ObjectProphecy $executableFinder
- * @property \PhpTuf\ComposerStager\Internal\Process\Factory\ProcessFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $processFactory
- * @property \Symfony\Component\Process\Process|\Prophecy\Prophecy\ObjectProphecy $process
  */
 final class ComposerIsAvailableUnitTest extends PreconditionTestCase
 {
     private const COMPOSER_PATH = '/usr/bin/composer';
+
+    private ExecutableFinderInterface|ObjectProphecy $executableFinder;
+    private ProcessFactoryInterface|ObjectProphecy $processFactory;
+    private SymfonyProcess|ObjectProphecy $process;
 
     protected function setUp(): void
     {
@@ -44,7 +45,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionTestCase
             ->find('composer')
             ->willReturn(self::COMPOSER_PATH);
         $this->processFactory = $this->prophesize(ProcessFactoryInterface::class);
-        $this->process = $this->prophesize(Process::class);
+        $this->process = $this->prophesize(SymfonyProcess::class);
         $this->process
             ->mustRun()
             ->willReturn($this->process);
@@ -143,7 +144,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionTestCase
     {
         $this->process
             ->mustRun()
-            ->willThrow(ProcessFailedException::class);
+            ->willThrow(SymfonyProcessFailedException::class);
         $sut = $this->createSut();
 
         $message = $this->invalidComposerErrorMessage();

--- a/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
+++ b/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
@@ -16,16 +16,16 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPre
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Throwable;
 
-/**
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
- */
 abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCase
 {
     abstract protected function fulfilledStatusMessage(): string;
+
+    protected FileFinderInterface|ObjectProphecy $fileFinder;
+    protected FilesystemInterface|ObjectProphecy $filesystem;
+    protected PathFactoryInterface|ObjectProphecy $pathFactory;
 
     protected function setUp(): void
     {

--- a/tests/Precondition/Service/HostSupportsRunningProcessesFunctionalTest.php
+++ b/tests/Precondition/Service/HostSupportsRunningProcessesFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
-use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses;
 use PhpTuf\ComposerStager\Tests\TestCase;
 
@@ -13,9 +12,6 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  */
 final class HostSupportsRunningProcessesFunctionalTest extends TestCase
 {
-    private PathInterface $activeDir;
-    private PathInterface $stagingDir;
-
     protected function setUp(): void
     {
         $this->activeDir = self::activeDirPath();

--- a/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
+++ b/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
@@ -21,8 +21,6 @@ use Symfony\Component\Process\Process;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $translatableFactory
  */
 final class HostSupportsRunningProcessesUnitTest extends PreconditionTestCase
 {

--- a/tests/Precondition/Service/LinkPreconditionsFunctionalTestCase.php
+++ b/tests/Precondition/Service/LinkPreconditionsFunctionalTestCase.php
@@ -6,10 +6,6 @@ use PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface;
 use PhpTuf\ComposerStager\Internal\Path\Factory\PathFactory;
 use PhpTuf\ComposerStager\Tests\TestCase;
 
-/**
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $activeDir
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
- */
 abstract class LinkPreconditionsFunctionalTestCase extends TestCase
 {
     protected function setUp(): void

--- a/tests/Precondition/Service/NoAbsoluteSymlinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoAbsoluteSymlinksExistUnitTest.php
@@ -13,8 +13,6 @@ use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  */
 final class NoAbsoluteSymlinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {

--- a/tests/Precondition/Service/NoHardLinksExistFunctionalTest.php
+++ b/tests/Precondition/Service/NoHardLinksExistFunctionalTest.php
@@ -11,9 +11,6 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist
  *
  * @covers ::__construct
- *
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $activeDir
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
  */
 final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {

--- a/tests/Precondition/Service/NoHardLinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoHardLinksExistUnitTest.php
@@ -12,10 +12,6 @@ use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class NoHardLinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {

--- a/tests/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
+++ b/tests/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
@@ -11,9 +11,6 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows
  *
  * @covers ::__construct
- *
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $activeDir
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
  */
 final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {

--- a/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
+++ b/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
@@ -17,14 +17,11 @@ use Prophecy\Argument;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
- * @property \PhpTuf\ComposerStager\Internal\Host\Service\HostInterface $host
  */
 final class NoLinksExistOnWindowsUnitTest extends FileIteratingPreconditionUnitTestCase
 {
+    private HostInterface $host;
+
     protected function setUp(): void
     {
         $this->host = $this->createWindowsHost();

--- a/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
@@ -12,9 +12,6 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTh
  *
  * @covers ::__construct
  * @covers ::exitEarly
- *
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $activeDir
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
  */
 final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {

--- a/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
@@ -19,10 +19,6 @@ use Prophecy\Argument;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class NoSymlinksPointOutsideTheCodebaseUnitTest extends FileIteratingPreconditionUnitTestCase
 {

--- a/tests/Precondition/Service/NoSymlinksPointToADirectoryFunctionalTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointToADirectoryFunctionalTest.php
@@ -14,9 +14,6 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointToADirect
  *
  * @covers ::__construct
  * @covers ::exitEarly
- *
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $activeDir
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
  */
 final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {

--- a/tests/Precondition/Service/NoSymlinksPointToADirectoryUnitTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointToADirectoryUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\PhpFileSyncerInterface;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\RsyncFileSyncerInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
@@ -12,6 +13,7 @@ use PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointToADirectory;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointToADirectory
@@ -22,14 +24,11 @@ use Prophecy\Argument;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface|\Prophecy\Prophecy\ObjectProphecy $fileSyncer
- * @property \PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $pathFactory
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinderInterface|\Prophecy\Prophecy\ObjectProphecy $fileFinder
  */
 final class NoSymlinksPointToADirectoryUnitTest extends FileIteratingPreconditionUnitTestCase
 {
+    private FileSyncerInterface|ObjectProphecy $fileSyncer;
+
     protected function setUp(): void
     {
         $this->fileFinder = $this->prophesize(FileFinderInterface::class);

--- a/tests/Precondition/Service/NoUnsupportedLinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoUnsupportedLinksExistUnitTest.php
@@ -10,6 +10,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\NoSymlinksPointOutsideTheCode
 use PhpTuf\ComposerStager\API\Precondition\Service\NoSymlinksPointToADirectoryInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoUnsupportedLinksExist;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoUnsupportedLinksExist
@@ -19,15 +20,15 @@ use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\NoAbsoluteSymlinksExistInterface|\Prophecy\Prophecy\ObjectProphecy $noAbsoluteSymlinksExist
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\NoHardLinksExistInterface|\Prophecy\Prophecy\ObjectProphecy $noHardLinksExist
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\NoLinksExistOnWindowsInterface|\Prophecy\Prophecy\ObjectProphecy $noLinksExistOnWindows
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\NoSymlinksPointOutsideTheCodebaseInterface|\Prophecy\Prophecy\ObjectProphecy $noSymlinksPointOutsideTheCodebase
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\NoSymlinksPointToADirectoryInterface|\Prophecy\Prophecy\ObjectProphecy $noSymlinksPointToADirectory
  */
 final class NoUnsupportedLinksExistUnitTest extends PreconditionTestCase
 {
+    private NoAbsoluteSymlinksExistInterface|ObjectProphecy $noAbsoluteSymlinksExist;
+    private NoHardLinksExistInterface|ObjectProphecy $noHardLinksExist;
+    private NoLinksExistOnWindowsInterface|ObjectProphecy $noLinksExistOnWindows;
+    private NoSymlinksPointOutsideTheCodebaseInterface|ObjectProphecy $noSymlinksPointOutsideTheCodebase;
+    private NoSymlinksPointToADirectoryInterface|ObjectProphecy $noSymlinksPointToADirectory;
+
     protected function setUp(): void
     {
         $this->noAbsoluteSymlinksExist = $this->prophesize(NoAbsoluteSymlinksExistInterface::class);

--- a/tests/Precondition/Service/PreconditionTestCase.php
+++ b/tests/Precondition/Service/PreconditionTestCase.php
@@ -9,11 +9,6 @@ use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPathList;
 use PhpTuf\ComposerStager\Tests\TestCase;
 
-/**
- * @property \PhpTuf\ComposerStager\API\Path\Value\PathListInterface $exclusions
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $activeDir
- * @property \PhpTuf\ComposerStager\Tests\Path\Value\TestPath $stagingDir
- */
 abstract class PreconditionTestCase extends TestCase
 {
     // Multiply expected calls to prophecies to account for multiple calls to ::isFulfilled()

--- a/tests/Precondition/Service/StagerPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/StagerPreconditionsUnitTest.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagerPreconditions;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagerPreconditions
@@ -16,12 +17,12 @@ use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface|\Prophecy\Prophecy\ObjectProphecy $commonPreconditions
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface|\Prophecy\Prophecy\ObjectProphecy $stagingDirIsReady
  */
 final class StagerPreconditionsUnitTest extends PreconditionTestCase
 {
+    private CommonPreconditionsInterface|ObjectProphecy $commonPreconditions;
+    private StagingDirIsReadyInterface|ObjectProphecy $stagingDirIsReady;
+
     protected function setUp(): void
     {
         $this->commonPreconditions = $this->prophesize(CommonPreconditionsInterface::class);

--- a/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
+++ b/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirDoesNotExist;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirDoesNotExist
@@ -15,11 +16,11 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  */
 final class StagingDirDoesNotExistUnitTest extends PreconditionTestCase
 {
+    private FilesystemInterface|ObjectProphecy $filesystem;
+
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);

--- a/tests/Precondition/Service/StagingDirExistsUnitTest.php
+++ b/tests/Precondition/Service/StagingDirExistsUnitTest.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirExists;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirExists
@@ -15,11 +16,11 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  */
 final class StagingDirExistsUnitTest extends PreconditionTestCase
 {
+    private FilesystemInterface|ObjectProphecy $filesystem;
+
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);

--- a/tests/Precondition/Service/StagingDirIsReadyUnitTest.php
+++ b/tests/Precondition/Service/StagingDirIsReadyUnitTest.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirExistsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsWritableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsReady;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsReady
@@ -16,12 +17,12 @@ use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\StagingDirExistsInterface|\Prophecy\Prophecy\ObjectProphecy $stagingDirExists
- * @property \PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsWritableInterface|\Prophecy\Prophecy\ObjectProphecy $stagingDirIsWritable
  */
 final class StagingDirIsReadyUnitTest extends PreconditionTestCase
 {
+    private StagingDirExistsInterface|ObjectProphecy $stagingDirExists;
+    private StagingDirIsWritableInterface|ObjectProphecy $stagingDirIsWritable;
+
     protected function setUp(): void
     {
         $this->stagingDirExists = $this->prophesize(StagingDirExistsInterface::class);

--- a/tests/Precondition/Service/StagingDirIsWritableUnitTest.php
+++ b/tests/Precondition/Service/StagingDirIsWritableUnitTest.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsWritable;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsWritable
@@ -15,11 +16,11 @@ use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessa
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
- *
- * @property \PhpTuf\ComposerStager\Internal\Filesystem\Service\FilesystemInterface|\Prophecy\Prophecy\ObjectProphecy $filesystem
  */
 final class StagingDirIsWritableUnitTest extends PreconditionTestCase
 {
+    private FilesystemInterface|ObjectProphecy $filesystem;
+
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
@@ -30,6 +31,7 @@ final class StagingDirIsWritableUnitTest extends PreconditionTestCase
     protected function createSut(): StagingDirIsWritable
     {
         $filesystem = $this->filesystem->reveal();
+        assert($filesystem instanceof FilesystemInterface);
         $translatableFactory = new TestTranslatableFactory();
 
         return new StagingDirIsWritable($filesystem, $translatableFactory);

--- a/tests/Process/Service/AbstractProcessRunnerUnitTest.php
+++ b/tests/Process/Service/AbstractProcessRunnerUnitTest.php
@@ -13,22 +13,23 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Process\Exception\ProcessFailedException as SymfonyProcessFailedException;
-use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Process as SymfonyProcess;
 use Throwable;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Service\AbstractProcessRunner
  *
  * @covers ::__construct
- *
- * @property \PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinderInterface|\Prophecy\Prophecy\ObjectProphecy $executableFinder
- * @property \PhpTuf\ComposerStager\Internal\Process\Factory\ProcessFactoryInterface|\Prophecy\Prophecy\ObjectProphecy $processFactory
- * @property \Symfony\Component\Process\Process|\Prophecy\Prophecy\ObjectProphecy $process
  */
 final class AbstractProcessRunnerUnitTest extends TestCase
 {
     private const COMMAND_NAME = 'test';
+
+    private ExecutableFinderInterface|ObjectProphecy $executableFinder;
+    private ProcessFactoryInterface|ObjectProphecy $processFactory;
+    private SymfonyProcess|ObjectProphecy $process;
 
     public function setUp(): void
     {
@@ -37,7 +38,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
             ->find(Argument::any())
             ->willReturnArgument();
         $this->processFactory = $this->prophesize(ProcessFactoryInterface::class);
-        $this->process = $this->prophesize(Process::class);
+        $this->process = $this->prophesize(SymfonyProcess::class);
         $this->process
             ->setTimeout(Argument::any())
             ->willReturn($this->process);
@@ -146,7 +147,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         // SymfonyProcessFailedException can't be initialized with a known message
         // value, so dynamically get the message it will generate.
         try {
-            $process = $this->prophesize(Process::class);
+            $process = $this->prophesize(SymfonyProcess::class);
             $process->isSuccessful()
                 ->willReturn(true);
             $previous = new SymfonyProcessFailedException($process->reveal());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace PhpTuf\ComposerStager\Tests;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslationParametersInterface;
 use PhpTuf\ComposerStager\Internal\Path\Factory\PathFactory;
@@ -37,6 +38,10 @@ abstract class TestCase extends PHPUnitTestCase
     protected const CHANGED_CONTENT = 'changed';
     public const DOMAIN_DEFAULT = 'messages';
     public const DOMAIN_EXCEPTIONS = 'exceptions';
+
+    protected PathListInterface $exclusions;
+    protected PathInterface $activeDir;
+    protected PathInterface $stagingDir;
 
     protected static function testWorkingDirPath(): PathInterface
     {

--- a/tools/phpstan/Rules/Interfaces/PreconditionDiagramsInSyncRule.php
+++ b/tools/phpstan/Rules/Interfaces/PreconditionDiagramsInSyncRule.php
@@ -60,7 +60,7 @@ final class PreconditionDiagramsInSyncRule extends AbstractRule
 
         return [
             $this->buildErrorMessage(sprintf(
-                'Precondition system classes have changed. Make sure the  '
+                'Precondition system classes have changed. Make sure the '
                 . 'appropriate changes have been made to the diagrams in docs/preconditions '
                 . "(don't forget to export and optimize the images) and update "
                 . 'phpstan.neon.dist:parameters.preconditionSystemHash to %s',


### PR DESCRIPTION
This eliminates dynamic properties in tests for compatibility with PHP 8.2, which has deprecate them: https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties.