### PR TITLE
Rename API\Path\Value\PathInterface::resolved() and ::resolvedRelativeTo() to ::absolute() and ::relative(), respectively

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,7 +17,7 @@ parameters:
         - tests/PHPUnit
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: 3b4e79e47411a0380918a4e6b28a16c9
+    preconditionSystemHash: 28b3482e0ec91cbdd68d150e5c486918
     translationSystemHash: ef73496b0fe8d024eba0831e405db0af
     gitattributesExportInclude:
         - composer.json

--- a/src/API/Path/Value/PathInterface.php
+++ b/src/API/Path/Value/PathInterface.php
@@ -15,12 +15,6 @@ namespace PhpTuf\ComposerStager\API\Path\Value;
  */
 interface PathInterface
 {
-    /** Determines whether the original path string as given is absolute, without resolving it. */
-    public function isAbsolute(): bool;
-
-    /** Gets the unresolved path string, exactly as given. */
-    public function raw(): string;
-
     /**
      * Gets the fully resolved, absolute path string without trailing slash.
      *
@@ -28,7 +22,13 @@ interface PathInterface
      * by `getcwd()` at runtime, e.g., "/var/www/example" given a path of
      * "example" and a working directory of "/var/www".
      */
-    public function resolved(): string;
+    public function absolute(): string;
+
+    /** Determines whether the original path string as given is absolute, without resolving it. */
+    public function isAbsolute(): bool;
+
+    /** Gets the unresolved path string, exactly as given. */
+    public function raw(): string;
 
     /**
      * Gets the fully resolved, absolute path string without trailing slash, relative to another given path.
@@ -40,5 +40,5 @@ interface PathInterface
      * "/var/one/two/three" relative to "/var/four/five/six" would return
      * "/var/one/two/three".
      */
-    public function resolvedRelativeTo(PathInterface $basePath): string;
+    public function relative(PathInterface $basePath): string;
 }

--- a/src/Internal/Core/Stager.php
+++ b/src/Internal/Core/Stager.php
@@ -89,7 +89,7 @@ final class Stager implements StagerInterface
         ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $command = array_merge(
-            ['--working-dir=' . $stagingDir->resolved()],
+            ['--working-dir=' . $stagingDir->absolute()],
             $composerCommand,
         );
 

