### PR TITLE
Make `$timeout` arguments non-nullable

### DIFF
--- a/src/API/Core/BeginnerInterface.php
+++ b/src/API/Core/BeginnerInterface.php
@@ -39,9 +39,9 @@ interface BeginnerInterface
      *   as when committing.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\PreconditionException
      *   If the preconditions are unfulfilled.
@@ -55,6 +55,6 @@ interface BeginnerInterface
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Core/CleanerInterface.php
+++ b/src/API/Core/CleanerInterface.php
@@ -24,9 +24,9 @@ interface CleanerInterface
      *   The staging directory.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\PreconditionException
      *   If the preconditions are unfulfilled.
@@ -37,6 +37,6 @@ interface CleanerInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Core/CommitterInterface.php
+++ b/src/API/Core/CommitterInterface.php
@@ -28,9 +28,9 @@ interface CommitterInterface
      *   you should use the same exclusions when committing as when beginning.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\PreconditionException
      *   If the preconditions are unfulfilled.
@@ -44,6 +44,6 @@ interface CommitterInterface
         PathInterface $activeDir,
         ?PathListInterface $exclusions = null,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Core/StagerInterface.php
+++ b/src/API/Core/StagerInterface.php
@@ -35,9 +35,9 @@ interface StagerInterface
      *   The staging directory.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\InvalidArgumentException
      *   If the given Composer command is invalid.
@@ -51,6 +51,6 @@ interface StagerInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/FileSyncer/Service/FileSyncerInterface.php
+++ b/src/API/FileSyncer/Service/FileSyncerInterface.php
@@ -35,9 +35,9 @@ interface FileSyncerInterface
      *   "underneath" or "inside" it.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\IOException
      *   If the destination directory cannot be created.
@@ -49,6 +49,6 @@ interface FileSyncerInterface
         PathInterface $destination,
         ?PathListInterface $exclusions = null,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -170,9 +170,9 @@ interface FilesystemInterface
      *   A path to remove.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\IOException
      *   If the file cannot be removed.
@@ -180,6 +180,6 @@ interface FilesystemInterface
     public function remove(
         PathInterface $path,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Process/Service/ComposerProcessRunnerInterface.php
+++ b/src/API/Process/Service/ComposerProcessRunnerInterface.php
@@ -26,9 +26,9 @@ interface ComposerProcessRunnerInterface
      *   ```
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\LogicException
      *   If the command process cannot be created due to host configuration.
@@ -40,6 +40,6 @@ interface ComposerProcessRunnerInterface
     public function run(
         array $command,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/API/Process/Service/ProcessInterface.php
+++ b/src/API/Process/Service/ProcessInterface.php
@@ -82,12 +82,12 @@ interface ProcessInterface
     /**
      * Sets the process timeout (max. runtime) in seconds.
      *
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\InvalidArgumentException
      *   If the given timeout is negative.
      */
-    public function setTimeout(?int $timeout = self::DEFAULT_TIMEOUT): self;
+    public function setTimeout(int $timeout = self::DEFAULT_TIMEOUT): self;
 }

--- a/src/API/Process/Service/ProcessInterface.php
+++ b/src/API/Process/Service/ProcessInterface.php
@@ -82,12 +82,12 @@ interface ProcessInterface
     /**
      * Sets the process timeout (max. runtime) in seconds.
      *
-     * @param float|null $timeout
+     * @param int|null $timeout
      *   An optional process timeout (maximum runtime) in seconds. Set to null
      *   to disable.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\InvalidArgumentException
      *   If the given timeout is negative.
      */
-    public function setTimeout(?float $timeout = self::DEFAULT_TIMEOUT): self;
+    public function setTimeout(?int $timeout = self::DEFAULT_TIMEOUT): self;
 }

--- a/src/API/Process/Service/RsyncProcessRunnerInterface.php
+++ b/src/API/Process/Service/RsyncProcessRunnerInterface.php
@@ -26,9 +26,9 @@ interface RsyncProcessRunnerInterface
      *   ```
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
-     * @param int|null $timeout
-     *   An optional process timeout (maximum runtime) in seconds. Set to null
-     *   to disable.
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\LogicException
      *   If the command process cannot be created due to host configuration.
@@ -40,6 +40,6 @@ interface RsyncProcessRunnerInterface
     public function run(
         array $command,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 }

--- a/src/Internal/Core/Beginner.php
+++ b/src/Internal/Core/Beginner.php
@@ -30,7 +30,7 @@ final class Beginner implements BeginnerInterface
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions);
 

