### PR TITLE
Add `$timeout` argument to relevant `API\Precondition\Service\PreconditionInterface` methods

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,7 +17,7 @@ parameters:
         - tests
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: c6b2b48b68975314dc3708c271559fae
+    preconditionSystemHash: 54a37bf8c9e9be8e703d4e2219df1d49
     translationSystemHash: e573838804f62414d8488e329ec32123
     gitattributesExportInclude:
         - composer.json

--- a/src/API/Precondition/Service/PreconditionInterface.php
+++ b/src/API/Precondition/Service/PreconditionInterface.php
@@ -4,6 +4,7 @@ namespace PhpTuf\ComposerStager\API\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
 /**
@@ -38,22 +39,38 @@ interface PreconditionInterface
      * example dependency is ready," or if unfulfilled, "The example dependency
      * cannot be found. Make sure it's installed." If the precondition has
      * unfulfilled leaves, the status message from the first one will be returned.
+     *
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      */
     public function getStatusMessage(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): TranslatableInterface;
 
-    /** Determines whether the precondition is fulfilled. */
+    /**
+     * Determines whether the precondition is fulfilled.
+     *
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
+     */
     public function isFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): bool;
 
     /**
      * Asserts that the precondition is fulfilled.
+     *
+     * @param int $timeout
+     *   An optional process timeout (maximum runtime) in seconds. If set to
+     *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\PreconditionException
      *   If the precondition is unfulfilled.
@@ -62,6 +79,7 @@ interface PreconditionInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;
 
     /**

--- a/src/Internal/Core/Beginner.php
+++ b/src/Internal/Core/Beginner.php
@@ -32,7 +32,7 @@ final class Beginner implements BeginnerInterface
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions);
+        $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout);
 
         try {
             $this->fileSyncer->sync($activeDir, $stagingDir, $exclusions, $callback, $timeout);

--- a/src/Internal/Core/Cleaner.php
+++ b/src/Internal/Core/Cleaner.php
@@ -30,7 +30,7 @@ final class Cleaner implements CleanerInterface
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        $this->preconditions->assertIsFulfilled($activeDir, $stagingDir);
+        $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, null, $timeout);
 
         try {
             $this->filesystem->remove($stagingDir, $callback, $timeout);

--- a/src/Internal/Core/Committer.php
+++ b/src/Internal/Core/Committer.php
@@ -32,7 +32,7 @@ final class Committer implements CommitterInterface
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions);
+        $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout);
 
         try {
             $this->fileSyncer->sync($stagingDir, $activeDir, $exclusions, $callback, $timeout);

--- a/src/Internal/Precondition/Service/AbstractFileIteratingPrecondition.php
+++ b/src/Internal/Precondition/Service/AbstractFileIteratingPrecondition.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
@@ -9,6 +10,7 @@ use PhpTuf\ComposerStager\API\Finder\Service\FileFinderInterface;
 use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 
@@ -37,18 +39,20 @@ abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
     ): void;
 
     public function __construct(
+        EnvironmentInterface $environment,
         protected readonly FileFinderInterface $fileFinder,
         protected readonly FilesystemInterface $filesystem,
         protected readonly PathFactoryInterface $pathFactory,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         try {
             $exclusions ??= new PathList();

--- a/src/Internal/Precondition/Service/AbstractPreconditionsTree.php
+++ b/src/Internal/Precondition/Service/AbstractPreconditionsTree.php
@@ -2,10 +2,12 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
@@ -46,8 +48,11 @@ abstract class AbstractPreconditionsTree implements PreconditionInterface
      *
      * @see https://github.com/php-tuf/composer-stager/issues/75
      */
-    public function __construct(TranslatableFactoryInterface $translatableFactory, PreconditionInterface ...$children)
-    {
+    public function __construct(
+        private readonly EnvironmentInterface $environment,
+        TranslatableFactoryInterface $translatableFactory,
+        PreconditionInterface ...$children,
+    ) {
         $this->setTranslatableFactory($translatableFactory);
         $this->children = $children;
     }
@@ -56,9 +61,10 @@ abstract class AbstractPreconditionsTree implements PreconditionInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): TranslatableInterface {
         try {
-            $this->assertIsFulfilled($activeDir, $stagingDir, $exclusions);
+            $this->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout);
         } catch (PreconditionException $e) {
             return $e->getTranslatableMessage();
         }
@@ -70,9 +76,10 @@ abstract class AbstractPreconditionsTree implements PreconditionInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): bool {
         try {
-            $this->assertIsFulfilled($activeDir, $stagingDir, $exclusions);
+            $this->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout);
         } catch (PreconditionException) {
             return false;
         }
@@ -84,9 +91,12 @@ abstract class AbstractPreconditionsTree implements PreconditionInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
+        $this->environment->setTimeLimit($timeout);
+
         foreach ($this->getLeaves() as $leaf) {
-            $leaf->assertIsFulfilled($activeDir, $stagingDir, $exclusions);
+            $leaf->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout);
         }
     }
 }

