### PR TITLE
Introduce API\Process\Value\OutputTypeEnum for a safer API\Process\Service\OutputCallbackInterface

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -257,6 +257,7 @@
     <rule ref="SlevomatCodingStandard.Functions.FunctionLength.FunctionLength"><exclude-pattern>tests</exclude-pattern><exclude-pattern>tools/phpcs</exclude-pattern></rule>
     <rule ref="SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall"><exclude-pattern>rector.php</exclude-pattern></rule>
     <rule ref="SlevomatCodingStandard.Functions.RequireMultiLineCall.RequiredMultiLineCall"><exclude-pattern>tests</exclude-pattern></rule>
+    <rule ref="SlevomatCodingStandard.PHP.DisallowDirectMagicInvokeCall.DisallowDirectMagicInvokeCall"><exclude-pattern>tests</exclude-pattern></rule>
     <rule ref="SlevomatCodingStandard.PHP.DisallowReference.DisallowedAssigningByReference"><exclude-pattern>tests</exclude-pattern></rule>
     <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"><exclude-pattern>tests</exclude-pattern></rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint"><exclude-pattern>tests</exclude-pattern></rule>

--- a/src/API/Core/BeginnerInterface.php
+++ b/src/API/Core/BeginnerInterface.php
@@ -4,8 +4,8 @@ namespace PhpTuf\ComposerStager\API\Core;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * Begins the staging process by copying the active directory to the staging directory.
@@ -37,7 +37,7 @@ interface BeginnerInterface
      *
      *   With rare exception, you should use the same exclusions when beginning
      *   as when committing.
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -54,7 +54,7 @@ interface BeginnerInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Core/CleanerInterface.php
+++ b/src/API/Core/CleanerInterface.php
@@ -3,8 +3,8 @@
 namespace PhpTuf\ComposerStager\API\Core;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * Removes the staging directory.
