### PR TITLE
Add mutation testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,3 +110,23 @@ jobs:
 
             -   name: "Run performance tests"
                 run: "composer phpbench -- --progress=plain --ansi"
+
+    mutation:
+        name: "Mutation"
+        runs-on: ubuntu-latest
+        steps:
+            -   name: "Set up PHP"
+                uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
+                with:
+                    php-version: "8.1"
+                    extensions: gd
+                    ini-values: assert.active=1, assert.exception=1, zend.assertions=1
+
+            -   name: "Checkout code"
+                uses: actions/checkout@v4 # https://github.com/marketplace/actions/checkout
+
+            -   name: "Install dependencies"
+                uses: ramsey/composer-install@v2 # https://github.com/marketplace/actions/install-composer-dependencies
+
+            -   name: "Run mutation tests"
+                run: "composer infection -- --show-mutations --ansi"

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -31,6 +31,7 @@
   </component>
   <component name="PhpIncludePathManager">
     <include_path>
+      <path value="$PROJECT_DIR$/vendor/colinodell/json5" />
       <path value="$PROJECT_DIR$/vendor/composer" />
       <path value="$PROJECT_DIR$/vendor/dealerdirect/phpcodesniffer-composer-installer" />
       <path value="$PROJECT_DIR$/vendor/doctrine/annotations" />
@@ -43,11 +44,17 @@
       <path value="$PROJECT_DIR$/vendor/ergebnis/json-pointer" />
       <path value="$PROJECT_DIR$/vendor/ergebnis/json-printer" />
       <path value="$PROJECT_DIR$/vendor/ergebnis/json-schema-validator" />
+      <path value="$PROJECT_DIR$/vendor/fidry/cpu-core-counter" />
+      <path value="$PROJECT_DIR$/vendor/infection/abstract-testframework-adapter" />
+      <path value="$PROJECT_DIR$/vendor/infection/extension-installer" />
+      <path value="$PROJECT_DIR$/vendor/infection/include-interceptor" />
+      <path value="$PROJECT_DIR$/vendor/infection/infection" />
       <path value="$PROJECT_DIR$/vendor/jangregor/phpstan-prophecy" />
       <path value="$PROJECT_DIR$/vendor/justinrainbow/json-schema" />
       <path value="$PROJECT_DIR$/vendor/localheinz/diff" />
       <path value="$PROJECT_DIR$/vendor/myclabs/deep-copy" />
       <path value="$PROJECT_DIR$/vendor/nikic/php-parser" />
+      <path value="$PROJECT_DIR$/vendor/ondram/ci-detector" />
       <path value="$PROJECT_DIR$/vendor/pdepend/pdepend" />
       <path value="$PROJECT_DIR$/vendor/phar-io/manifest" />
       <path value="$PROJECT_DIR$/vendor/phar-io/version" />
@@ -77,7 +84,10 @@
       <path value="$PROJECT_DIR$/vendor/psr/cache" />
       <path value="$PROJECT_DIR$/vendor/psr/container" />
       <path value="$PROJECT_DIR$/vendor/psr/log" />
+      <path value="$PROJECT_DIR$/vendor/qossmic/deptrac-shim" />
       <path value="$PROJECT_DIR$/vendor/rector/rector" />
+      <path value="$PROJECT_DIR$/vendor/sanmai/later" />
+      <path value="$PROJECT_DIR$/vendor/sanmai/pipeline" />
       <path value="$PROJECT_DIR$/vendor/sebastian/cli-parser" />
       <path value="$PROJECT_DIR$/vendor/sebastian/code-unit" />
       <path value="$PROJECT_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
@@ -115,6 +125,7 @@
       <path value="$PROJECT_DIR$/vendor/symfony/var-exporter" />
       <path value="$PROJECT_DIR$/vendor/symfony/yaml" />
       <path value="$PROJECT_DIR$/vendor/thecodingmachine/phpstan-strict-rules" />