--- a/src/Internal/Core/Cleaner.php
+++ b/src/Internal/Core/Cleaner.php
@@ -28,7 +28,7 @@ final class Cleaner implements CleanerInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir);
 

--- a/src/Internal/Core/Committer.php
+++ b/src/Internal/Core/Committer.php
@@ -30,7 +30,7 @@ final class Committer implements CommitterInterface
         PathInterface $activeDir,
         ?PathListInterface $exclusions = null,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions);
 

--- a/src/Internal/Core/Stager.php
+++ b/src/Internal/Core/Stager.php
@@ -36,7 +36,7 @@ final class Stager implements StagerInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir);
 
@@ -86,7 +86,7 @@ final class Stager implements StagerInterface
         PathInterface $stagingDir,
         array $composerCommand,
         ?OutputCallbackInterface $callback,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $command = array_merge(
             ['--working-dir=' . $stagingDir->absolute()],

--- a/src/Internal/FileSyncer/Service/PhpFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/PhpFileSyncer.php
@@ -38,9 +38,9 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
         PathInterface $destination,
         ?PathListInterface $exclusions = null,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        set_time_limit((int) $timeout);
+        set_time_limit($timeout);
 
         $exclusions ??= new PathList();
 

--- a/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
@@ -47,14 +47,14 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
         PathInterface $destination,
         ?PathListInterface $exclusions = null,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $sourceAbsolute = $source->absolute();
         $destinationAbsolute = $destination->absolute();
 
         $this->assertDirectoriesAreNotTheSame($source, $destination);
         $this->assertSourceExists($source);
-        set_time_limit((int) $timeout);
+        set_time_limit($timeout);
         $this->runCommand($exclusions, $sourceAbsolute, $destinationAbsolute, $destination, $callback);
     }
 

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -174,12 +174,12 @@ final class Filesystem implements FilesystemInterface
     public function remove(
         PathInterface $path,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         try {
             // Symfony Filesystem doesn't have a builtin mechanism for setting a
             // timeout, so we have to enforce it ourselves.
-            set_time_limit((int) $timeout);
+            set_time_limit($timeout);
 
             $this->symfonyFilesystem->remove($path->absolute());
         } catch (SymfonyExceptionInterface $e) {

--- a/src/Internal/Process/Service/AbstractProcessRunner.php
+++ b/src/Internal/Process/Service/AbstractProcessRunner.php
@@ -52,7 +52,7 @@ abstract class AbstractProcessRunner
     public function run(
         array $command,
         ?OutputCallbackInterface $callback = null,
-        ?int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         array_unshift($command, $this->findExecutable());
         $process = $this->processFactory->create($command);

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -106,7 +106,7 @@ final class Process implements ProcessInterface
         return $this;
     }
 
-    public function setTimeout(?float $timeout = self::DEFAULT_TIMEOUT): self
+    public function setTimeout(?int $timeout = self::DEFAULT_TIMEOUT): self
     {
         try {
             $this->symfonyProcess->setTimeout($timeout);

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -106,7 +106,7 @@ final class Process implements ProcessInterface
         return $this;
     }
 
-    public function setTimeout(?int $timeout = self::DEFAULT_TIMEOUT): self
+    public function setTimeout(int $timeout = self::DEFAULT_TIMEOUT): self
     {
         try {
             $this->symfonyProcess->setTimeout($timeout);

--- a/tests/Core/BeginnerUnitTest.php
+++ b/tests/Core/BeginnerUnitTest.php
@@ -70,7 +70,7 @@ final class BeginnerUnitTest extends TestCase
         string $stagingDir,
         ?PathListInterface $exclusions,
         ?OutputCallbackInterface $callback,
-        ?int $timeout,
+        int $timeout,
     ): void {
         $activeDir = new TestPath($activeDir);
         $stagingDir = new TestPath($stagingDir);
@@ -93,7 +93,7 @@ final class BeginnerUnitTest extends TestCase
                 'stagingDir' => 'three/four',
                 'givenExclusions' => null,
                 'callback' => null,
-                'timeout' => null,
+                'timeout' => 0,
             ],
             [
                 'activeDir' => 'five/six',

--- a/tests/Core/CleanerUnitTest.php
+++ b/tests/Core/CleanerUnitTest.php
@@ -61,7 +61,7 @@ final class CleanerUnitTest extends TestCase
      *
      * @dataProvider providerCleanWithOptionalParams
      */
-    public function testCleanWithOptionalParams(string $path, ?OutputCallbackInterface $callback, ?int $timeout): void
+    public function testCleanWithOptionalParams(string $path, ?OutputCallbackInterface $callback, int $timeout): void
     {
         $path = new TestPath($path);
         $this->preconditions
@@ -81,7 +81,7 @@ final class CleanerUnitTest extends TestCase
             [
                 'path' => '/one/two',
                 'callback' => null,
-                'timeout' => null,
+                'timeout' => 0,
             ],
             [
                 'path' => 'three/four',

--- a/tests/Core/CommitterUnitTest.php
+++ b/tests/Core/CommitterUnitTest.php
@@ -70,7 +70,7 @@ final class CommitterUnitTest extends TestCase
         string $activeDir,
         ?PathListInterface $exclusions,
         ?OutputCallbackInterface $callback,
-        ?int $timeout,
+        int $timeout,
     ): void {
         $activeDir = new TestPath($activeDir);
         $stagingDir = new TestPath($stagingDir);
@@ -93,7 +93,7 @@ final class CommitterUnitTest extends TestCase
                 'activeDir' => '/three/four',
                 'exclusions' => null,
                 'callback' => null,
-                'timeout' => null,
+                'timeout' => 0,
             ],
             [
                 'stagingDir' => 'five/six',

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -76,7 +76,7 @@ final class StagerUnitTest extends TestCase
         array $givenCommand,
         array $expectedCommand,
         ?OutputCallbackInterface $callback,
-        ?int $timeout,
+        int $timeout,
     ): void {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
@@ -102,7 +102,7 @@ final class StagerUnitTest extends TestCase
                     'update',
                 ],
                 'callback' => null,
-                'timeout' => null,
+                'timeout' => 0,
             ],
             [
                 'givenCommand' => [self::INERT_COMMAND],

--- a/tests/FileSyncer/Service/FileSyncerFunctionalTestCase.php
+++ b/tests/FileSyncer/Service/FileSyncerFunctionalTestCase.php
@@ -40,7 +40,7 @@ abstract class FileSyncerFunctionalTestCase extends TestCase
      *
      * @dataProvider providerSyncTimeout
      */
-    public function testSyncTimeout(?int $givenTimeout, int $expectedTimeout): void
+    public function testSyncTimeout(int $givenTimeout, int $expectedTimeout): void
     {
         $sut = $this->createSut();
 
@@ -53,7 +53,7 @@ abstract class FileSyncerFunctionalTestCase extends TestCase
     {
         return [
             [
-                'givenTimeout' => null,
+                'givenTimeout' => 0,
                 'expectedTimeout' => 0,
             ],
             [

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -191,7 +191,7 @@ final class FilesystemUnitTest extends TestCase
             [
                 'path' => '/one/two',
                 'callback' => null,
-                'givenTimeout' => null,
+                'givenTimeout' => 0,
                 'expectedTimeout' => 0,
             ],
             [

--- a/tests/Process/Service/AbstractProcessRunnerUnitTest.php
+++ b/tests/Process/Service/AbstractProcessRunnerUnitTest.php
@@ -84,7 +84,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         array $givenCommand,
         array $expectedCommand,
         ?OutputCallbackInterface $callback,
-        ?int $timeout,
+        int $timeout,
     ): void {
         $this->executableFinder
             ->find($executableName)
@@ -116,7 +116,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
                 'givenCommand' => [],
                 'expectedCommand' => ['one'],
                 'callback' => null,
-                'timeout' => null,
+                'timeout' => 0,
             ],
             [
                 'executableName' => 'two',


### PR DESCRIPTION
`$timeout` arguments used to take `null` to disable timeout. This changes them to be-non-nullable and take zero (0) instead to impose no limit, in line with [`set_time_limit()`](https://www.php.net/manual/en/function.set-time-limit.php).