@@ -22,7 +22,7 @@ interface CleanerInterface
      *   The active directory.
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
      *   The staging directory.
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -36,7 +36,7 @@ interface CleanerInterface
     public function clean(
         PathInterface $activeDir,
         PathInterface $stagingDir,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Core/CommitterInterface.php
+++ b/src/API/Core/CommitterInterface.php
@@ -4,8 +4,8 @@ namespace PhpTuf\ComposerStager\API\Core;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * Makes the staged changes live by syncing the active directory with the staging directory.
@@ -26,7 +26,7 @@ interface CommitterInterface
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathListInterface|null $exclusions
      *   Paths to exclude, relative to the staging directory. With rare exception,
      *   you should use the same exclusions when committing as when beginning.
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -43,7 +43,7 @@ interface CommitterInterface
         PathInterface $stagingDir,
         PathInterface $activeDir,
         ?PathListInterface $exclusions = null,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Core/StagerInterface.php
+++ b/src/API/Core/StagerInterface.php
@@ -3,8 +3,8 @@
 namespace PhpTuf\ComposerStager\API\Core;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * Executes a Composer command in the staging directory.
@@ -31,7 +31,7 @@ interface StagerInterface
      *   The active directory.
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $stagingDir
      *   The staging directory.
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -48,7 +48,7 @@ interface StagerInterface
         array $composerCommand,
         PathInterface $activeDir,
         PathInterface $stagingDir,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/FileSyncer/Service/FileSyncerInterface.php
+++ b/src/API/FileSyncer/Service/FileSyncerInterface.php
@@ -4,8 +4,8 @@ namespace PhpTuf\ComposerStager\API\FileSyncer\Service;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * Recursively syncs files from one directory to another.
@@ -33,7 +33,7 @@ interface FileSyncerInterface
      *   directory is automatically excluded in order to prevent infinite
      *   recursion if it is a descendant of the source directory, i.e., if it is
      *   "underneath" or "inside" it.
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -48,7 +48,7 @@ interface FileSyncerInterface
         PathInterface $source,
         PathInterface $destination,
         ?PathListInterface $exclusions = null,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -3,8 +3,8 @@
 namespace PhpTuf\ComposerStager\API\Filesystem\Service;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * Provides basic utilities for interacting with the file system.
@@ -168,7 +168,7 @@ interface FilesystemInterface
      *
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $path
      *   A path to remove.
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -179,7 +179,7 @@ interface FilesystemInterface
      */
     public function remove(
         PathInterface $path,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Process/Service/ComposerProcessRunnerInterface.php
+++ b/src/API/Process/Service/ComposerProcessRunnerInterface.php
@@ -24,7 +24,7 @@ interface ComposerProcessRunnerInterface
      *       '--with-all-dependencies',
      *   ];
      *   ```
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -39,7 +39,7 @@ interface ComposerProcessRunnerInterface
      */
     public function run(
         array $command,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Process/Service/OutputCallbackInterface.php
+++ b/src/API/Process/Service/OutputCallbackInterface.php
@@ -2,36 +2,22 @@
 
 namespace PhpTuf\ComposerStager\API\Process\Service;
 
+use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
+
 /**
  * Receives streamed process output.
  *
  * This provides an interface for output callbacks accepted by API classes.
- * It is designed for compatibility with the Symfony Process component.
- *
- * @see https://symfony.com/doc/current/components/process.html#running-processes-asynchronously
  *
  * @package Process
  *
  * @api This interface is subject to our backward compatibility promise and may be safely depended upon.
- *
- * @noinspection PhpUnused
  */
 interface OutputCallbackInterface
 {
-    /** Standard output (stdout). */
-    public const OUT = 'OUT';
-
-    /** Standard error (stderr). */
-    public const ERR = 'ERR';
-
     /**
-     * @param string $type
-     *   The output type. Possible values are ::OUT for standard output (stdout)
-     *   and ::ERR for standard error (stderr).
      * @param string $buffer
      *   A line of output.
-     *
-     * @see \Symfony\Component\Process\Process::readPipes
      */
-    public function __invoke(string $type, string $buffer): void;
+    public function __invoke(OutputTypeEnum $type, string $buffer): void;
 }

--- a/src/API/Process/Service/OutputCallbackInterface.php
+++ b/src/API/Process/Service/OutputCallbackInterface.php
@@ -16,7 +16,7 @@ namespace PhpTuf\ComposerStager\API\Process\Service;
  *
  * @noinspection PhpUnused
  */
-interface ProcessOutputCallbackInterface
+interface OutputCallbackInterface
 {
     /** Standard output (stdout). */
     public const OUT = 'OUT';

--- a/src/API/Process/Service/ProcessInterface.php
+++ b/src/API/Process/Service/ProcessInterface.php
@@ -20,7 +20,7 @@ interface ProcessInterface
      * @throws \PhpTuf\ComposerStager\API\Exception\RuntimeException
      *   If the process doesn't terminate successfully.
      */
-    public function mustRun(?ProcessOutputCallbackInterface $callback = null): self;
+    public function mustRun(?OutputCallbackInterface $callback = null): self;
 
     /**
      * Returns the current output of the process (STDOUT).

--- a/src/API/Process/Service/RsyncProcessRunnerInterface.php
+++ b/src/API/Process/Service/RsyncProcessRunnerInterface.php
@@ -24,7 +24,7 @@ interface RsyncProcessRunnerInterface
      *       'path/to/destination',
      *   ];
      *   ```
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
@@ -39,7 +39,7 @@ interface RsyncProcessRunnerInterface
      */
     public function run(
         array $command,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Process/Value/OutputTypeEnum.php
+++ b/src/API/Process/Value/OutputTypeEnum.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\API\Process\Value;
+
+/**
+ * Defines process output type values.
+ *
+ * @package Process
+ *
+ * @api This enum is subject to our backward compatibility promise and may be safely depended upon.
+ */
+enum OutputTypeEnum
+{
+    /** Standard output (stdout). */
+    case OUT;
+
+    /** Standard error (stderr). */
+    case ERR;
+}

--- a/src/Internal/Core/Beginner.php
+++ b/src/Internal/Core/Beginner.php
@@ -9,8 +9,8 @@ use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\BeginnerPreconditionsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * @package Core
@@ -29,7 +29,7 @@ final class Beginner implements BeginnerInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions);

--- a/src/Internal/Core/Cleaner.php
+++ b/src/Internal/Core/Cleaner.php
@@ -8,8 +8,8 @@ use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CleanerPreconditionsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * @package Core
@@ -27,7 +27,7 @@ final class Cleaner implements CleanerInterface
     public function clean(
         PathInterface $activeDir,
         PathInterface $stagingDir,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir);

--- a/src/Internal/Core/Committer.php
+++ b/src/Internal/Core/Committer.php
@@ -9,8 +9,8 @@ use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommitterPreconditionsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 
 /**
  * @package Core
@@ -29,7 +29,7 @@ final class Committer implements CommitterInterface
         PathInterface $stagingDir,
         PathInterface $activeDir,
         ?PathListInterface $exclusions = null,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions);

--- a/src/Internal/Core/Stager.php
+++ b/src/Internal/Core/Stager.php
@@ -9,8 +9,8 @@ use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagerPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ComposerProcessRunnerInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 
@@ -35,7 +35,7 @@ final class Stager implements StagerInterface
         array $composerCommand,
         PathInterface $activeDir,
         PathInterface $stagingDir,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir);
@@ -85,7 +85,7 @@ final class Stager implements StagerInterface
     private function runCommand(
         PathInterface $stagingDir,
         array $composerCommand,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $command = array_merge(

--- a/src/Internal/FileSyncer/Service/PhpFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/PhpFileSyncer.php
@@ -10,8 +10,8 @@ use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathList;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 
@@ -37,7 +37,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
         PathInterface $source,
         PathInterface $destination,
         ?PathListInterface $exclusions = null,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         set_time_limit((int) $timeout);

--- a/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
@@ -10,8 +10,8 @@ use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathList;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\RsyncProcessRunnerInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
@@ -45,7 +45,7 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
         PathInterface $source,
         PathInterface $destination,
         ?PathListInterface $exclusions = null,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $sourceResolved = $source->resolved();
@@ -90,7 +90,7 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
         string $sourceResolved,
         string $destinationResolved,
         PathInterface $destination,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
     ): void {
         $this->ensureDestinationDirectoryExists($destination);
         $command = $this->buildCommand($exclusions, $sourceResolved, $destinationResolved);

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -7,8 +7,8 @@ use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 use Symfony\Component\Filesystem\Exception\ExceptionInterface as SymfonyExceptionInterface;
@@ -173,7 +173,7 @@ final class Filesystem implements FilesystemInterface
 
     public function remove(
         PathInterface $path,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         try {

--- a/src/Internal/Process/Service/AbstractProcessRunner.php
+++ b/src/Internal/Process/Service/AbstractProcessRunner.php
@@ -4,8 +4,8 @@ namespace PhpTuf\ComposerStager\Internal\Process\Service;
 
 use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 
@@ -37,7 +37,7 @@ abstract class AbstractProcessRunner
      *   The command to run and its arguments as separate string values, e.g.,
      *   ['require', 'example/package'] or ['source', 'destination']. The return
      *   value of ::executableName() will be automatically prepended.
-     * @param \PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface|null $callback
+     * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\InvalidArgumentException
@@ -51,7 +51,7 @@ abstract class AbstractProcessRunner
      */
     public function run(
         array $command,
-        ?ProcessOutputCallbackInterface $callback = null,
+        ?OutputCallbackInterface $callback = null,
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         array_unshift($command, $this->findExecutable());

--- a/src/Internal/Process/Service/OutputCallbackAdapter.php
+++ b/src/Internal/Process/Service/OutputCallbackAdapter.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Internal\Process\Service;
+
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
+use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
+use Symfony\Component\Process\Process as SymfonyProcess;
+
+/**
+ * @package Process
+ *
+ * @internal Don't depend directly on this class. It may be changed or removed at any time without notice.
+ */
+final class OutputCallbackAdapter implements OutputCallbackAdapterInterface
+{
+    public function __construct(private readonly ?OutputCallbackInterface $callback = null)
+    {
+    }
+
+    public function __invoke(string $type, string $buffer): void
+    {
+        if (!$this->callback instanceof OutputCallbackInterface) {
+            return;
+        }
+
+        $enumType = $type === SymfonyProcess::OUT
+            ? OutputTypeEnum::OUT
+            : OutputTypeEnum::ERR;
+
+        call_user_func($this->callback, $enumType, $buffer);
+    }
+}

--- a/src/Internal/Process/Service/OutputCallbackAdapterInterface.php
+++ b/src/Internal/Process/Service/OutputCallbackAdapterInterface.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Internal\Process\Service;
+
+/**
+ * Adapts an OutputCallback to Symfony Process's callback expectations.
+ *
+ * @see https://symfony.com/doc/current/components/process.html#running-processes-asynchronously
+ *
+ * @package Process
+ *
+ * @internal Don't depend directly on this interface. It may be changed or removed at any time without notice.
+ */
+interface OutputCallbackAdapterInterface
+{
+    /** @see \Symfony\Component\Process\Process::readPipes */
+    public function __invoke(string $type, string $buffer): void;
+}

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -5,8 +5,8 @@ namespace PhpTuf\ComposerStager\Internal\Process\Service;
 use PhpTuf\ComposerStager\API\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
@@ -62,7 +62,7 @@ final class Process implements ProcessInterface
         }
     }
 