+      <path value="$PROJECT_DIR$/vendor/thecodingmachine/safe" />
       <path value="$PROJECT_DIR$/vendor/theseer/tokenizer" />
       <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
       <path value="$PROJECT_DIR$/vendor/webmozart/glob" />

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "ergebnis/composer-normalize": "^2.33",
+        "infection/infection": "^0.27.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpbench/phpbench": "^1.2",
@@ -70,7 +71,8 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true,
             "phpro/grumphp-shim": false,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "infection/extension-installer": true
         },
         "optimize-autoloader": true,
         "sort-packages": true
@@ -104,6 +106,7 @@
         "fast": "phpunit --exclude-group=slow,windows_only",
         "fix": "@phpcbf",
         "functional": "phpunit --testsuite=functional --exclude-group=windows_only",
+        "infection": "infection",
         "lint": "parallel-lint --no-progress src tests",
         "md": "@phpmd",
         "phpbench": "phpbench run --report=all --output=console --output=html",
@@ -137,6 +140,7 @@
         "fast": "Runs only fast automated tests",
         "fix": "[phpcbf] Automatically fixes standards violations where possible",
         "functional": "Runs functional tests",
+        "infection": "Performs mutation testing",
         "lint": "Lints PHP files",
         "md": "[phpmd] Looks for potential problems within the source code",
         "phpbench": "[bench] Run benchmarks",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e3d9742747a946cd81cde0404cf1260",