--- a/src/Internal/FileSyncer/Service/PhpFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/PhpFileSyncer.php
@@ -54,11 +54,11 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
     /** @throws \PhpTuf\ComposerStager\API\Exception\LogicException */
     private function assertSourceAndDestinationAreDifferent(PathInterface $source, PathInterface $destination): void
     {
-        if ($source->resolved() === $destination->resolved()) {
+        if ($source->absolute() === $destination->absolute()) {
             throw new LogicException(
                 $this->t(
                     'The source and destination directories cannot be the same at %path',
-                    $this->p(['%path' => $source->resolved()]),
+                    $this->p(['%path' => $source->absolute()]),
                     $this->d()->exceptions(),
                 ),
             );
@@ -71,7 +71,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
         if (!$this->filesystem->exists($source)) {
             throw new LogicException($this->t(
                 'The source directory does not exist at %path',
-                $this->p(['%path' => $source->resolved()]),
+                $this->p(['%path' => $source->absolute()]),
                 $this->d()->exceptions(),
             ));
         }
@@ -97,12 +97,12 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
 
         $destinationFiles = $this->fileFinder->find($destination, $exclusions);
 
-        $sourceResolved = $source->resolved();
-        $destinationResolved = $destination->resolved();
+        $sourceAbsolute = $source->absolute();
+        $destinationAbsolute = $destination->absolute();
 
         foreach ($destinationFiles as $destinationFilePathname) {
-            $relativePathname = self::getRelativePath($destinationResolved, $destinationFilePathname);
-            $sourceFilePathname = $sourceResolved . DIRECTORY_SEPARATOR . $relativePathname;
+            $relativePathname = self::getRelativePath($destinationAbsolute, $destinationFilePathname);
+            $sourceFilePathname = $sourceAbsolute . DIRECTORY_SEPARATOR . $relativePathname;
 
             $sourceFilePath = $this->pathFactory::create($sourceFilePathname);
 
@@ -128,15 +128,15 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
     ): void {
         $sourceFiles = $this->fileFinder->find($source, $exclusions);
 
-        $sourceResolved = $source->resolved();
-        $destinationResolved = $destination->resolved();
+        $sourceAbsolute = $source->absolute();
+        $destinationAbsolute = $destination->absolute();
 
         foreach ($sourceFiles as $sourceFilePathname) {
             // Once support for Symfony 4 is dropped, see if any of this logic can be
             // eliminated in favor of the new path manipulation utilities in Symfony 5.4:
             // https://symfony.com/doc/5.4/components/filesystem.html#path-manipulation-utilities
-            $relativePathname = self::getRelativePath($sourceResolved, $sourceFilePathname);
-            $destinationFilePathname = $destinationResolved . DIRECTORY_SEPARATOR . $relativePathname;
+            $relativePathname = self::getRelativePath($sourceAbsolute, $sourceFilePathname);
+            $destinationFilePathname = $destinationAbsolute . DIRECTORY_SEPARATOR . $relativePathname;
 
             $sourceFilePathname = $this->pathFactory::create($sourceFilePathname);
             $destinationFilePathname = $this->pathFactory::create($destinationFilePathname);

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -47,31 +47,31 @@ final class Filesystem implements FilesystemInterface
 
     public function copy(PathInterface $source, PathInterface $destination): void
     {
-        $sourceResolved = $source->resolved();
-        $destinationResolved = $destination->resolved();
+        $sourceAbsolute = $source->absolute();
+        $destinationAbsolute = $destination->absolute();
 
-        if ($sourceResolved === $destinationResolved) {
+        if ($sourceAbsolute === $destinationAbsolute) {
             throw new LogicException($this->t(
                 'The source and destination files cannot be the same at %path',
-                $this->p(['%path' => $sourceResolved]),
+                $this->p(['%path' => $sourceAbsolute]),
                 $this->d()->exceptions(),
             ));
         }
 
         try {
-            $this->symfonyFilesystem->copy($sourceResolved, $destinationResolved, true);
+            $this->symfonyFilesystem->copy($sourceAbsolute, $destinationAbsolute, true);
         } catch (SymfonyFileNotFoundException $e) {
             throw new LogicException($this->t(
                 'The source file does not exist or is not a file at %path',
-                $this->p(['%path' => $sourceResolved]),
+                $this->p(['%path' => $sourceAbsolute]),
                 $this->d()->exceptions(),
             ), 0, $e);
         } catch (SymfonyIOException $e) {
             throw new IOException($this->t(
                 'Failed to copy %source to %destination: %details',
                 $this->p([
-                    '%source' => $sourceResolved,
-                    '%destination' => $destinationResolved,
+                    '%source' => $sourceAbsolute,
+                    '%destination' => $destinationAbsolute,
                     '%details' => $e->getMessage(),
                 ]),
                 $this->d()->exceptions(),
@@ -92,7 +92,7 @@ final class Filesystem implements FilesystemInterface
     /** @SuppressWarnings(PHPMD.ErrorControlOperator) */
     public function isDirEmpty(PathInterface $path): bool
     {
-        $scandir = @scandir($path->resolved());
+        $scandir = @scandir($path->absolute());
 
         if ($scandir === false) {
             // @todo This doesn't seem to fail without the exceptions domain.
@@ -100,7 +100,7 @@ final class Filesystem implements FilesystemInterface
             /** @noinspection PhpUnhandledExceptionInspection */
             throw new IOException($this->t(
                 'The path does not exist or is not a directory at %path',
-                $this->p(['%path' => $path->resolved()]),
+                $this->p(['%path' => $path->absolute()]),
                 $this->d()->exceptions(),
             ));
         }
@@ -133,19 +133,19 @@ final class Filesystem implements FilesystemInterface
 
     public function isWritable(PathInterface $path): bool
     {
-        return is_writable($path->resolved()); // @codeCoverageIgnore
+        return is_writable($path->absolute()); // @codeCoverageIgnore
     }
 
     public function mkdir(PathInterface $path): void
     {
-        $pathResolved = $path->resolved();
+        $pathAbsolute = $path->absolute();
 
         try {
-            $this->symfonyFilesystem->mkdir($pathResolved);
+            $this->symfonyFilesystem->mkdir($pathAbsolute);
         } catch (SymfonyIOException $e) {
             throw new IOException($this->t(
                 'Failed to create directory at %path',
-                $this->p(['%path' => $pathResolved]),
+                $this->p(['%path' => $pathAbsolute]),
                 $this->d()->exceptions(),
             ), 0, $e);
         }
@@ -157,12 +157,12 @@ final class Filesystem implements FilesystemInterface
             // @todo This doesn't seem to fail without the exceptions domain.
             throw new IOException($this->t(
                 'The path does not exist or is not a symlink at %path',
-                $this->p(['%path' => $path->resolved()]),
+                $this->p(['%path' => $path->absolute()]),
                 $this->d()->exceptions(),
             ));
         }
 
-        $target = readlink($path->resolved());
+        $target = readlink($path->absolute());
         assert(is_string($target));
 
         // Resolve the target relative to the link's parent directory, not the CWD of the PHP process at runtime.
@@ -181,7 +181,7 @@ final class Filesystem implements FilesystemInterface
             // timeout, so we have to enforce it ourselves.
             set_time_limit((int) $timeout);
 
-            $this->symfonyFilesystem->remove($path->resolved());
+            $this->symfonyFilesystem->remove($path->absolute());
         } catch (SymfonyExceptionInterface $e) {
             throw new IOException($this->t(
                 $e->getMessage(),
@@ -198,7 +198,7 @@ final class Filesystem implements FilesystemInterface
         // and `is_link()`, etc., not to mention being the only way to detect hard links at all.
         // Error reporting is suppressed because using `lstat()` on a non-link emits E_WARNING,
         // which may or may not throw an exception depending on error_reporting configuration.
-        $lstat = @lstat($path->resolved());
+        $lstat = @lstat($path->absolute());
 
         if ($lstat === false) {
             return self::PATH_DOES_NOT_EXIST;

--- a/src/Internal/Finder/Service/FileFinder.php
+++ b/src/Internal/Finder/Service/FileFinder.php
@@ -36,11 +36,11 @@ final class FileFinder implements FileFinderInterface
     {
         $exclusions ??= new PathList();
 
-        $directoryIterator = $this->getRecursiveDirectoryIterator($directory->resolved());
+        $directoryIterator = $this->getRecursiveDirectoryIterator($directory->absolute());
 
         // Resolve the exclusions relative to the search directory.
         $exclusions = array_map(fn ($path): string => $this->pathFactory::create($path)
-            ->resolvedRelativeTo($directory), $exclusions->getAll());
+            ->relative($directory), $exclusions->getAll());
 
         // Apply exclusions. On the surface, it may look like individual descendants
         // of an excluded directory, i.e., files "underneath" or "inside" it, won't

--- a/src/Internal/Path/Value/AbstractPath.php
+++ b/src/Internal/Path/Value/AbstractPath.php
@@ -13,7 +13,7 @@ abstract class AbstractPath implements PathInterface
 {
     protected string $basePath;
 
-    abstract protected function doResolve(string $basePath): string;
+    abstract protected function doAbsolute(string $basePath): string;
 
     /**
      * @param string $path
@@ -32,8 +32,13 @@ abstract class AbstractPath implements PathInterface
         // object should be immune to environmental details like the current
         // working directory. Cache the CWD at time of creation.
         $this->basePath = $basePath instanceof PathInterface
-            ? $basePath->resolved()
+            ? $basePath->absolute()
             : $this->getcwd();
+    }
+
+    public function absolute(): string
+    {
+        return $this->doAbsolute($this->basePath);
     }
 
     public function raw(): string
@@ -41,16 +46,11 @@ abstract class AbstractPath implements PathInterface
         return $this->path;
     }
 
-    public function resolved(): string
+    public function relative(PathInterface $basePath): string
     {
-        return $this->doResolve($this->basePath);
-    }
+        $basePathAbsolute = $basePath->absolute();
 
-    public function resolvedRelativeTo(PathInterface $basePath): string
-    {
-        $resolvedBasePath = $basePath->resolved();
-
-        return $this->doResolve($resolvedBasePath);
+        return $this->doAbsolute($basePathAbsolute);
     }
 
     // Once support for Symfony 4 is dropped, some of this logic could possibly be

--- a/src/Internal/Path/Value/UnixLikePath.php
+++ b/src/Internal/Path/Value/UnixLikePath.php
@@ -21,7 +21,7 @@ final class UnixLikePath extends AbstractPath
         return str_starts_with($this->path, DIRECTORY_SEPARATOR);
     }
 
-    protected function doResolve(string $basePath): string
+    protected function doAbsolute(string $basePath): string
     {
         $absolute = $this->makeAbsolute($basePath);
 

--- a/src/Internal/Path/Value/WindowsPath.php
+++ b/src/Internal/Path/Value/WindowsPath.php
@@ -33,7 +33,7 @@ final class WindowsPath extends AbstractPath
      *
      * @see https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
      */
-    protected function doResolve(string $basePath): string
+    protected function doAbsolute(string $basePath): string
     {
         $path = $this->path;
 

--- a/src/Internal/Precondition/Service/AbstractFileIteratingPrecondition.php
+++ b/src/Internal/Precondition/Service/AbstractFileIteratingPrecondition.php
@@ -52,7 +52,7 @@ abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
     ): void {
         try {
             $exclusions ??= new PathList();
-            $exclusions->add($stagingDir->resolved());
+            $exclusions->add($stagingDir->absolute());
 
             if ($this->exitEarly($activeDir, $stagingDir, $exclusions)) {
                 return;

--- a/src/Internal/Precondition/Service/ActiveAndStagingDirsAreDifferent.php
+++ b/src/Internal/Precondition/Service/ActiveAndStagingDirsAreDifferent.php
@@ -31,7 +31,7 @@ final class ActiveAndStagingDirsAreDifferent extends AbstractPrecondition implem
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
     ): void {
-        if ($activeDir->resolved() === $stagingDir->resolved()) {
+        if ($activeDir->absolute() === $stagingDir->absolute()) {
             throw new PreconditionException($this, $this->t(
                 'The active and staging directories are the same.',
                 null,

--- a/src/Internal/Precondition/Service/NoAbsoluteSymlinksExist.php
+++ b/src/Internal/Precondition/Service/NoAbsoluteSymlinksExist.php
@@ -49,8 +49,8 @@ final class NoAbsoluteSymlinksExist extends AbstractFileIteratingPrecondition im
                     . 'which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
-                        '%codebase_root' => $codebaseRoot->resolved(),
-                        '%file' => $file->resolved(),
+                        '%codebase_root' => $codebaseRoot->absolute(),
+                        '%file' => $file->absolute(),
                     ]),
                 ),
             );

--- a/src/Internal/Precondition/Service/NoHardLinksExist.php
+++ b/src/Internal/Precondition/Service/NoHardLinksExist.php
@@ -42,8 +42,8 @@ final class NoHardLinksExist extends AbstractFileIteratingPrecondition implement
                     . 'hard links, which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
-                        '%codebase_root' => $codebaseRoot->resolved(),
-                        '%file' => $file->resolved(),
+                        '%codebase_root' => $codebaseRoot->absolute(),
+                        '%file' => $file->absolute(),
                     ]),
                     $this->d()->exceptions(),
                 ),

--- a/src/Internal/Precondition/Service/NoLinksExistOnWindows.php
+++ b/src/Internal/Precondition/Service/NoLinksExistOnWindows.php
@@ -71,8 +71,8 @@ final class NoLinksExistOnWindows extends AbstractFileIteratingPrecondition impl
                     . 'which is not supported on Windows. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
-                        '%codebase_root' => $codebaseRoot->resolved(),
-                        '%file' => $file->resolved(),
+                        '%codebase_root' => $codebaseRoot->absolute(),
+                        '%file' => $file->absolute(),
                     ]),
                     $this->d()->exceptions(),
                 ),

--- a/src/Internal/Precondition/Service/NoSymlinksPointOutsideTheCodebase.php
+++ b/src/Internal/Precondition/Service/NoSymlinksPointOutsideTheCodebase.php
@@ -47,8 +47,8 @@ final class NoSymlinksPointOutsideTheCodebase extends AbstractFileIteratingPreco
                     . 'which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
-                        '%codebase_root' => $codebaseRoot->resolved(),
-                        '%file' => $file->resolved(),
+                        '%codebase_root' => $codebaseRoot->absolute(),
+                        '%file' => $file->absolute(),
                     ]),
                     $this->d()->exceptions(),
                 ),
@@ -61,7 +61,7 @@ final class NoSymlinksPointOutsideTheCodebase extends AbstractFileIteratingPreco
     {
         $target = $this->filesystem->readLink($link);
 
-        return !$this->isDescendant($target->resolved(), $path->resolved());
+        return !$this->isDescendant($target->absolute(), $path->absolute());
     }
 
     private function isDescendant(string $descendant, string $ancestor): bool

--- a/src/Internal/Precondition/Service/NoSymlinksPointToADirectory.php
+++ b/src/Internal/Precondition/Service/NoSymlinksPointToADirectory.php
@@ -77,8 +77,8 @@ final class NoSymlinksPointToADirectory extends AbstractFileIteratingPreconditio
                     . 'which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
-                        '%codebase_root' => $codebaseRoot->resolved(),
-                        '%file' => $file->resolved(),
+                        '%codebase_root' => $codebaseRoot->absolute(),
+                        '%file' => $file->absolute(),
                     ]),
                     $this->d()->exceptions(),
                 ),

--- a/tests/PHPUnit/EndToEnd/EndToEndFunctionalTestCase.php
+++ b/tests/PHPUnit/EndToEnd/EndToEndFunctionalTestCase.php
@@ -108,7 +108,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
         ]);
 
         $arbitrarySymlinkTarget = 'file_in_active_dir_root_NEVER_CHANGED_anywhere.txt';
-        self::createSymlinks($activeDirPath->resolved(), [
+        self::createSymlinks($activeDirPath->absolute(), [
             'EXCLUDED_symlink_in_active_dir_root.txt' => $arbitrarySymlinkTarget,
             'EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt' => $arbitrarySymlinkTarget,
         ]);
@@ -139,7 +139,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             // Non-existent (ignore).
             'file_that_NEVER_EXISTS_anywhere.txt',
             // Absolute path (ignore).
-            PathFactory::create('absolute/path')->resolved(),
+            PathFactory::create('absolute/path')->absolute(),
         ];
         $exclusions = new PathList(...$exclusions);
 
@@ -154,7 +154,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             $preconditionMet = false;
             self::assertEquals(NoAbsoluteSymlinksExist::class, $failedPrecondition::class, 'Correct "codebase contains symlinks" unmet.');
         } finally {
-            assert(filetype($activeDirPath->resolved() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
+            assert(filetype($activeDirPath->absolute() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
             self::assertFalse($preconditionMet, 'Beginner fails with symlinks present in the codebase.');
         }
 
@@ -174,7 +174,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             'not/an/EXCLUDED_dir/file.txt',
             'not/the/arbitrary_subdir/with/an/EXCLUDED_file.txt',
         ];
-        self::assertDirectoryListing($stagingDirPath->resolved(), $expectedStagingDirListing, '', sprintf('Synced correct files from active directory to new staging directory:%s- From: %s%s- To:   %s', PHP_EOL, $activeDir, PHP_EOL, $stagingDir));
+        self::assertDirectoryListing($stagingDirPath->absolute(), $expectedStagingDirListing, '', sprintf('Synced correct files from active directory to new staging directory:%s- From: %s%s- To:   %s', PHP_EOL, $activeDir, PHP_EOL, $stagingDir));
 
         // Stage: Execute a Composer command (that doesn't make any HTTP requests).
         $newComposerName = 'new/name';
@@ -201,12 +201,12 @@ abstract class EndToEndFunctionalTestCase extends TestCase
         self::createFile($stagingDir, 'another_subdir/CREATE_in_staging_dir.txt');
 
         // Create symlink.
-        self::createSymlink($stagingDirPath->resolved(), 'EXCLUDED_dir/symlink_CREATED_in_staging_dir.txt', $arbitrarySymlinkTarget);
+        self::createSymlink($stagingDirPath->absolute(), 'EXCLUDED_dir/symlink_CREATED_in_staging_dir.txt', $arbitrarySymlinkTarget);
 
         // Sanity check to ensure that the expected changes were made.
         $deletion = array_search('DELETE_from_staging_dir_before_syncing_back_to_active_dir.txt', $expectedStagingDirListing, true);
         unset($expectedStagingDirListing[$deletion]);
-        self::assertDirectoryListing($stagingDirPath->resolved(), [
+        self::assertDirectoryListing($stagingDirPath->absolute(), [
             ...$expectedStagingDirListing,
             // Additions.
             'CREATE_in_staging_dir.txt',
@@ -227,14 +227,14 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             $preconditionMet = false;
             self::assertEquals(NoAbsoluteSymlinksExist::class, $failedPrecondition::class, 'Correct "codebase contains symlinks" unmet.');
         } finally {
-            assert(filetype($activeDirPath->resolved() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
+            assert(filetype($activeDirPath->absolute() . '/EXCLUDED_dir/symlink_NEVER_CHANGED_anywhere.txt') === 'link', 'An actual symlink is present in the codebase.');
             self::assertFalse($preconditionMet, 'Beginner fails with symlinks present in the codebase.');
         }
 
         // Commit: Sync files from the staging directory back to the directory.
         $this->committer->commit($stagingDirPath, $activeDirPath, $exclusions);
 
-        self::assertDirectoryListing($activeDirPath->resolved(), [
+        self::assertDirectoryListing($activeDirPath->absolute(), [
             'composer.json',
             // Unchanged files are left alone.
             'file_in_active_dir_root_NEVER_CHANGED_anywhere.txt',
@@ -271,7 +271,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
             // Files included despite including excluded paths at the wrong depth.
             'not/an/EXCLUDED_dir/file.txt',
             'not/the/arbitrary_subdir/with/an/EXCLUDED_file.txt',
-        ], $stagingDirPath->resolved(), sprintf('Synced correct files from staging directory back to active directory:%s%s ->%s%s"', PHP_EOL, $stagingDir, PHP_EOL, $activeDir));
+        ], $stagingDirPath->absolute(), sprintf('Synced correct files from staging directory back to active directory:%s%s ->%s%s"', PHP_EOL, $stagingDir, PHP_EOL, $activeDir));
 
         // Unchanged file contents.
         self::assertFileNotChanged($activeDir, 'file_in_active_dir_root_NEVER_CHANGED_anywhere.txt');
@@ -304,7 +304,7 @@ abstract class EndToEndFunctionalTestCase extends TestCase
         // Clean: Remove the staging directory.
         $this->cleaner->clean($activeDirPath, $stagingDirPath);
 
-        self::assertFileDoesNotExist($stagingDirPath->resolved(), 'Staging directory was completely removed.');
+        self::assertFileDoesNotExist($stagingDirPath->absolute(), 'Staging directory was completely removed.');
     }
 
     public function providerDirectories(): array

--- a/tests/PHPUnit/FileSyncer/Service/FileSyncerFunctionalTestCase.php
+++ b/tests/PHPUnit/FileSyncer/Service/FileSyncerFunctionalTestCase.php
@@ -22,8 +22,8 @@ abstract class FileSyncerFunctionalTestCase extends TestCase
         $this->destination = PathFactory::create(self::DESTINATION_DIR);
 
         FilesystemHelper::createDirectories([
-            $this->source->resolved(),
-            $this->destination->resolved(),
+            $this->source->absolute(),
+            $this->destination->absolute(),
         ]);
     }
 
@@ -78,15 +78,15 @@ abstract class FileSyncerFunctionalTestCase extends TestCase
     {
         $link = PathFactory::create('link', $this->source);
         $target = PathFactory::create('directory', $this->source);
-        FilesystemHelper::createDirectories($target->resolved());
-        $file = PathFactory::create('directory/file.txt', $this->source)->resolved();
+        FilesystemHelper::createDirectories($target->absolute());
+        $file = PathFactory::create('directory/file.txt', $this->source)->absolute();
         touch($file);
-        symlink($target->resolved(), $link->resolved());
+        symlink($target->absolute(), $link->absolute());
         $sut = $this->createSut();
 
         $sut->sync($this->source, $this->destination);
 
-        self::assertDirectoryListing($this->destination->resolved(), [
+        self::assertDirectoryListing($this->destination->absolute(), [
             'link',
             'directory/file.txt',
         ], '', 'Correctly synced files, including a symlink to a directory.');

--- a/tests/PHPUnit/FileSyncer/Service/PhpFileSyncerUnitTest.php
+++ b/tests/PHPUnit/FileSyncer/Service/PhpFileSyncerUnitTest.php
@@ -67,7 +67,7 @@ final class PhpFileSyncerUnitTest extends TestCase
             ->willReturn(false);
         $sut = $this->createSut();
 
-        $message = sprintf('The source directory does not exist at %s', $this->source->resolved());
+        $message = sprintf('The source directory does not exist at %s', $this->source->absolute());
         self::assertTranslatableException(function () use ($sut): void {
             $sut->sync($this->source, $this->destination);
         }, LogicException::class, $message);
@@ -78,7 +78,7 @@ final class PhpFileSyncerUnitTest extends TestCase
         $same = new TestPath('same');
         $sut = $this->createSut();
 
-        $message = sprintf('The source and destination directories cannot be the same at %s', $same->resolved());
+        $message = sprintf('The source and destination directories cannot be the same at %s', $same->absolute());
         self::assertTranslatableException(static function () use ($sut, $same): void {
             $sut->sync($same, $same);
         }, LogicException::class, $message);

--- a/tests/PHPUnit/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/PHPUnit/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -214,7 +214,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
             ->willReturn(false);
         $sut = $this->createSut();
 
-        $message = sprintf('The source directory does not exist at %s', $this->source->resolved());
+        $message = sprintf('The source directory does not exist at %s', $this->source->absolute());
         self::assertTranslatableException(function () use ($sut): void {
             $sut->sync($this->source, $this->destination);
         }, LogicException::class, $message);
@@ -227,7 +227,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
         $destination = $source;
         $sut = $this->createSut();
 
-        $message = sprintf('The source and destination directories cannot be the same at %s', $source->resolved());
+        $message = sprintf('The source and destination directories cannot be the same at %s', $source->absolute());
         self::assertTranslatableException(static function () use ($sut, $source, $destination): void {
             $sut->sync($source, $destination);
         }, LogicException::class, $message);

--- a/tests/PHPUnit/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/PHPUnit/Filesystem/Service/FilesystemUnitTest.php
@@ -54,7 +54,7 @@ final class FilesystemUnitTest extends TestCase
         $source = new TestPath($source);
         $destination = new TestPath($destination);
         $this->symfonyFilesystem
-            ->copy($source->resolved(), $destination->resolved(), true)
+            ->copy($source->absolute(), $destination->absolute(), true)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -102,7 +102,7 @@ final class FilesystemUnitTest extends TestCase
             ->willThrow($previous);
         $sut = $this->createSut();
 
-        $message = sprintf('The source file does not exist or is not a file at %s', $this->activeDir->resolved());
+        $message = sprintf('The source file does not exist or is not a file at %s', $this->activeDir->absolute());
         self::assertTranslatableException(function () use ($sut): void {
             $sut->copy($this->activeDir, $this->stagingDir);
         }, LogicException::class, $message, $previous);
@@ -115,7 +115,7 @@ final class FilesystemUnitTest extends TestCase
         $destination = $source;
         $sut = $this->createSut();
 
-        $message = sprintf('The source and destination files cannot be the same at %s', $source->resolved());
+        $message = sprintf('The source and destination files cannot be the same at %s', $source->absolute());
         self::assertTranslatableException(static function () use ($sut, $source, $destination): void {
             $sut->copy($source, $destination);
         }, LogicException::class, $message);

--- a/tests/PHPUnit/Finder/Service/FileFinderFunctionalTest.php
+++ b/tests/PHPUnit/Finder/Service/FileFinderFunctionalTest.php
@@ -44,7 +44,7 @@ final class FileFinderFunctionalTest extends TestCase
     public function testFind(array $files, ?PathListInterface $exclusions, array $expected): void
     {
         $directory = self::activeDirPath();
-        self::createFiles($directory->resolved(), $files);
+        self::createFiles($directory->absolute(), $files);
         $sut = $this->createSut();
 
         $actual = $sut->find($directory, $exclusions);
@@ -163,7 +163,7 @@ final class FileFinderFunctionalTest extends TestCase
                 ],
             );
 
-            return PathFactory::create($path)->resolved();
+            return PathFactory::create($path)->absolute();
         }, $paths);
 
         sort($paths);

--- a/tests/PHPUnit/Path/Value/TestPath.php
+++ b/tests/PHPUnit/Path/Value/TestPath.php
@@ -10,6 +10,11 @@ final class TestPath implements PathInterface
     {
     }
 
+    public function absolute(): string
+    {
+        return $this->path;
+    }
+
     public function isAbsolute(): bool
     {
         return true;
@@ -20,12 +25,7 @@ final class TestPath implements PathInterface
         return $this->path;
     }
 
-    public function resolved(): string
-    {
-        return $this->path;
-    }
-
-    public function resolvedRelativeTo(PathInterface $basePath): string
+    public function relative(PathInterface $basePath): string
     {
         return $this->path;
     }

--- a/tests/PHPUnit/Precondition/Service/LinkPreconditionsIsolationFunctionalTest.php
+++ b/tests/PHPUnit/Precondition/Service/LinkPreconditionsIsolationFunctionalTest.php
@@ -95,8 +95,8 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     /** @group no_windows */
     public function testNoAbsoluteSymlinksExist(): void
     {
-        $source = self::path('source.txt')->resolved();
-        $target = self::path('target.txt')->resolved();
+        $source = self::path('source.txt')->absolute();
+        $target = self::path('target.txt')->absolute();
         touch($target);
         symlink($target, $source);
 
@@ -106,8 +106,8 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     /** @group windows_only */
     public function testNoLinksExistOnWindows(): void
     {
-        $source = self::path('source.txt')->resolved();
-        $target = self::path('target.txt')->resolved();
+        $source = self::path('source.txt')->absolute();
+        $target = self::path('target.txt')->absolute();
         touch($target);
         symlink($target, $source);
 
@@ -124,7 +124,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     /** @group no_windows */
     public function testNoSymlinksPointOutsideTheCodebase(): void
     {
-        $source = self::path('source.txt')->resolved();
+        $source = self::path('source.txt')->absolute();
         $target = self::path('../target.txt')->raw();
         touch($target);
         symlink($target, $source);
@@ -135,7 +135,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     /** @group no_windows */
     public function testNoSymlinksPointToADirectory(): void
     {
-        $source = self::path('link')->resolved();
+        $source = self::path('link')->absolute();
         $target = self::path('directory')->raw();
         FilesystemHelper::createDirectories($target);
         symlink($target, $source);
@@ -146,8 +146,8 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
     /** @group no_windows */
     public function testNoHardLinksExistExist(): void
     {
-        $source = self::path('source.txt')->resolved();
-        $target = self::path('target.txt')->resolved();
+        $source = self::path('source.txt')->absolute();
+        $target = self::path('target.txt')->absolute();
         touch($target);
         link($target, $source);
 

--- a/tests/PHPUnit/Precondition/Service/NoAbsoluteSymlinksExistFunctionalTest.php
+++ b/tests/PHPUnit/Precondition/Service/NoAbsoluteSymlinksExistFunctionalTest.php
@@ -78,11 +78,11 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
     {
         $link = PathFactory::create($link, $dirPath);
         $target = PathFactory::create('target.txt', $dirPath);
-        $parentDir = dirname($link->resolved());
+        $parentDir = dirname($link->absolute());
         @mkdir($parentDir, 0777, true);
-        touch($target->resolved());
+        touch($target->absolute());
         // Point at the resolved target, i.e., its absolute path.
-        symlink($target->resolved(), $link->resolved());
+        symlink($target->absolute(), $link->absolute());
         $sut = $this->createSut();
 
         $isFulfilled = $sut->isFulfilled(self::activeDirPath(), self::stagingDirPath());
@@ -92,8 +92,8 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         $pattern = sprintf(
             'The %s directory at %s contains absolute links, which is not supported. The first one is %s.',
             $dirName,
-            $dirPath->resolved(),
-            $link->resolved(),
+            $dirPath->absolute(),
+            $link->absolute(),
         );
         self::assertTranslatableMessage($pattern, $statusMessage, 'Returned correct status message.');
     }
@@ -109,12 +109,12 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
     {
         $link = PathFactory::create($link, $dirPath);
         $target = PathFactory::create('target.txt', $dirPath);
-        $parentDir = dirname($link->resolved());
+        $parentDir = dirname($link->absolute());
         @mkdir($parentDir, 0777, true);
-        touch($target->resolved());
+        touch($target->absolute());
         chdir($parentDir);
         // Point at the raw target, i.e., its relative path.
-        symlink($target->raw(), $link->resolved());
+        symlink($target->raw(), $link->absolute());
         $sut = $this->createSut();
 
         $isFulfilled = $sut->isFulfilled(self::activeDirPath(), self::stagingDirPath());
@@ -175,8 +175,8 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
      */
     public function testWithHardLink(): void
     {
-        $link = PathFactory::create('link.txt', self::activeDirPath())->resolved();
-        $target = PathFactory::create('target.txt', self::activeDirPath())->resolved();
+        $link = PathFactory::create('link.txt', self::activeDirPath())->absolute();
+        $target = PathFactory::create('target.txt', self::activeDirPath())->absolute();
         $parentDir = dirname($link);
         @mkdir($parentDir, 0777, true);
         touch($target);
@@ -199,7 +199,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         $targetFile = 'target.txt';
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList(...$exclusions);
-        $dirPath = self::activeDirPath()->resolved();
+        $dirPath = self::activeDirPath()->absolute();
         self::createFile($dirPath, $targetFile);
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();

--- a/tests/PHPUnit/Precondition/Service/NoHardLinksExistFunctionalTest.php
+++ b/tests/PHPUnit/Precondition/Service/NoHardLinksExistFunctionalTest.php
@@ -44,8 +44,8 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
      */
     public function testFulfilledWithSymlink(): void
     {
-        $target = PathFactory::create('target.txt', $this->activeDir)->resolved();
-        $link = PathFactory::create('link.txt', $this->activeDir)->resolved();
+        $target = PathFactory::create('target.txt', $this->activeDir)->absolute();
+        $link = PathFactory::create('link.txt', $this->activeDir)->absolute();
         touch($target);
         symlink($target, $link);
         $sut = $this->createSut();
@@ -63,8 +63,8 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
      */
     public function testUnfulfilled(string $directory, string $dirName): void
     {
-        $target = PathFactory::create($directory . '/target.txt')->resolved();
-        $link = PathFactory::create($directory . '/link.txt')->resolved();
+        $target = PathFactory::create($directory . '/target.txt')->absolute();
+        $link = PathFactory::create($directory . '/link.txt')->absolute();
         touch($target);
         link($target, $link);
         $sut = $this->createSut();
@@ -72,7 +72,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         $message = sprintf(
             'The %s directory at %s contains hard links, which is not supported. The first one is %s.',
             $dirName,
-            PathFactory::create($directory)->resolved(),
+            PathFactory::create($directory)->absolute(),
             $link,
         );
         self::assertTranslatableException(function () use ($sut): void {
@@ -120,7 +120,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
 
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList(...$exclusions);
-        $dirPath = $this->activeDir->resolved();
+        $dirPath = $this->activeDir->absolute();
         self::createFile($dirPath, $targetFile);
         self::createHardlinks($dirPath, $links);
         $sut = $this->createSut();

--- a/tests/PHPUnit/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
+++ b/tests/PHPUnit/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
@@ -52,11 +52,11 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
     public function testUnfulfilled(array $symlinks, array $hardLinks): void
     {
         $basePath = self::activeDirPath();
-        $link = PathFactory::create('link.txt', $basePath)->resolved();
-        $target = PathFactory::create('target.txt', $basePath)->resolved();
+        $link = PathFactory::create('link.txt', $basePath)->absolute();
+        $target = PathFactory::create('target.txt', $basePath)->absolute();
         touch($target);
-        self::createSymlinks($basePath->resolved(), $symlinks);
-        self::createHardlinks($basePath->resolved(), $hardLinks);
+        self::createSymlinks($basePath->absolute(), $symlinks);
+        self::createHardlinks($basePath->absolute(), $hardLinks);
         $sut = $this->createSut();
 
         $isFulfilled = $sut->isFulfilled($this->activeDir, $this->stagingDir);
@@ -64,7 +64,7 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
 
         $message = sprintf(
             'The active directory at %s contains links, which is not supported on Windows. The first one is %s.',
-            $basePath->resolved(),
+            $basePath->absolute(),
             $link,
         );
         self::assertTranslatableException(function () use ($sut): void {
@@ -111,7 +111,7 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
         $targetFile = 'target.txt';
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList(...$exclusions);
-        $dirPath = $this->activeDir->resolved();
+        $dirPath = $this->activeDir->absolute();
         self::createFile($dirPath, $targetFile);
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();

--- a/tests/PHPUnit/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
+++ b/tests/PHPUnit/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
@@ -36,9 +36,9 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
      */
     public function testFulfilledWithValidLink(string $link, string $target): void
     {
-        $link = PathFactory::create($link, $this->activeDir)->resolved();
+        $link = PathFactory::create($link, $this->activeDir)->absolute();
         self::ensureParentDirectory($link);
-        $target = PathFactory::create($target, $this->activeDir)->resolved();
+        $target = PathFactory::create($target, $this->activeDir)->absolute();
         self::ensureParentDirectory($target);
         touch($target);
         symlink($target, $link);
@@ -89,8 +89,8 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
      */
     public function testUnfulfilled(string $targetDir, string $linkDir, string $linkDirName): void
     {
-        $target = PathFactory::create($targetDir . '/target.txt')->resolved();
-        $link = PathFactory::create($linkDir . '/link.txt')->resolved();
+        $target = PathFactory::create($targetDir . '/target.txt')->absolute();
+        $link = PathFactory::create($linkDir . '/link.txt')->absolute();
         touch($target);
         symlink($target, $link);
         $sut = $this->createSut();
@@ -98,7 +98,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         $message = sprintf(
             'The %s directory at %s contains links that point outside the codebase, which is not supported. The first one is %s.',
             $linkDirName,
-            PathFactory::create($linkDir)->resolved(),
+            PathFactory::create($linkDir)->absolute(),
             $link,
         );
         self::assertTranslatableException(function () use ($sut): void {
@@ -139,8 +139,8 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
     public function testWithHardLink(): void
     {
         $dirPath = self::activeDirPath();
-        $link = PathFactory::create('link.txt', $dirPath)->resolved();
-        $target = PathFactory::create('target.txt', $dirPath)->resolved();
+        $link = PathFactory::create('link.txt', $dirPath)->absolute();
+        $target = PathFactory::create('target.txt', $dirPath)->absolute();
         $parentDir = dirname($link);
         @mkdir($parentDir, 0777, true);
         touch($target);
@@ -161,8 +161,8 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
     public function testWithAbsoluteLink(): void
     {
         $dirPath = self::activeDirPath();
-        $link = PathFactory::create('link.txt', $dirPath)->resolved();
-        $target = PathFactory::create('target.txt', $dirPath)->resolved();
+        $link = PathFactory::create('link.txt', $dirPath)->absolute();
+        $target = PathFactory::create('target.txt', $dirPath)->absolute();
         $parentDir = dirname($link);
         @mkdir($parentDir, 0777, true);
         touch($target);
@@ -188,7 +188,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         $targetFile = '../';
         $links = array_fill_keys($links, $targetFile);
         $exclusions = new PathList(...$exclusions);
-        $dirPath = $this->activeDir->resolved();
+        $dirPath = $this->activeDir->absolute();
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();
 

--- a/tests/PHPUnit/Precondition/Service/NoSymlinksPointToADirectoryFunctionalTest.php
+++ b/tests/PHPUnit/Precondition/Service/NoSymlinksPointToADirectoryFunctionalTest.php
@@ -43,9 +43,9 @@ final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsF
      */
     public function testFulfilledWithValidLink(): void
     {
-        $link = PathFactory::create('link.txt', $this->activeDir)->resolved();
+        $link = PathFactory::create('link.txt', $this->activeDir)->absolute();
         self::ensureParentDirectory($link);
-        $target = PathFactory::create('target.txt', $this->activeDir)->resolved();
+        $target = PathFactory::create('target.txt', $this->activeDir)->absolute();
         self::ensureParentDirectory($target);
         touch($target);
         symlink($target, $link);
@@ -64,8 +64,8 @@ final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsF
      */
     public function testUnfulfilled(string $targetDir, string $linkDir, string $linkDirName): void
     {
-        $target = PathFactory::create($targetDir . '/target_directory')->resolved();
-        $link = PathFactory::create($linkDir . '/directory_link')->resolved();
+        $target = PathFactory::create($targetDir . '/target_directory')->absolute();
+        $link = PathFactory::create($linkDir . '/directory_link')->absolute();
         FilesystemHelper::createDirectories($target);
         symlink($target, $link);
         $sut = $this->createSut();
@@ -73,7 +73,7 @@ final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsF
         $message = sprintf(
             'The %s directory at %s contains symlinks that point to a directory, which is not supported. The first one is %s.',
             $linkDirName,
-            PathFactory::create($linkDir)->resolved(),
+            PathFactory::create($linkDir)->absolute(),
             $link,
         );
         self::assertTranslatableException(function () use ($sut): void {
@@ -106,10 +106,10 @@ final class NoSymlinksPointToADirectoryFunctionalTest extends LinkPreconditionsF
     public function testFulfilledExclusions(array $links, array $exclusions, bool $shouldBeFulfilled): void
     {
         $targetDir = './target_directory';
-        FilesystemHelper::createDirectories(PathFactory::create($targetDir, $this->activeDir)->resolved());
+        FilesystemHelper::createDirectories(PathFactory::create($targetDir, $this->activeDir)->absolute());
         $links = array_fill_keys($links, $targetDir);
         $exclusions = new PathList(...$exclusions);
-        $dirPath = $this->activeDir->resolved();
+        $dirPath = $this->activeDir->absolute();
         self::createSymlinks($dirPath, $links);
         $sut = $this->createSut();
 

--- a/tests/PHPUnit/TestCase.php
+++ b/tests/PHPUnit/TestCase.php
@@ -107,7 +107,7 @@ abstract class TestCase extends PHPUnitTestCase
 
     protected static function createFile(string $basePath, string $filename): void
     {
-        $filename = PathFactory::create("{$basePath}/{$filename}")->resolved();
+        $filename = PathFactory::create("{$basePath}/{$filename}")->absolute();
         static::ensureParentDirectory($filename);
 
         $touchResult = touch($filename);
@@ -146,7 +146,7 @@ abstract class TestCase extends PHPUnitTestCase
 
         self::prepareForLink($link, $target);
 
-        symlink($target->resolved(), $link->resolved());
+        symlink($target->absolute(), $link->absolute());
     }
 
     protected static function createHardlinks(string $basePath, array $symlinks): void
@@ -163,17 +163,17 @@ abstract class TestCase extends PHPUnitTestCase
 
         self::prepareForLink($link, $target);
 
-        link($target->resolved(), $link->resolved());
+        link($target->absolute(), $link->absolute());
     }
 
     private static function prepareForLink(PathInterface $link, PathInterface $target): void
     {
-        static::ensureParentDirectory($link->resolved());
+        static::ensureParentDirectory($link->absolute());
 
         // If the symlink target doesn't exist, the tests will pass on Unix-like
         // systems but fail on Windows. Avoid hard-to-debug problems by making
         // sure it fails everywhere in that case.
-        assert(file_exists($target->resolved()), 'Symlink target exists.');
+        assert(file_exists($target->absolute()), 'Symlink target exists.');
     }
 
     protected static function ensureParentDirectory(string $filename): void


### PR DESCRIPTION
This renames `\PhpTuf\ComposerStager\API\Path\Value\PathInterface::resolved()` to `::absolute()` and `\PhpTuf\ComposerStager\API\Path\Value\PathInterface::resolvedRelativeTo()` to `::relative()` to reflect the precedent set by the Symfony Filesystem component. More skimmably:

| From | To |
|---|---|
| `::resolved()` | `::absolute()` |
| `::resolvedRelativeTo()` | `::relative()` |