-    public function mustRun(?ProcessOutputCallbackInterface $callback = null): self
+    public function mustRun(?OutputCallbackInterface $callback = null): self
     {
         try {
             $this->symfonyProcess->mustRun($callback);

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -65,7 +65,8 @@ final class Process implements ProcessInterface
     public function mustRun(?OutputCallbackInterface $callback = null): self
     {
         try {
-            $this->symfonyProcess->mustRun($callback);
+            $callbackAdapter = new OutputCallbackAdapter($callback);
+            $this->symfonyProcess->mustRun($callbackAdapter);
         } catch (Throwable $e) {
             throw new RuntimeException($this->t(
                 'Failed to run process: %details',

--- a/tests/Core/BeginnerUnitTest.php
+++ b/tests/Core/BeginnerUnitTest.php
@@ -10,12 +10,12 @@ use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\BeginnerPreconditionsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Core\Beginner;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPathList;
-use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
+use PhpTuf\ComposerStager\Tests\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
@@ -70,7 +70,7 @@ final class BeginnerUnitTest extends TestCase
         string $activeDir,
         string $stagingDir,
         ?PathListInterface $exclusions,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
         ?int $timeout,
     ): void {
         $activeDir = new TestPath($activeDir);
@@ -100,7 +100,7 @@ final class BeginnerUnitTest extends TestCase
                 'activeDir' => 'five/six',
                 'stagingDir' => 'seven/eight',
                 'givenExclusions' => new TestPathList(),
-                'callback' => new TestProcessOutputCallback(),
+                'callback' => new TestOutputCallback(),
                 'timeout' => 100,
             ],
         ];

--- a/tests/Core/CleanerUnitTest.php
+++ b/tests/Core/CleanerUnitTest.php
@@ -7,11 +7,11 @@ use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CleanerPreconditionsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Core\Cleaner;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
-use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
+use PhpTuf\ComposerStager\Tests\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
@@ -62,11 +62,8 @@ final class CleanerUnitTest extends TestCase
      *
      * @dataProvider providerCleanWithOptionalParams
      */
-    public function testCleanWithOptionalParams(
-        string $path,
-        ?ProcessOutputCallbackInterface $callback,
-        ?int $timeout,
-    ): void {
+    public function testCleanWithOptionalParams(string $path, ?OutputCallbackInterface $callback, ?int $timeout): void
+    {
         $path = new TestPath($path);
         $this->preconditions
             ->assertIsFulfilled($this->activeDir, $path)
@@ -89,7 +86,7 @@ final class CleanerUnitTest extends TestCase
             ],
             [
                 'path' => 'three/four',
-                'callback' => new TestProcessOutputCallback(),
+                'callback' => new TestOutputCallback(),
                 'timeout' => 10,
             ],
         ];

--- a/tests/Core/CommitterUnitTest.php
+++ b/tests/Core/CommitterUnitTest.php
@@ -10,12 +10,12 @@ use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommitterPreconditionsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Core\Committer;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPathList;
-use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
+use PhpTuf\ComposerStager\Tests\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
 use Prophecy\Argument;
@@ -70,7 +70,7 @@ final class CommitterUnitTest extends TestCase
         string $stagingDir,
         string $activeDir,
         ?PathListInterface $exclusions,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
         ?int $timeout,
     ): void {
         $activeDir = new TestPath($activeDir);
@@ -100,7 +100,7 @@ final class CommitterUnitTest extends TestCase
                 'stagingDir' => 'five/six',
                 'activeDir' => 'seven/eight',
                 'exclusions' => new TestPathList(),
-                'callback' => new TestProcessOutputCallback(),
+                'callback' => new TestOutputCallback(),
                 'timeout' => 10,
             ],
         ];

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -10,11 +10,11 @@ use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagerPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ComposerProcessRunnerInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Core\Stager;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
-use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
+use PhpTuf\ComposerStager\Tests\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
@@ -74,7 +74,7 @@ final class StagerUnitTest extends TestCase
     public function testStageWithOptionalParams(
         array $givenCommand,
         array $expectedCommand,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
         ?int $timeout,
     ): void {
         $this->preconditions
@@ -106,7 +106,7 @@ final class StagerUnitTest extends TestCase
                     '--working-dir=' . PathHelper::stagingDirRelative(),
                     self::INERT_COMMAND,
                 ],
-                'callback' => new TestProcessOutputCallback(),
+                'callback' => new TestOutputCallback(),
                 'timeout' => 10,
             ],
         ];

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -10,11 +10,11 @@ use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathList;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\RsyncProcessRunnerInterface;
 use PhpTuf\ComposerStager\Internal\FileSyncer\Service\RsyncFileSyncer;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