+    "content-hash": "692bf646249d0cdc344034f3b2ac34a6",
     "packages": [
         {
             "name": "symfony/filesystem",
@@ -375,6 +375,97 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "colinodell/json5",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/colinodell/json5.git",
+                "reference": "15b063f8cb5e6deb15f0cd39123264ec0d19c710"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/colinodell/json5/zipball/15b063f8cb5e6deb15f0cd39123264ec0d19c710",
+                "reference": "15b063f8cb5e6deb15f0cd39123264ec0d19c710",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1.3|^8.0"
+            },
+            "conflict": {
+                "scrutinizer/ocular": "1.7.*"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "^1.2.5",
+                "phpstan/phpstan": "^1.4",
+                "scrutinizer/ocular": "^1.6",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0",
+                "symfony/finder": "^4.4|^5.4|^6.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0"
+            },
+            "bin": [
+                "bin/json5"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/global.php"
+                ],
+                "psr-4": {
+                    "ColinODell\\Json5\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "UTF-8 compatible JSON5 parser for PHP",
+            "homepage": "https://github.com/colinodell/json5",
+            "keywords": [
+                "JSON5",
+                "json",
+                "json5_decode",
+                "json_decode"
+            ],
+            "support": {
+                "issues": "https://github.com/colinodell/json5/issues",
+                "source": "https://github.com/colinodell/json5/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/colinodell",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2022-12-27T16:44:40+00:00"
+        },
         {
             "name": "composer/pcre",
             "version": "3.1.0",
@@ -1255,6 +1346,376 @@
             "time": "2022-12-10T14:50:15+00:00"
         },
         {
+            "name": "fidry/cpu-core-counter",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^9.5.26 || ^8.5.31",
+                "theofidry/php-cs-fixer-config": "^1.0",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-24T12:35:10+00:00"
+        },
+        {
+            "name": "infection/abstract-testframework-adapter",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/abstract-testframework-adapter.git",
+                "reference": "18925e20d15d1a5995bb85c9dc09e8751e1e069b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/abstract-testframework-adapter/zipball/18925e20d15d1a5995bb85c9dc09e8751e1e069b",
+                "reference": "18925e20d15d1a5995bb85c9dc09e8751e1e069b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.8",
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\AbstractTestFramework\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Abstract Test Framework Adapter for Infection",
+            "support": {
+                "issues": "https://github.com/infection/abstract-testframework-adapter/issues",
+                "source": "https://github.com/infection/abstract-testframework-adapter/tree/0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2021-08-17T18:49:12+00:00"
+        },
+        {
+            "name": "infection/extension-installer",
+            "version": "0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/extension-installer.git",
+                "reference": "9b351d2910b9a23ab4815542e93d541e0ca0cdcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/extension-installer/zipball/9b351d2910b9a23ab4815542e93d541e0ca0cdcf",
+                "reference": "9b351d2910b9a23ab4815542e93d541e0ca0cdcf",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.18, <2.19",
+                "infection/infection": "^0.15.2",
+                "php-coveralls/php-coveralls": "^2.4",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.10",
+                "phpstan/phpstan-phpunit": "^0.12.6",
+                "phpstan/phpstan-strict-rules": "^0.12.2",
+                "phpstan/phpstan-webmozart-assert": "^0.12.2",
+                "phpunit/phpunit": "^9.5",
+                "vimeo/psalm": "^4.8"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Infection\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Infection\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Infection Extension Installer",
+            "support": {
+                "issues": "https://github.com/infection/extension-installer/issues",
+                "source": "https://github.com/infection/extension-installer/tree/0.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2021-10-20T22:08:34+00:00"
+        },
+        {
+            "name": "infection/include-interceptor",
+            "version": "0.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/include-interceptor.git",
+                "reference": "0cc76d95a79d9832d74e74492b0a30139904bdf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/include-interceptor/zipball/0cc76d95a79d9832d74e74492b0a30139904bdf7",
+                "reference": "0cc76d95a79d9832d74e74492b0a30139904bdf7",
+                "shasum": ""
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "infection/infection": "^0.15.0",
+                "phan/phan": "^2.4 || ^3",
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpstan/phpstan": "^0.12.8",
+                "phpunit/phpunit": "^8.5",
+                "vimeo/psalm": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\StreamWrapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Stream Wrapper: Include Interceptor. Allows to replace included (autoloaded) file with another one.",
+            "support": {
+                "issues": "https://github.com/infection/include-interceptor/issues",
+                "source": "https://github.com/infection/include-interceptor/tree/0.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2021-08-09T10:03:57+00:00"
+        },
+        {
+            "name": "infection/infection",
+            "version": "0.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/infection.git",
+                "reference": "a9ff8171577d98b887d7f16428edd81ff69ce887"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/infection/zipball/a9ff8171577d98b887d7f16428edd81ff69ce887",
+                "reference": "a9ff8171577d98b887d7f16428edd81ff69ce887",
+                "shasum": ""
+            },
+            "require": {
+                "colinodell/json5": "^2.2",
+                "composer-runtime-api": "^2.0",
+                "composer/xdebug-handler": "^2.0 || ^3.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "fidry/cpu-core-counter": "^0.4.0 || ^0.5.0",
+                "infection/abstract-testframework-adapter": "^0.5.0",
+                "infection/extension-installer": "^0.1.0",
+                "infection/include-interceptor": "^0.2.5",
+                "justinrainbow/json-schema": "^5.2.10",
+                "nikic/php-parser": "^4.15.1",
+                "ondram/ci-detector": "^4.1.0",
+                "php": "^8.1",
+                "sanmai/later": "^0.1.1",
+                "sanmai/pipeline": "^5.1 || ^6",
+                "sebastian/diff": "^3.0.2 || ^4.0 || ^5.0",
+                "symfony/console": "^5.4 || ^6.0",
+                "symfony/filesystem": "^5.4 || ^6.0",
+                "symfony/finder": "^5.4 || ^6.0",
+                "symfony/process": "^5.4 || ^6.0",
+                "thecodingmachine/safe": "^2.1.2",
+                "webmozart/assert": "^1.11"
+            },
+            "conflict": {
+                "antecedent/patchwork": "<2.1.25",
+                "dg/bypass-finals": "<1.4.1",
+                "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17,<9.2.21"
+            },
+            "require-dev": {
+                "brianium/paratest": "^6.3",
+                "ext-simplexml": "*",
+                "fidry/makefile": "^0.2.0",
+                "helmich/phpunit-json-assert": "^3.0",
+                "phpspec/prophecy": "^1.15",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1.1.0",
+                "phpstan/phpstan": "^1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpstan/phpstan-webmozart-assert": "^1.0.2",
+                "phpunit/phpunit": "^9.5.5",
+                "rector/rector": "^0.16.0",
+                "sidz/phpstan-rules": "^0.2.1",
+                "symfony/phpunit-bridge": "^5.4 || ^6.0",
+                "symfony/yaml": "^5.4 || ^6.0",
+                "thecodingmachine/phpstan-safe-rule": "^1.2.0"
+            },
+            "bin": [
+                "bin/infection"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com",
+                    "homepage": "https://twitter.com/maks_rafalko"
+                },
+                {
+                    "name": "Oleg Zhulnev",
+                    "homepage": "https://github.com/sidz"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "homepage": "https://github.com/BackEndTea"
+                },
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com",
+                    "homepage": "https://twitter.com/tfidry"
+                },
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com",
+                    "homepage": "https://www.alexeykopytko.com"
+                },
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Infection is a Mutation Testing framework for PHP. The mutation adequacy score can be used to measure the effectiveness of a test set in terms of its ability to detect faults.",
+            "keywords": [
+                "coverage",
+                "mutant",
+                "mutation framework",
+                "mutation testing",
+                "testing",
+                "unit testing"
+            ],
+            "support": {
+                "issues": "https://github.com/infection/infection/issues",
+                "source": "https://github.com/infection/infection/tree/0.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/infection",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/infection",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-05-16T05:28:04+00:00"
+        },
+        {
             "name": "jangregor/phpstan-prophecy",
             "version": "1.0.0",
             "source": {
@@ -1563,6 +2024,84 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
             },
             "time": "2023-08-13T19:53:39+00:00"
+        },
+        {
+            "name": "ondram/ci-detector",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/OndraM/ci-detector.git",
+                "reference": "8a4b664e916df82ff26a44709942dfd593fa6f30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/OndraM/ci-detector/zipball/8a4b664e916df82ff26a44709942dfd593fa6f30",
+                "reference": "8a4b664e916df82ff26a44709942dfd593fa6f30",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.2",
+                "lmc/coding-standard": "^1.3 || ^2.1",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0.5",
+                "phpstan/phpstan": "^0.12.58",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpunit/phpunit": "^7.1 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OndraM\\CiDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Machulda",
+                    "email": "ondrej.machulda@gmail.com"
+                }
+            ],
+            "description": "Detect continuous integration environment and provide unified access to properties of current build",
+            "keywords": [
+                "CircleCI",
+                "Codeship",
+                "Wercker",
+                "adapter",
+                "appveyor",
+                "aws",
+                "aws codebuild",
+                "azure",
+                "azure devops",
+                "azure pipelines",
+                "bamboo",
+                "bitbucket",
+                "buddy",
+                "ci-info",
+                "codebuild",
+                "continuous integration",
+                "continuousphp",
+                "devops",
+                "drone",
+                "github",
+                "gitlab",
+                "interface",
+                "jenkins",
+                "pipelines",
+                "sourcehut",
+                "teamcity",
+                "travis"
+            ],
+            "support": {
+                "issues": "https://github.com/OndraM/ci-detector/issues",
+                "source": "https://github.com/OndraM/ci-detector/tree/4.1.0"
+            },
+            "time": "2021-04-14T09:16:52+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -3331,6 +3870,129 @@
                 }
             ],
             "time": "2023-09-06T08:50:38+00:00"