--- a/src/Internal/Precondition/Service/ActiveAndStagingDirsAreDifferent.php
+++ b/src/Internal/Precondition/Service/ActiveAndStagingDirsAreDifferent.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveAndStagingDirsAreDifferentInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
 /**
@@ -26,10 +27,11 @@ final class ActiveAndStagingDirsAreDifferent extends AbstractPrecondition implem
         return $this->t('The active and staging directories cannot be the same.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         if ($activeDir->absolute() === $stagingDir->absolute()) {
             throw new PreconditionException($this, $this->t(

--- a/src/Internal/Precondition/Service/ActiveDirExists.php
+++ b/src/Internal/Precondition/Service/ActiveDirExists.php
@@ -2,11 +2,13 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirExistsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
@@ -18,10 +20,11 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class ActiveDirExists extends AbstractPrecondition implements ActiveDirExistsInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         private readonly FilesystemInterface $filesystem,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface
@@ -34,10 +37,11 @@ final class ActiveDirExists extends AbstractPrecondition implements ActiveDirExi
         return $this->t('There must be an active directory present before any operations can be performed.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         if (!$this->filesystem->exists($activeDir)) {
             throw new PreconditionException($this, $this->t(

--- a/src/Internal/Precondition/Service/ActiveDirIsReady.php
+++ b/src/Internal/Precondition/Service/ActiveDirIsReady.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirExistsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsReadyInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsWritableInterface;
@@ -16,11 +17,12 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class ActiveDirIsReady extends AbstractPreconditionsTree implements ActiveDirIsReadyInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         ActiveDirExistsInterface $activeDirExists,
         ActiveDirIsWritableInterface $activeDirIsWritable,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory, $activeDirExists, $activeDirIsWritable);
+        parent::__construct($environment, $translatableFactory, $activeDirExists, $activeDirIsWritable);
     }
 
     public function getName(): TranslatableInterface

--- a/src/Internal/Precondition/Service/ActiveDirIsWritable.php
+++ b/src/Internal/Precondition/Service/ActiveDirIsWritable.php
@@ -2,11 +2,13 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsWritableInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
@@ -18,10 +20,11 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class ActiveDirIsWritable extends AbstractPrecondition implements ActiveDirIsWritableInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         private readonly FilesystemInterface $filesystem,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface
@@ -34,10 +37,11 @@ final class ActiveDirIsWritable extends AbstractPrecondition implements ActiveDi
         return $this->t('The active directory must be writable before any operations can be performed.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         if (!$this->filesystem->isWritable($activeDir)) {
             throw new PreconditionException($this, $this->t(

--- a/src/Internal/Precondition/Service/BeginnerPreconditions.php
+++ b/src/Internal/Precondition/Service/BeginnerPreconditions.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\BeginnerPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoUnsupportedLinksExistInterface;
@@ -17,12 +18,14 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class BeginnerPreconditions extends AbstractPreconditionsTree implements BeginnerPreconditionsInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         CommonPreconditionsInterface $commonPreconditions,
         NoUnsupportedLinksExistInterface $noUnsupportedLinksExist,
         StagingDirDoesNotExistInterface $stagingDirDoesNotExist,
         TranslatableFactoryInterface $translatableFactory,
     ) {
         parent::__construct(
+            $environment,
             $translatableFactory,
             $commonPreconditions,
             $noUnsupportedLinksExist,

--- a/src/Internal/Precondition/Service/CleanerPreconditions.php
+++ b/src/Internal/Precondition/Service/CleanerPreconditions.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CleanerPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
@@ -16,11 +17,12 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class CleanerPreconditions extends AbstractPreconditionsTree implements CleanerPreconditionsInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         CommonPreconditionsInterface $commonPreconditions,
         StagingDirIsReadyInterface $stagingDirIsReady,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory, $commonPreconditions, $stagingDirIsReady);
+        parent::__construct($environment, $translatableFactory, $commonPreconditions, $stagingDirIsReady);
     }
 
     public function getName(): TranslatableInterface

--- a/src/Internal/Precondition/Service/CommitterPreconditions.php
+++ b/src/Internal/Precondition/Service/CommitterPreconditions.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommitterPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoUnsupportedLinksExistInterface;
@@ -17,12 +18,19 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class CommitterPreconditions extends AbstractPreconditionsTree implements CommitterPreconditionsInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         CommonPreconditionsInterface $commonPreconditions,
         NoUnsupportedLinksExistInterface $noUnsupportedLinksExist,
         StagingDirIsReadyInterface $stagingDirIsReady,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory, $commonPreconditions, $noUnsupportedLinksExist, $stagingDirIsReady);
+        parent::__construct(
+            $environment,
+            $translatableFactory,
+            $commonPreconditions,
+            $noUnsupportedLinksExist,
+            $stagingDirIsReady,
+        );
     }
 
     public function getName(): TranslatableInterface

--- a/src/Internal/Precondition/Service/CommonPreconditions.php
+++ b/src/Internal/Precondition/Service/CommonPreconditions.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveAndStagingDirsAreDifferentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsReadyInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
@@ -18,6 +19,7 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class CommonPreconditions extends AbstractPreconditionsTree implements CommonPreconditionsInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         TranslatableFactoryInterface $translatableFactory,
         ActiveAndStagingDirsAreDifferentInterface $activeAndStagingDirsAreDifferent,
         ActiveDirIsReadyInterface $activeDirIsReady,
@@ -25,6 +27,7 @@ final class CommonPreconditions extends AbstractPreconditionsTree implements Com
         HostSupportsRunningProcessesInterface $hostSupportsRunningProcesses,
     ) {
         parent::__construct(
+            $environment,
             $translatableFactory,
             $activeAndStagingDirsAreDifferent,
             $activeDirIsReady,

--- a/src/Internal/Precondition/Service/ComposerIsAvailable.php
+++ b/src/Internal/Precondition/Service/ComposerIsAvailable.php
@@ -3,6 +3,7 @@
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
 use JsonException;
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
@@ -25,11 +26,12 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
     private string $executablePath;
 
     public function __construct(
+        EnvironmentInterface $environment,
         private readonly ExecutableFinderInterface $executableFinder,
         private readonly ProcessFactoryInterface $processFactory,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface
@@ -42,10 +44,11 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
         return $this->t('Composer must be available in order to stage commands.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $this->assertExecutableExists();
         $this->assertIsActuallyComposer();

--- a/src/Internal/Precondition/Service/HostSupportsRunningProcesses.php
+++ b/src/Internal/Precondition/Service/HostSupportsRunningProcesses.php
@@ -2,12 +2,14 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\ExceptionInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\HostSupportsRunningProcessesInterface;
 use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
@@ -19,10 +21,11 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class HostSupportsRunningProcesses extends AbstractPrecondition implements HostSupportsRunningProcessesInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         private readonly ProcessFactoryInterface $processFactory,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface
@@ -36,10 +39,11 @@ final class HostSupportsRunningProcesses extends AbstractPrecondition implements
             . 'PHP processes in order to run Composer and other shell commands.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         try {
             $this->processFactory->create([]);

--- a/src/Internal/Precondition/Service/NoLinksExistOnWindows.php
+++ b/src/Internal/Precondition/Service/NoLinksExistOnWindows.php
@@ -2,15 +2,10 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
-use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
-use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
-use PhpTuf\ComposerStager\API\Finder\Service\FileFinderInterface;
-use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoLinksExistOnWindowsInterface;
-use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
 /**
@@ -20,16 +15,6 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
  */
 final class NoLinksExistOnWindows extends AbstractFileIteratingPrecondition implements NoLinksExistOnWindowsInterface
 {
-    public function __construct(
-        private readonly EnvironmentInterface $environment,
-        FileFinderInterface $fileFinder,
-        FilesystemInterface $filesystem,
-        PathFactoryInterface $pathFactory,
-        TranslatableFactoryInterface $translatableFactory,
-    ) {
-        parent::__construct($fileFinder, $filesystem, $pathFactory, $translatableFactory);
-    }
-
     public function getName(): TranslatableInterface
     {
         return $this->t('No links exist on Windows');

--- a/src/Internal/Precondition/Service/NoSymlinksPointToADirectory.php
+++ b/src/Internal/Precondition/Service/NoSymlinksPointToADirectory.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\RsyncFileSyncerInterface;
@@ -23,13 +24,14 @@ final class NoSymlinksPointToADirectory extends AbstractFileIteratingPreconditio
     NoSymlinksPointToADirectoryInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         FileFinderInterface $fileFinder,
         private readonly FileSyncerInterface $fileSyncer,
         FilesystemInterface $filesystem,
         PathFactoryInterface $pathFactory,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($fileFinder, $filesystem, $pathFactory, $translatableFactory);
+        parent::__construct($environment, $fileFinder, $filesystem, $pathFactory, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface

--- a/src/Internal/Precondition/Service/NoUnsupportedLinksExist.php
+++ b/src/Internal/Precondition/Service/NoUnsupportedLinksExist.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoAbsoluteSymlinksExistInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoHardLinksExistInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoLinksExistOnWindowsInterface;
@@ -19,6 +20,7 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class NoUnsupportedLinksExist extends AbstractPreconditionsTree implements NoUnsupportedLinksExistInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         TranslatableFactoryInterface $translatableFactory,
         NoAbsoluteSymlinksExistInterface $noAbsoluteSymlinksExist,
         NoHardLinksExistInterface $noHardLinksExist,
@@ -27,6 +29,7 @@ final class NoUnsupportedLinksExist extends AbstractPreconditionsTree implements
         NoSymlinksPointToADirectoryInterface $noSymlinksPointToADirectory,
     ) {
         parent::__construct(
+            $environment,
             $translatableFactory,
             $noAbsoluteSymlinksExist,
             $noHardLinksExist,

--- a/src/Internal/Precondition/Service/StagerPreconditions.php
+++ b/src/Internal/Precondition/Service/StagerPreconditions.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagerPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
@@ -16,11 +17,12 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class StagerPreconditions extends AbstractPreconditionsTree implements StagerPreconditionsInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         TranslatableFactoryInterface $translatableFactory,
         CommonPreconditionsInterface $commonPreconditions,
         StagingDirIsReadyInterface $stagingDirIsReady,
     ) {
-        parent::__construct($translatableFactory, $commonPreconditions, $stagingDirIsReady);
+        parent::__construct($environment, $translatableFactory, $commonPreconditions, $stagingDirIsReady);
     }
 
     public function getName(): TranslatableInterface

--- a/src/Internal/Precondition/Service/StagingDirDoesNotExist.php
+++ b/src/Internal/Precondition/Service/StagingDirDoesNotExist.php
@@ -2,11 +2,13 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirDoesNotExistInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
@@ -18,10 +20,11 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class StagingDirDoesNotExist extends AbstractPrecondition implements StagingDirDoesNotExistInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         private readonly FilesystemInterface $filesystem,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface
@@ -34,10 +37,11 @@ final class StagingDirDoesNotExist extends AbstractPrecondition implements Stagi
         return $this->t('The staging directory must not already exist before beginning the staging process.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         if ($this->filesystem->exists($stagingDir)) {
             throw new PreconditionException($this, $this->t(

--- a/src/Internal/Precondition/Service/StagingDirExists.php
+++ b/src/Internal/Precondition/Service/StagingDirExists.php
@@ -2,11 +2,13 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirExistsInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
@@ -18,10 +20,11 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class StagingDirExists extends AbstractPrecondition implements StagingDirExistsInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         private readonly FilesystemInterface $filesystem,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface
@@ -34,10 +37,11 @@ final class StagingDirExists extends AbstractPrecondition implements StagingDirE
         return $this->t('The staging directory must exist before any operations can be performed.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         if (!$this->filesystem->exists($stagingDir)) {
             throw new PreconditionException($this, $this->t(

--- a/src/Internal/Precondition/Service/StagingDirIsReady.php
+++ b/src/Internal/Precondition/Service/StagingDirIsReady.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirExistsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsWritableInterface;
@@ -16,11 +17,12 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class StagingDirIsReady extends AbstractPreconditionsTree implements StagingDirIsReadyInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         TranslatableFactoryInterface $translatableFactory,
         StagingDirExistsInterface $stagingDirExists,
         StagingDirIsWritableInterface $stagingDirIsWritable,
     ) {
-        parent::__construct($translatableFactory, $stagingDirExists, $stagingDirIsWritable);
+        parent::__construct($environment, $translatableFactory, $stagingDirExists, $stagingDirIsWritable);
     }
 
     public function getName(): TranslatableInterface

--- a/src/Internal/Precondition/Service/StagingDirIsWritable.php
+++ b/src/Internal/Precondition/Service/StagingDirIsWritable.php
@@ -2,11 +2,13 @@
 
 namespace PhpTuf\ComposerStager\Internal\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsWritableInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 
@@ -18,10 +20,11 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 final class StagingDirIsWritable extends AbstractPrecondition implements StagingDirIsWritableInterface
 {
     public function __construct(
+        EnvironmentInterface $environment,
         private readonly FilesystemInterface $filesystem,
         TranslatableFactoryInterface $translatableFactory,
     ) {
-        parent::__construct($translatableFactory);
+        parent::__construct($environment, $translatableFactory);
     }
 
     public function getName(): TranslatableInterface
@@ -34,10 +37,11 @@ final class StagingDirIsWritable extends AbstractPrecondition implements Staging
         return $this->t('The staging directory must be writable before any operations can be performed.');
     }
 
-    public function assertIsFulfilled(
+    protected function doAssertIsFulfilled(
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         if (!$this->filesystem->isWritable($stagingDir)) {
             throw new PreconditionException($this, $this->t(

--- a/tests/Core/BeginnerUnitTest.php
+++ b/tests/Core/BeginnerUnitTest.php
@@ -49,11 +49,13 @@ final class BeginnerUnitTest extends TestCase
     /** @covers ::begin */
     public function testBeginWithMinimumParams(): void
     {
+        $timeout = ProcessInterface::DEFAULT_TIMEOUT;
+
         $this->preconditions
-            ->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null)
+            ->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null, $timeout)
             ->shouldBeCalledOnce();
         $this->fileSyncer
-            ->sync(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null, null, ProcessInterface::DEFAULT_TIMEOUT)
+            ->sync(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null, null, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -75,7 +77,7 @@ final class BeginnerUnitTest extends TestCase
         $activeDir = new TestPath($activeDir);
         $stagingDir = new TestPath($stagingDir);
         $this->preconditions
-            ->assertIsFulfilled($activeDir, $stagingDir, $exclusions)
+            ->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout)
             ->shouldBeCalledOnce();
         $this->fileSyncer
             ->sync($activeDir, $stagingDir, $exclusions, $callback, $timeout)

--- a/tests/Core/CleanerUnitTest.php
+++ b/tests/Core/CleanerUnitTest.php
@@ -45,11 +45,13 @@ final class CleanerUnitTest extends TestCase
     /** @covers ::clean */
     public function testCleanWithMinimumParams(): void
     {
+        $timeout = ProcessInterface::DEFAULT_TIMEOUT;
+
         $this->preconditions
-            ->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null)
+            ->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null, $timeout)
             ->shouldBeCalledOnce();
         $this->filesystem
-            ->remove(PathHelper::stagingDirPath(), null, ProcessInterface::DEFAULT_TIMEOUT)
+            ->remove(PathHelper::stagingDirPath(), null, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -65,7 +67,7 @@ final class CleanerUnitTest extends TestCase
     {
         $path = new TestPath($path);
         $this->preconditions
-            ->assertIsFulfilled(PathHelper::activeDirPath(), $path)
+            ->assertIsFulfilled(PathHelper::activeDirPath(), $path, null, $timeout)
             ->shouldBeCalledOnce();
         $this->filesystem
             ->remove($path, $callback, $timeout)

--- a/tests/Core/CommitterUnitTest.php
+++ b/tests/Core/CommitterUnitTest.php
@@ -49,11 +49,13 @@ final class CommitterUnitTest extends TestCase
     /** @covers ::commit */
     public function testCommitWithMinimumParams(): void
     {
+        $timeout = ProcessInterface::DEFAULT_TIMEOUT;
+
         $this->preconditions
-            ->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null)
+            ->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null, $timeout)
             ->shouldBeCalledOnce();
         $this->fileSyncer
-            ->sync(PathHelper::stagingDirPath(), PathHelper::activeDirPath(), null, null, ProcessInterface::DEFAULT_TIMEOUT)
+            ->sync(PathHelper::stagingDirPath(), PathHelper::activeDirPath(), null, null, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -75,7 +77,7 @@ final class CommitterUnitTest extends TestCase
         $activeDir = new TestPath($activeDir);
         $stagingDir = new TestPath($stagingDir);
         $this->preconditions
-            ->assertIsFulfilled($activeDir, $stagingDir, $exclusions)
+            ->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout)
             ->shouldBeCalledOnce();
         $this->fileSyncer
             ->sync($stagingDir, $activeDir, $exclusions, $callback, $timeout)

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -55,6 +55,7 @@ final class StagerUnitTest extends TestCase
     {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
+        $timeout = ProcessInterface::DEFAULT_TIMEOUT;
 
         $this->preconditions
             ->assertIsFulfilled($activeDirPath, $stagingDirPath)
@@ -64,7 +65,7 @@ final class StagerUnitTest extends TestCase
             self::INERT_COMMAND,
         ];
         $this->composerRunner
-            ->run($expectedCommand, null, ProcessInterface::DEFAULT_TIMEOUT)
+            ->run($expectedCommand, null, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 

--- a/tests/Environment/Service/TestEnvironment.php
+++ b/tests/Environment/Service/TestEnvironment.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\Tests\Environment\Service;
+
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
+
+final class TestEnvironment implements EnvironmentInterface
+{
+    public function isWindows(): bool
+    {
+        return false;
+    }
+
+    public function setTimeLimit(int $seconds): bool
+    {
+        return true;
+    }
+}

--- a/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
+++ b/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
@@ -20,8 +20,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition
  *
  * @covers ::__construct
- * @covers ::findFiles
- * @covers ::isFulfilled
  */
 final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreconditionUnitTestCase
 {
@@ -51,6 +49,7 @@ final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreco
 
     protected function createSut(): PreconditionInterface
     {
+        $environment = $this->environment->reveal();
         $fileFinder = $this->fileFinder->reveal();
         $filesystem = $this->filesystem->reveal();
         $pathFactory = $this->pathFactory->reveal();
@@ -58,7 +57,13 @@ final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreco
 
         // Create a concrete implementation for testing since the SUT in
         // this case, being abstract, can't be instantiated directly.
-        return new class ($fileFinder, $filesystem, $pathFactory, $translatableFactory) extends AbstractFileIteratingPrecondition
+        return new class (
+            $environment,
+            $fileFinder,
+            $filesystem,
+            $pathFactory,
+            $translatableFactory,
+        ) extends AbstractFileIteratingPrecondition
         {
             public bool $exitEarly = false;
 
@@ -96,8 +101,8 @@ final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreco
     }
 
     /**
-     * @covers ::assertIsFulfilled
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::exitEarly
+     * @covers ::doAssertIsFulfilled
+     * @covers ::exitEarly
      */
     public function testExitEarly(): void
     {

--- a/tests/Precondition/Service/ActiveAndStagingDirsAreDifferentUnitTest.php
+++ b/tests/Precondition/Service/ActiveAndStagingDirsAreDifferentUnitTest.php
@@ -6,24 +6,21 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveAndStagingDirsAreD
 use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveAndStagingDirsAreDifferent
- *
- * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
- */
+/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveAndStagingDirsAreDifferent */
 final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionTestCase
 {
     protected function createSut(): ActiveAndStagingDirsAreDifferent
     {
+        $environment = $this->environment->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new ActiveAndStagingDirsAreDifferent($translatableFactory);
+        return new ActiveAndStagingDirsAreDifferent($environment, $translatableFactory);
     }
 
+    /**
+     * @covers ::doAssertIsFulfilled
+     * @covers ::getFulfilledStatusMessage
+     */
     public function testFulfilled(): void
     {
         $this->doTestFulfilled(
@@ -33,7 +30,7 @@ final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionTestCas
         );
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The active and staging directories are the same.';

--- a/tests/Precondition/Service/ActiveDirExistsUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirExistsUnitTest.php
@@ -12,10 +12,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirExists
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class ActiveDirExistsUnitTest extends PreconditionTestCase
 {
@@ -30,12 +26,17 @@ final class ActiveDirExistsUnitTest extends PreconditionTestCase
 
     protected function createSut(): ActiveDirExists
     {
+        $environment = $this->environment->reveal();
         $filesystem = $this->filesystem->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new ActiveDirExists($filesystem, $translatableFactory);
+        return new ActiveDirExists($environment, $filesystem, $translatableFactory);
     }
 
+    /**
+     * @covers ::doAssertIsFulfilled
+     * @covers ::getFulfilledStatusMessage
+     */
     public function testFulfilled(): void
     {
         $this->filesystem
@@ -46,7 +47,7 @@ final class ActiveDirExistsUnitTest extends PreconditionTestCase
         $this->doTestFulfilled('The active directory exists.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The active directory does not exist.';

--- a/tests/Precondition/Service/ActiveDirIsReadyUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirIsReadyUnitTest.php
@@ -13,9 +13,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsReady
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::isFulfilled
  */
 final class ActiveDirIsReadyUnitTest extends PreconditionTestCase
 {
@@ -38,39 +35,43 @@ final class ActiveDirIsReadyUnitTest extends PreconditionTestCase
 
     protected function createSut(): ActiveDirIsReady
     {
+        $environment = $this->environment->reveal();
         $stagingDirExists = $this->activeDirExists->reveal();
         $stagingDirIsWritable = $this->activeDirIsWritable->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new ActiveDirIsReady($stagingDirExists, $stagingDirIsWritable, $translatableFactory);
+        return new ActiveDirIsReady($environment, $stagingDirExists, $stagingDirIsWritable, $translatableFactory);
     }
 
+    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
+        $timeout = 42;
 
         $this->activeDirExists
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $this->activeDirIsWritable
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
 
-        $this->doTestFulfilled('The active directory is ready to use.');
+        $this->doTestFulfilled('The active directory is ready to use.', $activeDirPath, $stagingDirPath, $timeout);
     }
 
     public function testUnfulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
+        $timeout = 42;
 
         $message = __METHOD__;
         $previous = self::createTestPreconditionException($message);
         $this->activeDirExists
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->willThrow($previous);
 
-        $this->doTestUnfulfilled($message);
+        $this->doTestUnfulfilled($message, null, $activeDirPath, $stagingDirPath, $timeout);
     }
 }

--- a/tests/Precondition/Service/ActiveDirIsWritableUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirIsWritableUnitTest.php
@@ -12,10 +12,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsWritable
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class ActiveDirIsWritableUnitTest extends PreconditionTestCase
 {
@@ -30,12 +26,17 @@ final class ActiveDirIsWritableUnitTest extends PreconditionTestCase
 
     protected function createSut(): ActiveDirIsWritable
     {
+        $environment = $this->environment->reveal();
         $filesystem = $this->filesystem->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new ActiveDirIsWritable($filesystem, $translatableFactory);
+        return new ActiveDirIsWritable($environment, $filesystem, $translatableFactory);
     }
 
+    /**
+     * @covers ::doAssertIsFulfilled
+     * @covers ::getFulfilledStatusMessage
+     */
     public function testFulfilled(): void
     {
         $this->filesystem
@@ -46,7 +47,7 @@ final class ActiveDirIsWritableUnitTest extends PreconditionTestCase
         $this->doTestFulfilled('The active directory is writable.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The active directory is not writable.';

--- a/tests/Precondition/Service/BeginnerPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/BeginnerPreconditionsUnitTest.php
@@ -14,10 +14,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\BeginnerPreconditions
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class BeginnerPreconditionsUnitTest extends PreconditionTestCase
 {
@@ -46,42 +42,57 @@ final class BeginnerPreconditionsUnitTest extends PreconditionTestCase
     protected function createSut(): BeginnerPreconditions
     {
         $commonPreconditions = $this->commonPreconditions->reveal();
+        $environment = $this->environment->reveal();
         $noUnsupportedLinksExist = $this->noUnsupportedLinksExist->reveal();
         $stagingDirDoesNotExist = $this->stagingDirDoesNotExist->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new BeginnerPreconditions($commonPreconditions, $noUnsupportedLinksExist, $stagingDirDoesNotExist, $translatableFactory);
+        return new BeginnerPreconditions(
+            $environment,
+            $commonPreconditions,
+            $noUnsupportedLinksExist,
+            $stagingDirDoesNotExist,
+            $translatableFactory,
+        );
     }
 
+    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
+        $timeout = 42;
 
         $this->commonPreconditions
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $this->noUnsupportedLinksExist
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $this->stagingDirDoesNotExist
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
 
-        $this->doTestFulfilled('The preconditions for beginning the staging process are fulfilled.');
+        $this->doTestFulfilled(
+            'The preconditions for beginning the staging process are fulfilled.',
+            $activeDirPath,
+            $stagingDirPath,
+            $timeout,
+        );
     }
 
     public function testUnfulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
+        $timeout = 42;
 
         $message = __METHOD__;
         $previous = self::createTestPreconditionException($message);
         $this->commonPreconditions
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->willThrow($previous);
 
-        $this->doTestUnfulfilled($message);
+        $this->doTestUnfulfilled($message, null, $activeDirPath, $stagingDirPath, $timeout);
     }
 }

--- a/tests/Precondition/Service/CommonPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/CommonPreconditionsUnitTest.php
@@ -15,10 +15,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\CommonPreconditions
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class CommonPreconditionsUnitTest extends PreconditionTestCase
 {
@@ -54,10 +50,12 @@ final class CommonPreconditionsUnitTest extends PreconditionTestCase
         $activeAndStagingDirsAreDifferent = $this->activeAndStagingDirsAreDifferent->reveal();
         $activeDirIsReady = $this->activeDirIsReady->reveal();
         $composerIsAvailable = $this->composerIsAvailable->reveal();
+        $environment = $this->environment->reveal();
         $hostSupportsRunningProcesses = $this->hostSupportsRunningProcesses->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
         return new CommonPreconditions(
+            $environment,
             $translatableFactory,
             $activeAndStagingDirsAreDifferent,
             $activeDirIsReady,
@@ -66,38 +64,41 @@ final class CommonPreconditionsUnitTest extends PreconditionTestCase
         );
     }
 
+    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
+        $timeout = 42;
 
         $this->composerIsAvailable
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $this->activeDirIsReady
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $this->activeAndStagingDirsAreDifferent
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $this->hostSupportsRunningProcesses
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
 
-        $this->doTestFulfilled('The common preconditions are fulfilled.');
+        $this->doTestFulfilled('The common preconditions are fulfilled.', $activeDirPath, $stagingDirPath, $timeout);
     }
 
     public function testUnfulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
         $stagingDirPath = PathHelper::stagingDirPath();
+        $timeout = 42;
 
         $message = __METHOD__;
         $previous = self::createTestPreconditionException($message);
         $this->activeAndStagingDirsAreDifferent
-            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions)
+            ->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout)
             ->willThrow($previous);
 
-        $this->doTestUnfulfilled($message);
+        $this->doTestUnfulfilled($message, null, $activeDirPath, $stagingDirPath, $timeout);
     }
 }

--- a/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
@@ -20,11 +20,7 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @covers ::__construct
  * @covers ::assertExecutableExists
  * @covers ::assertIsActuallyComposer
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
  * @covers ::getProcess
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  * @covers ::isValidExecutable
  */
 final class ComposerIsAvailableUnitTest extends PreconditionTestCase
@@ -60,6 +56,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionTestCase
 
     protected function createSut(): ComposerIsAvailable
     {
+        $environment = $this->environment->reveal();
         $executableFinder = $this->executableFinder->reveal();
         $process = $this->process->reveal();
         $this->processFactory
@@ -68,12 +65,13 @@ final class ComposerIsAvailableUnitTest extends PreconditionTestCase
         $processFactory = $this->processFactory->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new ComposerIsAvailable($executableFinder, $processFactory, $translatableFactory);
+        return new ComposerIsAvailable($environment, $executableFinder, $processFactory, $translatableFactory);
     }
 
     /**
      * @covers ::assertExecutableExists
      * @covers ::assertIsActuallyComposer
+     * @covers ::getFulfilledStatusMessage
      * @covers ::getProcess
      * @covers ::isValidExecutable
      */
@@ -122,7 +120,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionTestCase
     /**
      * @covers ::assertExecutableExists
      * @covers ::assertIsActuallyComposer
-     * @covers ::assertIsFulfilled
+     * @covers ::doAssertIsFulfilled
      * @covers ::getProcess
      */
     public function testFailedToCreateProcess(): void

--- a/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
+++ b/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
@@ -21,6 +21,7 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Throwable;
 
+/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition */
 abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCase
 {
     abstract protected function fulfilledStatusMessage(): string;
@@ -32,10 +33,6 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
 
     protected function setUp(): void
     {
-        $this->environment = $this->prophesize(EnvironmentInterface::class);
-        $this->environment
-            ->isWindows()
-            ->willReturn(false);
         $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->fileFinder
             ->find(Argument::type(PathInterface::class), Argument::type(PathListInterface::class))
@@ -49,7 +46,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
         parent::setUp();
     }
 
-    /** @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::exitEarly */
+    /** @covers ::exitEarly */
     public function testExitEarly(): void
     {
         $this->filesystem
@@ -59,6 +56,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
             ->find(Argument::cetera())
             ->shouldNotBeCalled();
 
+        $environment = $this->environment->reveal();
         $fileFinder = $this->fileFinder->reveal();
         $filesystem = $this->filesystem->reveal();
         $pathFactory = $this->pathFactory->reveal();
@@ -66,7 +64,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
 
         // Create a concrete implementation for testing since the SUT in
         // this case, being abstract, can't be instantiated directly.
-        $sut = new class ($fileFinder, $filesystem, $pathFactory, $translatableFactory) extends AbstractFileIteratingPrecondition
+        $sut = new class ($environment, $fileFinder, $filesystem, $pathFactory, $translatableFactory) extends AbstractFileIteratingPrecondition
         {
             // @phpcs:ignore SlevomatCodingStandard.Functions.DisallowEmptyFunction.EmptyFunction
             protected function assertIsSupportedFile(
@@ -110,7 +108,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
         $sut->assertIsFulfilled($activeDirPath, $stagingDirPath);
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testActiveDirectoryDoesNotExistCountsAsFulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
@@ -127,7 +125,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
         $this->assertFulfilled($isFulfilled, $statusMessage, 'Treated non-existent directories as fulfilled.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testStagingDirectoryDoesNotExistCountsAsFulfilled(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
@@ -144,7 +142,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
         $this->assertFulfilled($isFulfilled, $statusMessage, 'Treated non-existent directories as fulfilled.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testNoFilesFound(): void
     {
         $activeDirPath = PathHelper::activeDirPath();
@@ -162,7 +160,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
     }
 
     /**
-     * @covers ::assertIsFulfilled
+     * @covers ::doAssertIsFulfilled
      *
      * @dataProvider providerFileFinderExceptions
      */
@@ -197,6 +195,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionTestCas
         ];
     }
 
+    /** @covers ::doAssertIsFulfilled */
     public function assertFulfilled(
         bool $isFulfilled,
         TranslatableInterface $statusMessage,

--- a/tests/Precondition/Service/HostSupportsRunningProcessesFunctionalTest.php
+++ b/tests/Precondition/Service/HostSupportsRunningProcessesFunctionalTest.php
@@ -26,7 +26,7 @@ final class HostSupportsRunningProcessesFunctionalTest extends TestCase
     }
 
     /**
-     * @covers ::assertIsFulfilled
+     * @covers ::doAssertIsFulfilled
      *
      * This test proves that the precondition correctly detects a failure from
      * the Symfony Process component when the the proc_open() function is

--- a/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
+++ b/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Process\Process;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
+ * @covers ::doAssertIsFulfilled
  * @covers ::getFulfilledStatusMessage
  * @covers ::getStatusMessage
  * @covers ::isFulfilled
@@ -36,10 +36,11 @@ final class HostSupportsRunningProcessesUnitTest extends PreconditionTestCase
 
     protected function createSut(): HostSupportsRunningProcesses
     {
+        $environment = $this->environment->reveal();
         $processFactory = $this->processFactory->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new HostSupportsRunningProcesses($processFactory, $translatableFactory);
+        return new HostSupportsRunningProcesses($environment, $processFactory, $translatableFactory);
     }
 
     public function testFulfilled(): void
@@ -51,7 +52,7 @@ final class HostSupportsRunningProcessesUnitTest extends PreconditionTestCase
         $this->doTestFulfilled('The host supports running independent PHP processes.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = __METHOD__;

--- a/tests/Precondition/Service/LinkPreconditionsFunctionalTestCase.php
+++ b/tests/Precondition/Service/LinkPreconditionsFunctionalTestCase.php
@@ -23,7 +23,16 @@ abstract class LinkPreconditionsFunctionalTestCase extends TestCase
 
     abstract protected function createSut(): PreconditionInterface;
 
-    /** @dataProvider providerFulfilledDirectoryDoesNotExist */
+    /**
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::doAssertIsFulfilled
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::findFiles
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::assertIsFulfilled
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::doAssertIsFulfilled
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::isFulfilled
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows::exitEarly
+     *
+     * @dataProvider providerFulfilledDirectoryDoesNotExist
+     */
     public function testFulfilledDirectoryDoesNotExist(PathInterface $activeDir, PathInterface $stagingDir): void
     {
         $this->doTestFulfilledDirectoryDoesNotExist($activeDir, $stagingDir);
@@ -57,8 +66,11 @@ abstract class LinkPreconditionsFunctionalTestCase extends TestCase
     }
 
     /**
-     * @covers ::assertIsFulfilled
-     * @covers ::isFulfilled
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::doAssertIsFulfilled
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::findFiles
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::isFulfilled
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist::assertIsSupportedFile
+     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows::exitEarly
      */
     public function testFulfilledWithNoLinks(): void
     {

--- a/tests/Precondition/Service/LinkPreconditionsIsolationFunctionalTest.php
+++ b/tests/Precondition/Service/LinkPreconditionsIsolationFunctionalTest.php
@@ -18,7 +18,7 @@ use Throwable;
 /**
  * Tests the interaction of unsupported links preconditions.
  *
- * @coversNothing
+ * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition
  */
 final class LinkPreconditionsIsolationFunctionalTest extends TestCase
 {

--- a/tests/Precondition/Service/NoAbsoluteSymlinksExistFunctionalTest.php
+++ b/tests/Precondition/Service/NoAbsoluteSymlinksExistFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
-use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerHelper;
@@ -13,7 +12,6 @@ use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist
  *
  * @covers ::__construct
- * @covers ::findFiles
  *
  * @group no_windows
  */
@@ -31,9 +29,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
     }
 
     /**
-     * @covers ::assertIsFulfilled
      * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
      *
      * @dataProvider providerDoesNotContainLinks
      */
@@ -71,8 +67,6 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
 
     /**
      * @covers ::assertIsSupportedFile
-     * @covers ::findFiles
-     * @covers ::isFulfilled
      *
      * @dataProvider providerLinksExist
      */
@@ -103,8 +97,6 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
 
     /**
      * @covers ::assertIsSupportedFile
-     * @covers ::findFiles
-     * @covers ::isFulfilled
      *
      * @dataProvider providerLinksExist
      */
@@ -162,21 +154,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         ];
     }
 
-    /**
-     * @covers ::findFiles
-     * @covers ::isFulfilled
-     *
-     * @dataProvider providerFulfilledDirectoryDoesNotExist
-     */
-    public function testFulfilledDirectoryDoesNotExist(PathInterface $activeDir, PathInterface $stagingDir): void
-    {
-        $this->doTestFulfilledDirectoryDoesNotExist($activeDir, $stagingDir);
-    }
-
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
-     */
+    /** @covers ::assertIsSupportedFile */
     public function testWithHardLink(): void
     {
         $link = PathHelper::makeAbsolute('link.txt', PathHelper::activeDirAbsolute());
@@ -194,7 +172,6 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
 
     /**
      * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
      *
      * @dataProvider providerExclusions
      */

--- a/tests/Precondition/Service/NoAbsoluteSymlinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoAbsoluteSymlinksExistUnitTest.php
@@ -8,22 +8,20 @@ use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist
  *
- * @covers ::assertIsFulfilled
  * @covers ::exitEarly
  * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class NoAbsoluteSymlinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function createSut(): NoAbsoluteSymlinksExist
     {
+        $environment = $this->environment->reveal();
         $fileFinder = $this->fileFinder->reveal();
         $filesystem = $this->filesystem->reveal();
         $pathFactory = $this->pathFactory->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new NoAbsoluteSymlinksExist($fileFinder, $filesystem, $pathFactory, $translatableFactory);
+        return new NoAbsoluteSymlinksExist($environment, $fileFinder, $filesystem, $pathFactory, $translatableFactory);
     }
 
     protected function fulfilledStatusMessage(): string

--- a/tests/Precondition/Service/NoHardLinksExistFunctionalTest.php
+++ b/tests/Precondition/Service/NoHardLinksExistFunctionalTest.php
@@ -3,7 +3,6 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
-use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerHelper;
@@ -29,23 +28,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         return $sut;
     }
 
-    /**
-     * @covers ::assertIsFulfilled
-     * @covers ::assertIsSupportedFile
-     */
-    public function testFulfilledWithNoLinks(): void
-    {
-        $sut = $this->createSut();
-
-        $isFulfilled = $sut->isFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-
-        self::assertTrue($isFulfilled, 'Passed with no links in the codebase.');
-    }
-
-    /**
-     * @covers ::assertIsFulfilled
-     * @covers ::assertIsSupportedFile
-     */
+    /** @covers ::assertIsSupportedFile */
     public function testFulfilledWithSymlink(): void
     {
         $target = Path::makeAbsolute('target.txt', PathHelper::activeDirAbsolute());
@@ -60,7 +43,6 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
     }
 
     /**
-     * @covers ::assertIsFulfilled
      * @covers ::assertIsSupportedFile
      *
      * @dataProvider providerUnfulfilled
@@ -99,18 +81,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
     }
 
     /**
-     * @covers ::assertIsFulfilled
-     *
-     * @dataProvider providerFulfilledDirectoryDoesNotExist
-     */
-    public function testFulfilledDirectoryDoesNotExist(PathInterface $activeDir, PathInterface $stagingDir): void
-    {
-        $this->doTestFulfilledDirectoryDoesNotExist($activeDir, $stagingDir);
-    }
-
-    /**
      * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
      *
      * @dataProvider providerExclusions
      */

--- a/tests/Precondition/Service/NoHardLinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoHardLinksExistUnitTest.php
@@ -5,24 +5,18 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist
- *
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
- */
+/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist */
 final class NoHardLinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected function createSut(): NoHardLinksExist
     {
+        $environment = $this->environment->reveal();
         $fileFinder = $this->fileFinder->reveal();
         $filesystem = $this->filesystem->reveal();
         $pathFactory = $this->pathFactory->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new NoHardLinksExist($fileFinder, $filesystem, $pathFactory, $translatableFactory);
+        return new NoHardLinksExist($environment, $fileFinder, $filesystem, $pathFactory, $translatableFactory);
     }
 
     protected function fulfilledStatusMessage(): string
@@ -30,11 +24,16 @@ final class NoHardLinksExistUnitTest extends FileIteratingPreconditionUnitTestCa
         return 'There are no hard links in the codebase.';
     }
 
+    /**
+     * @covers ::assertIsSupportedFile
+     * @covers ::getFulfilledStatusMessage
+     */
     public function testFulfilled(): void
     {
         $this->doTestFulfilled('There are no hard links in the codebase.');
     }
 
+    /** @covers ::assertIsSupportedFile */
     public function testUnfulfilled(): void
     {
         // @todo Implement once the corresponding functionality is added.

--- a/tests/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
+++ b/tests/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
@@ -3,7 +3,6 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
-use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerHelper;
@@ -29,24 +28,8 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
     }
 
     /**
-     * @covers ::exitEarly
-     * @covers ::findFiles
-     * @covers ::isFulfilled
-     */
-    public function testFulfilledWithNoLinks(): void
-    {
-        $sut = $this->createSut();
-
-        $isFulfilled = $sut->isFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-
-        self::assertTrue($isFulfilled, 'Passed with no links in the codebase.');
-    }
-
-    /**
      * @covers ::assertIsSupportedFile
      * @covers ::exitEarly
-     * @covers ::findFiles
-     * @covers ::isFulfilled
      *
      * @dataProvider providerUnfulfilled
      *
@@ -90,18 +73,6 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
                 'hardLinks' => ['link.txt' => 'target.txt'],
             ],
         ];
-    }
-
-    /**
-     * @covers ::exitEarly
-     * @covers ::findFiles
-     * @covers ::isFulfilled
-     *
-     * @dataProvider providerFulfilledDirectoryDoesNotExist
-     */
-    public function testFulfilledDirectoryDoesNotExist(PathInterface $activeDir, PathInterface $stagingDir): void
-    {
-        $this->doTestFulfilledDirectoryDoesNotExist($activeDir, $stagingDir);
     }
 
     /**

--- a/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
+++ b/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
@@ -11,11 +11,9 @@ use Prophecy\Argument;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
+ * @covers ::assertIsSupportedFile
  * @covers ::exitEarly
  * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class NoLinksExistOnWindowsUnitTest extends FileIteratingPreconditionUnitTestCase
 {

--- a/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
@@ -3,7 +3,6 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
-use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTheCodebase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerHelper;
@@ -129,16 +128,6 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
                 'linkDirName' => 'staging',
             ],
         ];
-    }
-
-    /**
-     * @covers ::isFulfilled
-     *
-     * @dataProvider providerFulfilledDirectoryDoesNotExist
-     */
-    public function testFulfilledDirectoryDoesNotExist(PathInterface $activeDir, PathInterface $stagingDir): void
-    {
-        $this->doTestFulfilledDirectoryDoesNotExist($activeDir, $stagingDir);
     }
 
     /**

--- a/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
@@ -15,10 +15,8 @@ use Prophecy\Argument;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTheCodebase
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
+ * @covers ::assertIsSupportedFile
  * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class NoSymlinksPointOutsideTheCodebaseUnitTest extends FileIteratingPreconditionUnitTestCase
 {
@@ -44,11 +42,12 @@ final class NoSymlinksPointOutsideTheCodebaseUnitTest extends FileIteratingPreco
 
     protected function createSut(): NoSymlinksPointOutsideTheCodebase
     {
+        $environment = $this->environment->reveal();
         $fileFinder = $this->fileFinder->reveal();
         $filesystem = $this->filesystem->reveal();
         $pathFactory = $this->pathFactory->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new NoSymlinksPointOutsideTheCodebase($fileFinder, $filesystem, $pathFactory, $translatableFactory);
+        return new NoSymlinksPointOutsideTheCodebase($environment, $fileFinder, $filesystem, $pathFactory, $translatableFactory);
     }
 }

--- a/tests/Precondition/Service/NoSymlinksPointToADirectoryUnitTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointToADirectoryUnitTest.php
@@ -20,11 +20,9 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointToADirectory
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
+ * @covers ::assertIsSupportedFile
  * @covers ::exitEarly
  * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class NoSymlinksPointToADirectoryUnitTest extends FileIteratingPreconditionUnitTestCase
 {
@@ -53,13 +51,14 @@ final class NoSymlinksPointToADirectoryUnitTest extends FileIteratingPreconditio
 
     protected function createSut(): NoSymlinksPointToADirectory
     {
+        $environment = $this->environment->reveal();
         $fileFinder = $this->fileFinder->reveal();
         $fileSyncer = $this->fileSyncer->reveal();
         $filesystem = $this->filesystem->reveal();
         $pathFactory = $this->pathFactory->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new NoSymlinksPointToADirectory($fileFinder, $fileSyncer, $filesystem, $pathFactory, $translatableFactory);
+        return new NoSymlinksPointToADirectory($environment, $fileFinder, $fileSyncer, $filesystem, $pathFactory, $translatableFactory);
     }
 
     public function testExitEarlyWithRsyncFileSyncer(): void

--- a/tests/Precondition/Service/PreconditionTestCase.php
+++ b/tests/Precondition/Service/PreconditionTestCase.php
@@ -2,13 +2,18 @@
 
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
+use PhpTuf\ComposerStager\API\Environment\Service\EnvironmentInterface;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Tests\Path\Value\TestPathList;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 abstract class PreconditionTestCase extends TestCase
 {
@@ -16,8 +21,18 @@ abstract class PreconditionTestCase extends TestCase
     // and assertIsFulfilled() in ::doTestFulfilled() and ::doTestUnfulfilled(), respectively.
     protected const EXPECTED_CALLS_MULTIPLE = 3;
 
+    protected EnvironmentInterface|ObjectProphecy $environment;
+    protected PathListInterface $exclusions;
+
     protected function setUp(): void
     {
+        $this->environment = $this->prophesize(EnvironmentInterface::class);
+        $this->environment
+            ->isWindows()
+            ->willReturn(false);
+        $this->environment
+            ->setTimeLimit(Argument::any())
+            ->willReturn(true);
         $this->exclusions = new TestPathList();
     }
 
@@ -42,14 +57,19 @@ abstract class PreconditionTestCase extends TestCase
         string $expectedStatusMessage,
         ?PathInterface $activeDirPath = null,
         ?PathInterface $stagingDirPath = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $activeDirPath ??= PathHelper::activeDirPath();
         $stagingDirPath ??= PathHelper::stagingDirPath();
+
+        $this->environment
+            ->setTimeLimit($timeout)
+            ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $sut = $this->createSut();
 
-        $isFulfilled = $sut->isFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
-        $actualStatusMessage = $sut->getStatusMessage($activeDirPath, $stagingDirPath, $this->exclusions);
-        $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
+        $isFulfilled = $sut->isFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout);
+        $actualStatusMessage = $sut->getStatusMessage($activeDirPath, $stagingDirPath, $this->exclusions, $timeout);
+        $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout);
 
         self::assertTrue($isFulfilled);
         self::assertTranslatableMessage($expectedStatusMessage, $actualStatusMessage, 'Got correct status message.');
@@ -60,13 +80,14 @@ abstract class PreconditionTestCase extends TestCase
         ?string $previousException = null,
         ?PathInterface $activeDirPath = null,
         ?PathInterface $stagingDirPath = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         $activeDirPath ??= PathHelper::activeDirPath();
         $stagingDirPath ??= PathHelper::stagingDirPath();
         $sut = $this->createSut();
 
-        self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath): void {
-            $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
+        self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath, $timeout): void {
+            $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout);
         }, PreconditionException::class, $expectedStatusMessage, $previousException);
     }
 }

--- a/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
+++ b/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
@@ -12,10 +12,8 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirDoesNotExist
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
+ * @covers ::doAssertIsFulfilled
  * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class StagingDirDoesNotExistUnitTest extends PreconditionTestCase
 {
@@ -30,10 +28,11 @@ final class StagingDirDoesNotExistUnitTest extends PreconditionTestCase
 
     protected function createSut(): StagingDirDoesNotExist
     {
+        $environment = $this->environment->reveal();
         $filesystem = $this->filesystem->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new StagingDirDoesNotExist($filesystem, $translatableFactory);
+        return new StagingDirDoesNotExist($environment, $filesystem, $translatableFactory);
     }
 
     public function testFulfilled(): void
@@ -46,7 +45,7 @@ final class StagingDirDoesNotExistUnitTest extends PreconditionTestCase
         $this->doTestFulfilled('The staging directory does not already exist.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The staging directory already exists.';

--- a/tests/Precondition/Service/StagingDirExistsUnitTest.php
+++ b/tests/Precondition/Service/StagingDirExistsUnitTest.php
@@ -12,10 +12,8 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirExists
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
+ * @covers ::doAssertIsFulfilled
  * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class StagingDirExistsUnitTest extends PreconditionTestCase
 {
@@ -30,10 +28,11 @@ final class StagingDirExistsUnitTest extends PreconditionTestCase
 
     protected function createSut(): StagingDirExists
     {
+        $environment = $this->environment->reveal();
         $filesystem = $this->filesystem->reveal();
         $translatableFactory = new TestTranslatableFactory();
 
-        return new StagingDirExists($filesystem, $translatableFactory);
+        return new StagingDirExists($environment, $filesystem, $translatableFactory);
     }
 
     public function testFulfilled(): void
@@ -46,7 +45,7 @@ final class StagingDirExistsUnitTest extends PreconditionTestCase
         $this->doTestFulfilled('The staging directory exists.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The staging directory does not exist.';

--- a/tests/Precondition/Service/StagingDirIsWritableUnitTest.php
+++ b/tests/Precondition/Service/StagingDirIsWritableUnitTest.php
@@ -12,10 +12,8 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsWritable
  *
  * @covers ::__construct
- * @covers ::assertIsFulfilled
+ * @covers ::doAssertIsFulfilled
  * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
  */
 final class StagingDirIsWritableUnitTest extends PreconditionTestCase
 {
@@ -30,11 +28,12 @@ final class StagingDirIsWritableUnitTest extends PreconditionTestCase
 
     protected function createSut(): StagingDirIsWritable
     {
+        $environment = $this->environment->reveal();
         $filesystem = $this->filesystem->reveal();
         assert($filesystem instanceof FilesystemInterface);
         $translatableFactory = new TestTranslatableFactory();
 
-        return new StagingDirIsWritable($filesystem, $translatableFactory);
+        return new StagingDirIsWritable($environment, $filesystem, $translatableFactory);
     }
 
     public function testFulfilled(): void
@@ -47,7 +46,7 @@ final class StagingDirIsWritableUnitTest extends PreconditionTestCase
         $this->doTestFulfilled('The staging directory is writable.');
     }
 
-    /** @covers ::assertIsFulfilled */
+    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The staging directory is not writable.';

--- a/tests/Precondition/Service/TestPrecondition.php
+++ b/tests/Precondition/Service/TestPrecondition.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 
@@ -33,6 +34,7 @@ final class TestPrecondition implements PreconditionInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): TranslatableInterface {
         return new TestTranslatableMessage($this->statusMessage);
     }
@@ -41,6 +43,7 @@ final class TestPrecondition implements PreconditionInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): bool {
         return $this->isFulfilled;
     }
@@ -49,6 +52,7 @@ final class TestPrecondition implements PreconditionInterface
         PathInterface $activeDir,
         PathInterface $stagingDir,
         ?PathListInterface $exclusions = null,
+        int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         if ($this->isFulfilled) {
             return;

--- a/tests/Precondition/Service/TestPreconditionsTree.php
+++ b/tests/Precondition/Service/TestPreconditionsTree.php
@@ -6,6 +6,7 @@ use PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslationParametersInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPreconditionsTree;
+use PhpTuf\ComposerStager\Tests\Environment\Service\TestEnvironment;
 use PhpTuf\ComposerStager\Tests\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\Translation\Value\TestTranslatableMessage;
 
@@ -26,9 +27,10 @@ final class TestPreconditionsTree extends AbstractPreconditionsTree
 
     public function __construct(PreconditionInterface ...$children)
     {
+        $environment = new TestEnvironment();
         $translatableFactory = new TestTranslatableFactory();
 
-        parent::__construct($translatableFactory, ...$children);
+        parent::__construct($environment, $translatableFactory, ...$children);
     }
 
     public function getDescription(): TranslatableInterface

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace PhpTuf\ComposerStager\Tests;
 
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
-use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslationParametersInterface;
 use PhpTuf\ComposerStager\Tests\Precondition\Service\TestPrecondition;
 use PhpTuf\ComposerStager\Tests\TestUtils\AssertTrait;
@@ -25,8 +24,6 @@ abstract class TestCase extends PHPUnitTestCase
 
     protected const ORIGINAL_CONTENT = '';
     protected const CHANGED_CONTENT = 'changed';
-
-    protected PathListInterface $exclusions;
 
     protected static function createTestEnvironment(?string $activeDir = null): void
     {


### PR DESCRIPTION
- Closes #121 

Since some of the preconditions (particularly the file iterating ones) can be expensive, it makes sense to apply timeouts to them, too.