-use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
+use PhpTuf\ComposerStager\Tests\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
@@ -75,7 +75,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
         string $destination,
         ?PathListInterface $exclusions,
         array $command,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
     ): void {
         $source = new TestPath($source);
         $destination = new TestPath($destination);
@@ -120,7 +120,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
                     'source/two/',
                     'destination/two',
                 ],
-                'callback' => new TestProcessOutputCallback(),
+                'callback' => new TestOutputCallback(),
             ],
             'Siblings: duplicate exclusions given' => [
                 'source' => 'source/three',

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -5,10 +5,10 @@ namespace PhpTuf\ComposerStager\Tests\Filesystem\Service;
 use PhpTuf\ComposerStager\API\Exception\IOException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Filesystem\Service\Filesystem;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
-use PhpTuf\ComposerStager\Tests\Process\Service\TestProcessOutputCallback;
+use PhpTuf\ComposerStager\Tests\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use Prophecy\Argument;
@@ -167,7 +167,7 @@ final class FilesystemUnitTest extends TestCase
      */
     public function testRemove(
         string $path,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
         ?int $givenTimeout,
         int $expectedTimeout,
     ): void {
@@ -193,7 +193,7 @@ final class FilesystemUnitTest extends TestCase
             ],
             [
                 'path' => 'three/four',
-                'callback' => new TestProcessOutputCallback(),
+                'callback' => new TestOutputCallback(),
                 'givenTimeout' => 10,
                 'expectedTimeout' => 10,
             ],

--- a/tests/Process/Service/AbstractProcessRunnerUnitTest.php
+++ b/tests/Process/Service/AbstractProcessRunnerUnitTest.php
@@ -5,8 +5,8 @@ namespace PhpTuf\ComposerStager\Tests\Process\Service;
 use PhpTuf\ComposerStager\API\Exception\IOException;
 use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Process\Service\AbstractProcessRunner;
 use PhpTuf\ComposerStager\Tests\TestCase;
@@ -83,7 +83,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         string $executableName,
         array $givenCommand,
         array $expectedCommand,
-        ?ProcessOutputCallbackInterface $callback,
+        ?OutputCallbackInterface $callback,
         ?int $timeout,
     ): void {
         $this->executableFinder
@@ -129,7 +129,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
                 'executableName' => 'five',
                 'givenCommand' => [],
                 'expectedCommand' => ['five'],
-                'callback' => new TestProcessOutputCallback(),
+                'callback' => new TestOutputCallback(),
                 'timeout' => 200,
             ],
         ];

