### PR TITLE
Document and add tests for expanded Drupal core supported versions spread

### DIFF
--- a/tests/Compatability/CompatabilityFunctionalTest.php
+++ b/tests/Compatability/CompatabilityFunctionalTest.php
@@ -14,9 +14,15 @@ use Symfony\Component\Process\Process;
  */
 final class CompatabilityFunctionalTest extends TestCase
 {
+    // @see https://github.com/php-tuf/composer-stager/wiki/Library-compatibility-policy#drupal
     private const SUPPORTED_DRUPAL_VERSIONS = [
+        // Current major, oldest supported minor.
         '10.0.0',
+        '10.0.10',
+        // Current minor.
         '10.1.0',
+        '10.1.2',
+        // Next minor dev.
         '11.x-dev',
     ];
 


### PR DESCRIPTION
See new [Library compatibility policy](https://github.com/php-tuf/composer-stager/wiki/Library-compatibility-policy). tl;dr:

| Major version | Minor version | Point release | Example |
|---|---|---|---|
| Current | Oldest supported | Oldest available | `10.0.0` |
| Current | Oldest supported | Newest available | `10.0.10` |
| Current | Current | Oldest available | `10.1.0` |
| Current | Current | Newest available | `10.1.2` |
| Current | Next | Dev | `11.x-dev` |