+        },
+        {
+            "name": "sanmai/later",
+            "version": "0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sanmai/later.git",
+                "reference": "9b659fecef2030193fd02402955bc39629d5606f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sanmai/later/zipball/9b659fecef2030193fd02402955bc39629d5606f",
+                "reference": "9b659fecef2030193fd02402955bc39629d5606f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.13",
+                "infection/infection": ">=0.10.5",
+                "phan/phan": ">=2",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": ">=0.10",
+                "phpunit/phpunit": ">=7.4",
+                "vimeo/psalm": ">=2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Later\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com"
+                }
+            ],
+            "description": "Later: deferred wrapper object",
+            "support": {
+                "issues": "https://github.com/sanmai/later/issues",
+                "source": "https://github.com/sanmai/later/tree/0.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sanmai",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-02T10:26:44+00:00"
+        },
+        {
+            "name": "sanmai/pipeline",
+            "version": "v6.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sanmai/pipeline.git",
+                "reference": "2e88e466dd49f20c10a15330b3953d4d49c326e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/2e88e466dd49f20c10a15330b3953d4d49c326e3",
+                "reference": "2e88e466dd49f20c10a15330b3953d4d49c326e3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.8",
+                "friendsofphp/php-cs-fixer": "^3.17",
+                "infection/infection": ">=0.10.5",
+                "league/pipeline": "^0.3 || ^1.0",
+                "phan/phan": ">=1.1",
+                "php-coveralls/php-coveralls": "^2.4.1",
+                "phpstan/phpstan": ">=0.10",
+                "phpunit/phpunit": ">=9.4",
+                "vimeo/psalm": ">=2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "v6.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Pipeline\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com"
+                }
+            ],
+            "description": "General-purpose collections pipeline",
+            "support": {
+                "issues": "https://github.com/sanmai/pipeline/issues",
+                "source": "https://github.com/sanmai/pipeline/tree/v6.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sanmai",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-06-15T09:14:47+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5459,6 +6121,145 @@
                 "source": "https://github.com/thecodingmachine/phpstan-strict-rules/tree/v1.0.0"
             },
             "time": "2021-11-08T09:10:49+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "3115ecd6b4391662b4931daac4eba6b07a2ac1f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/3115ecd6b4391662b4931daac4eba6b07a2ac1f0",