--- a/tests/Process/Service/OutputCallbackAdapterUnitTest.php
+++ b/tests/Process/Service/OutputCallbackAdapterUnitTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Tests\Process\Service;
+
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
+use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
+use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter;
+use PhpTuf\ComposerStager\Tests\TestCase;
+use Symfony\Component\Process\Process as SymfonyProcess;
+
+/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter */
+final class OutputCallbackAdapterUnitTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::__invoke
+     *
+     * @dataProvider providerBasicFunctionality
+     */
+    public function testBasicFunctionality(string $givenType, OutputTypeEnum $expectedType, string $buffer): void
+    {
+        $callback = $this->prophesize(OutputCallbackInterface::class);
+        $callback->__invoke($expectedType, $buffer)
+            ->shouldBeCalledOnce();
+        $callback = $callback->reveal();
+        $sut = new OutputCallbackAdapter($callback);
+
+        $sut($givenType, $buffer);
+    }
+
+    public function providerBasicFunctionality(): array
+    {
+        return [
+            'stdout' => [
+                'givenType' => SymfonyProcess::OUT,
+                'expectedType' => OutputTypeEnum::OUT,
+                'buffer' => 'stdout',
+            ],
+            'stderr' => [
+                'givenType' => SymfonyProcess::ERR,
+                'expectedType' => OutputTypeEnum::ERR,
+                'buffer' => 'stderr',
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::__invoke
+     *
+     * @dataProvider providerNoCallback
+     */
+    public function testNoCallback(array $constructorArguments): void
+    {
+        // No explicit assertion is necessary for this test. The SUT will
+        // throw an exception if the behavior under doesn't behave as expected.
+        $this->expectNotToPerformAssertions();
+
+        $sut = new OutputCallbackAdapter(...$constructorArguments);
+
+        $sut(SymfonyProcess::OUT, __METHOD__);
+    }
+
+    public function providerNoCallback(): array
+    {
+        return [
+            'Implicit null' => [
+                'constructorArguments' => [],
+            ],
+            'Explicit null' => [
+                'constructorArguments' => [null],
+            ],
+        ];
+    }
+}

--- a/tests/Process/Service/ProcessFunctionalTest.php
+++ b/tests/Process/Service/ProcessFunctionalTest.php
@@ -36,7 +36,7 @@ final class ProcessFunctionalTest extends TestCase
     {
         $buffer = __METHOD__;
         $sut = $this->createSut(['echo', $buffer]);
-        $outputCallback = new TestProcessOutputCallback();
+        $outputCallback = new TestOutputCallback();
 
         $sut->mustRun($outputCallback);
         $sut->mustRun($outputCallback);

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -5,9 +5,10 @@ namespace PhpTuf\ComposerStager\Tests\Process\Service;
 use PhpTuf\ComposerStager\API\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
-use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactoryInterface;
+use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter;
+use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapterInterface;
 use PhpTuf\ComposerStager\Internal\Process\Service\Process;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ProcessHelper;
@@ -68,12 +69,12 @@ final class ProcessUnitTest extends TestCase
         array $givenConstructorArguments,
         array $expectedCommand,
         array $givenMustRunArguments,
-        ?OutputCallbackInterface $expectedMustRunArguments,
+        ?OutputCallbackAdapterInterface $expectedMustRunArgument,
         array $givenSetTimeoutArguments,
         string $output,
     ): void {
         $this->symfonyProcess
-            ->mustRun($expectedMustRunArguments)
+            ->mustRun($expectedMustRunArgument)
             ->shouldBeCalledOnce()
             ->willReturn($this->symfonyProcess);
         $this->symfonyProcess
@@ -105,7 +106,7 @@ final class ProcessUnitTest extends TestCase
                 'givenConstructorArguments' => [],
                 'expectedCommand' => [],
                 'givenMustRunArguments' => [],
-                'expectedMustRunArguments' => null,
+                'expectedMustRunArgument' => new OutputCallbackAdapter(null),
                 'givenSetTimeoutArguments' => [ProcessInterface::DEFAULT_TIMEOUT],
                 'output' => 'Minimum arguments output',
             ],
@@ -113,7 +114,7 @@ final class ProcessUnitTest extends TestCase
                 'givenConstructorArguments' => [['nullable', 'arguments']],
                 'expectedCommand' => ['nullable', 'arguments'],
                 'givenMustRunArguments' => [null],
-                'expectedMustRunArguments' => null,
+                'expectedMustRunArgument' => new OutputCallbackAdapter(null),
                 'givenSetTimeoutArguments' => [ProcessInterface::DEFAULT_TIMEOUT],
                 'output' => 'Nullable arguments output',
             ],
@@ -121,7 +122,7 @@ final class ProcessUnitTest extends TestCase
                 'givenConstructorArguments' => [['simple', 'arguments']],
                 'expectedCommand' => ['simple', 'arguments'],
                 'givenMustRunArguments' => [new TestOutputCallback()],
-                'expectedMustRunArguments' => new TestOutputCallback(),
+                'expectedMustRunArgument' => new OutputCallbackAdapter(new TestOutputCallback()),
                 'givenSetTimeoutArguments' => [42],
                 'output' => 'Simple arguments output',
             ],

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -5,8 +5,8 @@ namespace PhpTuf\ComposerStager\Tests\Process\Service;
 use PhpTuf\ComposerStager\API\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Process\Service\Process;
 use PhpTuf\ComposerStager\Tests\TestCase;
