### PR TITLE
Degrade gracefully when `set_time_limit()` is disabled

### DIFF
--- a/src/Internal/Environment/Service/Environment.php
+++ b/src/Internal/Environment/Service/Environment.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Internal\Environment\Service;
+
+/**
+ * @package Environment
+ *
+ * @internal Don't depend directly on this class. It may be changed or removed at any time without notice.
+ */
+final class Environment implements EnvironmentInterface
+{
+    public function setTimeLimit(int $seconds): bool
+    {
+        if (!function_exists('set_time_limit')) {
+            // It's impractical to mock a built-in class for the sake of code coverage. Ignore.
+            return false; // @codeCoverageIgnore
+        }
+
+        return set_time_limit($seconds);
+    }
+}

--- a/src/Internal/Environment/Service/EnvironmentInterface.php
+++ b/src/Internal/Environment/Service/EnvironmentInterface.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Internal\Environment\Service;
+
+/**
+ * Provides features for interacting with the PHP environment.
+ *
+ * @package Environment
+ *
+ * @internal Don't depend directly on this interface. It may be changed or removed at any time without notice.
+ */
+interface EnvironmentInterface
+{
+    /**
+     * Limits the maximum execution time of the current script in seconds.
+     *
+     * This exists to prevent errors in the common case on shared hosting of
+     * the built-in `set_time_limit()` function being disabled. In that case,
+     * the request will be silently ignored and `false` will be returned. In
+     * every other way, this behaves exactly like `set_time_limit()`.
+     *
+     * @param int $seconds
+     *   The maximum execution time, in seconds. If set to zero (0),
+     *   no time limit is imposed.
+     *
+     * @return bool
+     *   Returns true on success, or false on failure--including if it didn't
+     *   even try due to `set_time_limit()` being disabled.
+     *
+     * @see https://www.php.net/manual/en/function.set-time-limit.php
+     */
+    public function setTimeLimit(int $seconds): bool;
+}