+                "reference": "3115ecd6b4391662b4931daac4eba6b07a2ac1f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.2",
+                "thecodingmachine/phpstan-strict-rules": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "deprecated/apc.php",
+                    "deprecated/array.php",
+                    "deprecated/datetime.php",
+                    "deprecated/libevent.php",
+                    "deprecated/misc.php",
+                    "deprecated/password.php",
+                    "deprecated/mssql.php",
+                    "deprecated/stats.php",
+                    "deprecated/strings.php",
+                    "lib/special_cases.php",
+                    "deprecated/mysqli.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "deprecated/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v2.5.0"
+            },
+            "time": "2023-04-05T11:54:14+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -7,9 +7,12 @@
     },
     "timeout": 30,
     "logs": {
-        "text": "var/infection/infection.log"
+        "text": "var/infection/infection.log",
+        "html": "var/infection/log/infection.html",
+        "summary": "var/infection/log/summary.log"
     },
     "mutators": {
         "@default": true
-    }
+    },
+    "testFrameworkOptions": "--exclude-group=windows_only"
 }

--- a/src/Internal/Helper/PathHelper.php
+++ b/src/Internal/Helper/PathHelper.php
@@ -24,7 +24,11 @@ final class PathHelper implements PathHelperInterface
         // SymfonyPath always uses forward slashes. Use the OS's
         // directory separator instead. And it doesn't reduce repeated
         // slashes after Windows drive names, so eliminate them, too.
-        return (string) preg_replace('#/+#', DIRECTORY_SEPARATOR, $path);
+        $canonicalized = preg_replace('#/+#', DIRECTORY_SEPARATOR, $path);
+
+        assert(is_string($canonicalized));
+
+        return $canonicalized;
     }
 
     public static function isAbsolute(string $path): bool