@@ -68,7 +68,7 @@ final class ProcessUnitTest extends TestCase
         array $givenConstructorArguments,
         array $expectedCommand,
         array $givenMustRunArguments,
-        ?ProcessOutputCallbackInterface $expectedMustRunArguments,
+        ?OutputCallbackInterface $expectedMustRunArguments,
         array $givenSetTimeoutArguments,
         string $output,
     ): void {
@@ -120,8 +120,8 @@ final class ProcessUnitTest extends TestCase
             'Simple arguments' => [
                 'givenConstructorArguments' => [['simple', 'arguments']],
                 'expectedCommand' => ['simple', 'arguments'],
-                'givenMustRunArguments' => [new TestProcessOutputCallback()],
-                'expectedMustRunArguments' => new TestProcessOutputCallback(),
+                'givenMustRunArguments' => [new TestOutputCallback()],
+                'expectedMustRunArguments' => new TestOutputCallback(),
                 'givenSetTimeoutArguments' => [42],
                 'output' => 'Simple arguments output',
             ],

--- a/tests/Process/Service/TestOutputCallback.php
+++ b/tests/Process/Service/TestOutputCallback.php
@@ -2,9 +2,9 @@
 
 namespace PhpTuf\ComposerStager\Tests\Process\Service;
 
-use PhpTuf\ComposerStager\API\Process\Service\ProcessOutputCallbackInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 
-final class TestProcessOutputCallback implements ProcessOutputCallbackInterface
+final class TestOutputCallback implements OutputCallbackInterface
 {
     /** @var array{'out': array<string>, 'err': array<string>} */
     private array $output = [

--- a/tests/Process/Service/TestOutputCallback.php
+++ b/tests/Process/Service/TestOutputCallback.php
@@ -3,29 +3,36 @@
 namespace PhpTuf\ComposerStager\Tests\Process\Service;
 
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
+use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
 
 final class TestOutputCallback implements OutputCallbackInterface
 {
-    /** @var array{'out': array<string>, 'err': array<string>} */
+    private const OUT = 'OUT';
+    private const ERR = 'ERR';
+
+    /** @var array{'OUT': array<string>, 'ERR': array<string>} */
     private array $output = [
-        'out' => [],
-        'err' => [],
+        self::OUT => [],
+        self::ERR => [],
     ];
 
-    /** @phpcs:disable SlevomatCodingStandard.Functions */
-    public function __invoke(string $type, string $buffer): void
+    public function __invoke(OutputTypeEnum $type, string $buffer): void
     {
+        $stringType = $type === OutputTypeEnum::OUT
+            ? self::OUT
+            : self::ERR;
+
         // Avoid OS-sensitivity and simplify comparison by stripping line endings.
-        $this->output[$type][] = rtrim($buffer);
+        $this->output[$stringType][] = rtrim($buffer);
     }
 
     public function getErrorOutput(): array
     {
-        return $this->output['err'];
+        return $this->output[self::ERR];
     }
 
     public function getOutput(): array
     {
-        return $this->output['out'];
+        return $this->output[self::OUT];
     }
 }


### PR DESCRIPTION
This expands the anti-corruption layer in front of Symfony Process and strengthens `API\Process\Service\OutputCallbackInterface` by introducing `API\Process\Value\OutputTypeEnum` in place of `::OUT` and `::ERR` constants for type safety and regression protection.