### PR TITLE
Add ComposerRequireChecker for transitive dependency detection

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -52,6 +52,7 @@
       <path value="$PROJECT_DIR$/vendor/jangregor/phpstan-prophecy" />
       <path value="$PROJECT_DIR$/vendor/justinrainbow/json-schema" />
       <path value="$PROJECT_DIR$/vendor/localheinz/diff" />
+      <path value="$PROJECT_DIR$/vendor/maglnet/composer-require-checker" />
       <path value="$PROJECT_DIR$/vendor/myclabs/deep-copy" />
       <path value="$PROJECT_DIR$/vendor/nikic/php-parser" />
       <path value="$PROJECT_DIR$/vendor/ondram/ci-detector" />

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "ergebnis/composer-normalize": "^2.33",
         "infection/infection": "^0.27.0",
         "jangregor/phpstan-prophecy": "^1.0",
+        "maglnet/composer-require-checker": "^4.6",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpbench/phpbench": "^1.2",
         "phpmd/phpmd": "^2.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "692bf646249d0cdc344034f3b2ac34a6",
+    "content-hash": "47990f0c8dfaa2e1ba92aa1684c44172",
     "packages": [
         {
             "name": "symfony/filesystem",
@@ -1909,6 +1909,86 @@
                 }
             ],
             "time": "2020-07-06T04:49:32+00:00"
+        },
+        {
+            "name": "maglnet/composer-require-checker",
+            "version": "4.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maglnet/ComposerRequireChecker.git",
+                "reference": "a5d4951d0839b57fb5dce1d6d0a6e36f23b2823f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maglnet/ComposerRequireChecker/zipball/a5d4951d0839b57fb5dce1d6d0a6e36f23b2823f",
+                "reference": "a5d4951d0839b57fb5dce1d6d0a6e36f23b2823f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0.0",
+                "ext-phar": "*",
+                "nikic/php-parser": "^4.15.2",
+                "php": "~8.1.0 || ~8.2.0",
+                "symfony/console": "^6.2.3",
+                "webmozart/assert": "^1.11.0",
+                "webmozart/glob": "^4.6.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11.0.0",
+                "ext-zend-opcache": "*",
+                "mikey179/vfsstream": "^1.6.11",
+                "phing/phing": "^2.17.4",
+                "phpstan/phpstan": "^1.9.4",
+                "phpunit/phpunit": "^9.5.27",
+                "roave/infection-static-analysis-plugin": "^1.27.0",
+                "vimeo/psalm": "^5.4.0"
+            },
+            "bin": [
+                "bin/composer-require-checker"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ComposerRequireChecker\\": "src/ComposerRequireChecker"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                },
+                {
+                    "name": "Matthias Glaub",
+                    "email": "magl@magl.net",
+                    "homepage": "http://magl.net"
+                }
+            ],
+            "description": "CLI tool to analyze composer dependencies and verify that no unknown symbols are used in the sources of a package",
+            "homepage": "https://github.com/maglnet/ComposerRequireChecker",
+            "keywords": [
+                "analysis",
+                "cli",
+                "composer",
+                "dependency",
+                "imports",
+                "require",
+                "requirements"
+            ],
+            "support": {
+                "issues": "https://github.com/maglnet/ComposerRequireChecker/issues",
+                "source": "https://github.com/maglnet/ComposerRequireChecker/tree/4.6.0"
+            },
+            "time": "2023-04-21T21:13:53+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -17,6 +17,7 @@ grumphp:
             level: 100
         composer: ~
         composer_normalize: ~
+        composer_require_checker: ~
         phpcs:
             standard: []
             whitelist_patterns:
@@ -64,6 +65,7 @@ grumphp:
             tasks:
                 - composer
                 - composer_normalize
+                - composer_require_checker
                 - phpcs
                 - phplint
                 - phpmd


### PR DESCRIPTION
[ComposerRequireChecker](https://github.com/maglnet/ComposerRequireChecker) detects direct dependence on transitive dependencies, or "soft" dependencies, i.e., those that are in the codebase only "coincidentally" because a direct dependency in turn requires them. Such dependencies can legitimately disappear with Composer updates and cause unpredictable failures. This adds static analysis detection of this.