--- a/tests/Core/BeginnerUnitTest.php
+++ b/tests/Core/BeginnerUnitTest.php
@@ -133,28 +133,28 @@ final class BeginnerUnitTest extends TestCase
      *
      * @dataProvider providerExceptions
      */
-    public function testExceptions(ExceptionInterface $exception): void
+    public function testExceptions(ExceptionInterface $caughtException): void
     {
         $this->fileSyncer
             ->sync(Argument::cetera())
-            ->willThrow($exception);
+            ->willThrow($caughtException);
         $sut = $this->createSut();
 
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->begin(PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-        }, RuntimeException::class, $exception->getMessage(), $exception::class);
+        }, RuntimeException::class, $caughtException->getMessage(), null, $caughtException::class);
     }
 
     public function providerExceptions(): array
     {
         return [
             'InvalidArgumentException' => [
-                'exception' => new InvalidArgumentException(
+                'caughtException' => new InvalidArgumentException(
                     new TestTranslatableExceptionMessage('one'),
                 ),
             ],
             'IOException' => [
-                'exception' => new IOException(
+                'caughtException' => new IOException(
                     new TestTranslatableExceptionMessage('two'),
                 ),
             ],

--- a/tests/Core/CleanerUnitTest.php
+++ b/tests/Core/CleanerUnitTest.php
@@ -120,6 +120,6 @@ final class CleanerUnitTest extends TestCase
 
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->clean(PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-        }, RuntimeException::class, $message, $previous::class);
+        }, RuntimeException::class, $message, null, $previous::class);
     }
 }

--- a/tests/Core/CommitterUnitTest.php
+++ b/tests/Core/CommitterUnitTest.php
@@ -137,31 +137,29 @@ final class CommitterUnitTest extends TestCase
      *
      * @dataProvider providerExceptions
      */
-    public function testExceptions(ExceptionInterface $exception, string $message): void
+    public function testExceptions(ExceptionInterface $caughtException): void
     {
         $stagingDirPath = PathHelper::stagingDirPath();
         $activeDirPath = PathHelper::activeDirPath();
 
         $this->fileSyncer
             ->sync($stagingDirPath, $activeDirPath, Argument::cetera())
-            ->willThrow($exception);
+            ->willThrow($caughtException);
         $sut = $this->createSut();
 
         self::assertTranslatableException(static function () use ($sut, $activeDirPath, $stagingDirPath): void {
             $sut->commit($stagingDirPath, $activeDirPath);
-        }, RuntimeException::class, $message, $exception::class);
+        }, RuntimeException::class, $caughtException->getMessage(), null, $caughtException::class);
     }
 
     public function providerExceptions(): array
     {
         return [
             'InvalidArgumentException' => [
-                'exception' => new InvalidArgumentException(new TestTranslatableExceptionMessage('one')),
-                'message' => 'one',
+                'caughtException' => new InvalidArgumentException(new TestTranslatableExceptionMessage('one')),
             ],
             'IOException' => [
-                'exception' => new IOException(new TestTranslatableExceptionMessage('two')),
-                'message' => 'two',
+                'caughtException' => new IOException(new TestTranslatableExceptionMessage('two')),
             ],
         ];
     }

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -191,28 +191,26 @@ final class StagerUnitTest extends TestCase
     }
 
     /** @dataProvider providerExceptions */
-    public function testExceptions(ExceptionInterface $exception, string $message): void
+    public function testExceptions(ExceptionInterface $caughtException): void
     {
         $this->composerRunner
             ->run(Argument::cetera())
-            ->willThrow($exception);
+            ->willThrow($caughtException);
         $sut = $this->createSut();
 
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->stage([self::INERT_COMMAND], PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-        }, RuntimeException::class, $message, $exception::class);
+        }, RuntimeException::class, $caughtException->getMessage(), null, $caughtException::class);
     }
 
     public function providerExceptions(): array
     {
         return [
             'IOException' => [
-                'exception' => new IOException(new TestTranslatableExceptionMessage('one')),
-                'message' => 'one',
+                'caughtException' => new IOException(new TestTranslatableExceptionMessage('one')),
             ],
             'LogicException' => [
-                'exception' => new LogicException(new TestTranslatableExceptionMessage('two')),
-                'message' => 'two',
+                'caughtException' => new LogicException(new TestTranslatableExceptionMessage('two')),
             ],
         ];
     }