--- a/src/Internal/FileSyncer/Service/PhpFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/PhpFileSyncer.php
@@ -12,6 +12,7 @@ use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
+use PhpTuf\ComposerStager\Internal\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 
@@ -25,6 +26,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
     use TranslatableAwareTrait;
 
     public function __construct(
+        private readonly EnvironmentInterface $environment,
         private readonly FileFinderInterface $fileFinder,
         private readonly FilesystemInterface $filesystem,
         private readonly PathFactoryInterface $pathFactory,
@@ -40,7 +42,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        set_time_limit($timeout);
+        $this->environment->setTimeLimit($timeout);
 
         $exclusions ??= new PathList();
 

--- a/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
@@ -13,6 +13,7 @@ use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Process\Service\RsyncProcessRunnerInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
+use PhpTuf\ComposerStager\Internal\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\Internal\Helper\PathHelper;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
@@ -27,6 +28,7 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
     use TranslatableAwareTrait;
 
     public function __construct(
+        private readonly EnvironmentInterface $environment,
         private readonly FilesystemInterface $filesystem,
         private readonly RsyncProcessRunnerInterface $rsync,
         TranslatableFactoryInterface $translatableFactory,
@@ -49,12 +51,13 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
+        $this->environment->setTimeLimit($timeout);
+
         $sourceAbsolute = $source->absolute();
         $destinationAbsolute = $destination->absolute();
 
         $this->assertDirectoriesAreNotTheSame($source, $destination);
         $this->assertSourceExists($source);
-        set_time_limit($timeout);
         $this->runCommand($exclusions, $sourceAbsolute, $destinationAbsolute, $destination, $callback);
     }
 

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -10,6 +10,7 @@ use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
+use PhpTuf\ComposerStager\Internal\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 use Symfony\Component\Filesystem\Exception\ExceptionInterface as SymfonyExceptionInterface;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException as SymfonyFileNotFoundException;
@@ -38,6 +39,7 @@ final class Filesystem implements FilesystemInterface
     private const PATH_IS_SYMLINK = 'PATH_IS_SYMLINK';
 
     public function __construct(
+        private readonly EnvironmentInterface $environment,
         private readonly PathFactoryInterface $pathFactory,
         private readonly SymfonyFilesystem $symfonyFilesystem,
         TranslatableFactoryInterface $translatableFactory,
@@ -177,9 +179,7 @@ final class Filesystem implements FilesystemInterface
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         try {
-            // Symfony Filesystem doesn't have a builtin mechanism for setting a
-            // timeout, so we have to enforce it ourselves.
-            set_time_limit($timeout);
+            $this->environment->setTimeLimit($timeout);
 
             $this->symfonyFilesystem->remove($path->absolute());
         } catch (SymfonyExceptionInterface $e) {

--- a/tests/Environment/Service/EnvironmentFunctionalTest.php
+++ b/tests/Environment/Service/EnvironmentFunctionalTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Tests\Environment\Service;
+
+use PhpTuf\ComposerStager\Internal\Environment\Service\Environment;
+use PhpTuf\ComposerStager\Tests\TestCase;
+
+/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Environment\Service\Environment */
+final class EnvironmentFunctionalTest extends TestCase
+{
+    public function createSut(): Environment
+    {
+        return new Environment();
+    }
+
+    /**
+     * @covers ::setTimeLimit
+     *
+     * @dataProvider providerSetTimeLimit
+     */
+    public function testSetTimeLimit(int $timeout): void
+    {
+        $sut = $this->createSut();
+
+        $result = $sut->setTimeLimit($timeout);
+
+        self::assertSame((string) $timeout, ini_get('max_execution_time'), 'Correctly set timeout.');
+        // At the time of this writing, `set_time_limit()` ALWAYS return false with XDebug
+        // enabled. At least test that the SUT returns the same thing as a direct call.
+        self::assertSame($result, set_time_limit($timeout), 'Returned same result as set_time_limit() called directly.');
+    }
+
+    public function providerSetTimeLimit(): array
+    {
+        return [
+            [-30],
+            [-5],
+            [0],
+            [5],
+            [30],
+        ];
+    }
+}

--- a/tests/FileSyncer/Service/FileSyncerTestCase.php
+++ b/tests/FileSyncer/Service/FileSyncerTestCase.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Tests\FileSyncer\Service;
+
+use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
+use PhpTuf\ComposerStager\Internal\Environment\Service\EnvironmentInterface;
+use PhpTuf\ComposerStager\Tests\TestCase;
+use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Throwable;
+
+abstract class FileSyncerTestCase extends TestCase
+{
+    protected EnvironmentInterface|ObjectProphecy $environment;
+
+    protected function setUp(): void
+    {
+        $this->environment = $this->prophesize(EnvironmentInterface::class);
+        $this->environment->setTimeLimit(Argument::type('integer'))
+            ->willReturn(true);
+    }
+
+    abstract protected function createSut(): FileSyncerInterface;
+
+    /**
+     * @covers ::sync
+     *
+     * @dataProvider providerTimeout
+     */
+    public function testTimeout(int $timeout): void
+    {
+        $this->environment->setTimeLimit($timeout)
+            ->shouldBeCalledOnce();
+        $sut = $this->createSut();
+
+        // Use the same path for the source and destination in
+        // order to fail validation and avoid side effects.
+        try {
+            $sut->sync(PathHelper::sourceDirPath(), PathHelper::sourceDirPath(), null, null, $timeout);
+        } catch (Throwable) {
+            // @ignoreException
+        }
+    }
+
+    public function providerTimeout(): array
+    {
+        return [
+            [-30],
+            [-5],
+            [0],
+            [5],
+            [30],
+        ];
+    }
+}

--- a/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
@@ -10,11 +10,9 @@ use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Finder\Service\FileFinderInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
-use PhpTuf\ComposerStager\Internal\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer;
 use PhpTuf\ComposerStager\Internal\Host\Service\Host;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
-use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
@@ -28,9 +26,8 @@ use Throwable;
  *
  * @covers \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer
  */
-final class PhpFileSyncerUnitTest extends TestCase
+final class PhpFileSyncerUnitTest extends FileSyncerTestCase
 {
-    private EnvironmentInterface|ObjectProphecy $environment;
     private FileFinderInterface|ObjectProphecy $fileFinder;
     private FilesystemInterface|ObjectProphecy $filesystem;
     private PathFactoryInterface|ObjectProphecy $pathFactory;
@@ -41,9 +38,6 @@ final class PhpFileSyncerUnitTest extends TestCase
     {
         $this->source = new TestPath(PathHelper::activeDirRelative());
         $this->destination = new TestPath(PathHelper::stagingDirRelative());
-        $this->environment = $this->prophesize(EnvironmentInterface::class);
-        $this->environment->setTimeLimit(Argument::type('integer'))
-            ->willReturn(true);
         $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
@@ -55,9 +49,11 @@ final class PhpFileSyncerUnitTest extends TestCase
         $this->filesystem
             ->mkdir(Argument::any());
         $this->pathFactory = $this->prophesize(PathFactoryInterface::class);
+
+        parent::setUp();
     }
 
-    private function createSut(): PhpFileSyncer
+    protected function createSut(): PhpFileSyncer
     {
         $environment = $this->environment->reveal();
         $fileFinder = $this->fileFinder->reveal();

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -15,7 +15,6 @@ use PhpTuf\ComposerStager\Internal\FileSyncer\Service\RsyncFileSyncer;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPath;
 use PhpTuf\ComposerStager\Tests\Process\Service\TestOutputCallback;
-use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableExceptionMessage;
@@ -37,7 +36,7 @@ use Prophecy\Prophecy\ObjectProphecy;
  *
  * @group no_windows
  */
-final class RsyncFileSyncerUnitTest extends TestCase
+final class RsyncFileSyncerUnitTest extends FileSyncerTestCase
 {
     private FilesystemInterface|ObjectProphecy $filesystem;
     private PathInterface $destination;
@@ -55,15 +54,18 @@ final class RsyncFileSyncerUnitTest extends TestCase
         $this->filesystem
             ->mkdir(Argument::any());
         $this->rsync = $this->prophesize(RsyncProcessRunnerInterface::class);
+
+        parent::setUp();
     }
 
-    private function createSut(): RsyncFileSyncer
+    protected function createSut(): RsyncFileSyncer
     {
+        $environment = $this->environment->reveal();
         $filesystem = $this->filesystem->reveal();
         $rsync = $this->rsync->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new RsyncFileSyncer($filesystem, $rsync, $translatableFactory);
+        return new RsyncFileSyncer($environment, $filesystem, $rsync, $translatableFactory);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/php-tuf/composer-stager/issues/253

Some shared hosting disables the PHP `set_time_limit()` function, so calls to it cause fatal errors. This makes sure the function exists before calling it and ignores the timeout if not.