--- a/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
@@ -243,8 +243,6 @@ final class PhpFileSyncerUnitTest extends FileSyncerTestCase
             $sut = $reflection->newInstanceWithoutConstructor();
             $environment = $reflection->getProperty('environment');
             $environment->setValue($sut, $this->environment->reveal());
-            $translatableFactory = $reflection->getProperty('translatableFactory');
-            $translatableFactory->setValue($sut, null);
 
             $sut->sync($samePath, $samePath);
         }, AssertionError::class, 'The "p()" method requires a translatable factory. '

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -217,16 +217,16 @@ final class RsyncFileSyncerUnitTest extends FileSyncerTestCase
      *
      * @dataProvider providerSyncFailure
      */
-    public function testSyncFailure(ExceptionInterface $caught, string $thrown): void
+    public function testSyncFailure(ExceptionInterface $caughtException, string $thrownException): void
     {
         $this->rsync
             ->run(Argument::cetera())
-            ->willThrow($caught);
+            ->willThrow($caughtException);
         $sut = $this->createSut();
 
         self::assertTranslatableException(function () use ($sut): void {
             $sut->sync($this->source, $this->destination);
-        }, $thrown, $caught->getMessage(), $caught::class);
+        }, $thrownException, $caughtException->getMessage(), null, $caughtException::class);
     }
 
     public function providerSyncFailure(): array
@@ -235,12 +235,12 @@ final class RsyncFileSyncerUnitTest extends FileSyncerTestCase
 
         return [
             'LogicException' => [
-                'caught' => new LogicException($message),
-                'thrown' => IOException::class,
+                'caughtException' => new LogicException($message),
+                'thrownException' => IOException::class,
             ],
             'RuntimeException' => [
-                'caught' => new RuntimeException($message),
-                'thrown' => IOException::class,
+                'caughtException' => new RuntimeException($message),
+                'thrownException' => IOException::class,
             ],
         ];
     }

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -80,7 +80,7 @@ final class FilesystemUnitTest extends TestCase
 
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->copy(PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-        }, IOException::class, $message, $previous::class);
+        }, IOException::class, $message, null, $previous::class);
     }
 
     /** @covers ::copy */
@@ -96,7 +96,7 @@ final class FilesystemUnitTest extends TestCase
         $message = sprintf('The source file does not exist or is not a file at %s', PathHelper::activeDirAbsolute());
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->copy(PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-        }, LogicException::class, $message, $previous);
+        }, LogicException::class, $message, null, $previous);
     }
 
     /** @covers ::copy */
@@ -134,7 +134,7 @@ final class FilesystemUnitTest extends TestCase
 
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->mkdir(PathHelper::stagingDirPath());
-        }, IOException::class, $message, $previous::class);
+        }, IOException::class, $message, null, $previous::class);
     }
 
     /**
@@ -183,6 +183,6 @@ final class FilesystemUnitTest extends TestCase
 
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->remove(PathHelper::stagingDirPath());
-        }, IOException::class, $message, $previous::class);
+        }, IOException::class, $message, null, $previous::class);
     }
 }

--- a/tests/Precondition/Service/ComposerIsAvailableFunctionalTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableFunctionalTest.php
@@ -61,7 +61,7 @@ final class ComposerIsAvailableFunctionalTest extends TestCase
         $message = ComposerNotFoundExecutableFinder::EXCEPTION_MESSAGE;
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath());
-        }, PreconditionException::class, $message, LogicException::class);
+        }, PreconditionException::class, $message, null, LogicException::class);
     }
 
     public function testInvalidComposerFound(): void

--- a/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
@@ -114,7 +114,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionTestCase
         );
         self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath): void {
             $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
-        }, PreconditionException::class, $message, $previous);
+        }, PreconditionException::class, $message, null, $previous);
     }
 
     /**

--- a/tests/Precondition/Service/PreconditionTestCase.php
+++ b/tests/Precondition/Service/PreconditionTestCase.php
@@ -88,6 +88,6 @@ abstract class PreconditionTestCase extends TestCase
 
         self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath, $timeout): void {
             $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout);
-        }, PreconditionException::class, $expectedStatusMessage, $previousException);
+        }, PreconditionException::class, $expectedStatusMessage, null, $previousException);
     }
 }

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -216,7 +216,7 @@ final class ProcessUnitTest extends TestCase
         $expectedExceptionMessage = sprintf('Failed to get process output: %s', $previous->getMessage());
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->getOutput();
-        }, LogicException::class, $expectedExceptionMessage, $previous::class);
+        }, LogicException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
     /** @covers ::getErrorOutput */
@@ -231,7 +231,7 @@ final class ProcessUnitTest extends TestCase
         $expectedExceptionMessage = sprintf('Failed to get process error output: %s', $previous->getMessage());
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->getErrorOutput();
-        }, LogicException::class, $expectedExceptionMessage, $previous::class);
+        }, LogicException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
     /** @covers ::mustRun */
@@ -246,7 +246,7 @@ final class ProcessUnitTest extends TestCase
         $expectedExceptionMessage = sprintf('Failed to run process: %s', $previous->getMessage());
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->mustRun();
-        }, RuntimeException::class, $expectedExceptionMessage, $previous::class);
+        }, RuntimeException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
     /**
@@ -265,7 +265,7 @@ final class ProcessUnitTest extends TestCase
         $expectedExceptionMessage = sprintf('Failed to run process: %s', $previous->getMessage());
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->run();
-        }, RuntimeException::class, $expectedExceptionMessage, $previous::class);
+        }, RuntimeException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
     public function providerRunException(): array
@@ -379,6 +379,6 @@ final class ProcessUnitTest extends TestCase
         $expectedExceptionMessage = sprintf('Failed to set process timeout: %s', $previous->getMessage());
         self::assertTranslatableException(static function () use ($sut): void {
             $sut->setTimeout();
-        }, InvalidArgumentException::class, $expectedExceptionMessage, $previous::class);
+        }, InvalidArgumentException::class, $expectedExceptionMessage, null, $previous::class);
     }
 }


### PR DESCRIPTION
This adds mutation testing with [Infection](https://infection.github.io/), including a new CI job that runs it. (It _should_ [automatically comment on pull requests](https://infection.github.io/guide/command-line-options.html#logger-github); we'll see.)

Also included are some changes to bring the mutation score up a little (from 82% to 89%) for illustration.

**Note**: This brings in some new transitive dev dependencies, which can be discussed separately:

| Dev Changes                              | From | To     | Compare |
|------------------------------------------|------|--------|---------|
| colinodell/json5                         | NEW  | v2.3.0 |         |
| fidry/cpu-core-counter                   | NEW  | 0.5.1  |         |
| infection/abstract-testframework-adapter | NEW  | 0.5.0  |         |
| infection/extension-installer            | NEW  | 0.1.2  |         |
| infection/include-interceptor            | NEW  | 0.2.5  |         |
| infection/infection                      | NEW  | 0.27.0 |         |
| ondram/ci-detector                       | NEW  | 4.1.0  |         |
| sanmai/later                             | NEW  | 0.1.2  |         |
| sanmai/pipeline                          | NEW  | v6.8.1 |         |
| thecodingmachine/safe                    | NEW  | v2.5.0 |         |