### PR TITLE
Fix some untranslatable UI strings and add a PHPStan rule to prevent introducing any more

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,7 +19,7 @@ parameters:
         - tests
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: 007df614bcb782abcd5763502393410c
+    preconditionSystemHash: abea35f46ca341e6e7e961a393df3ca8
     translationSystemHash: 0df1e2f49634b4bf0b655f2eada7f493
     gitattributesExportInclude:
         - composer.json
@@ -109,6 +109,7 @@ parameters:
 rules:
     - PhpTuf\ComposerStager\PHPStan\Rules\Calls\NoCallingTranslatableFactoryDirectlyRule # Forbids calling TranslatableFactory::create() directly.
     - PhpTuf\ComposerStager\PHPStan\Rules\Calls\NoInstantiatingTranslatableDirectlyRule # Forbids instantiating translatables directly.
+    - PhpTuf\ComposerStager\PHPStan\Rules\Calls\ValidTranslatableStringsRule # Ensures that TranslatableAwareTrait::t() is only called with literal string messages.
     - PhpTuf\ComposerStager\PHPStan\Rules\Classes\FinalExceptionRule # Forbids exceptions from being final.
     - PhpTuf\ComposerStager\PHPStan\Rules\Classes\MissingExceptionInterfaceRule # Requires exceptions to implement ExceptionInterface.
     - PhpTuf\ComposerStager\PHPStan\Rules\Classes\MissingInterfaceRule # Requires concrete classes to implement an interface.

--- a/src/Internal/Precondition/Service/HostSupportsRunningProcesses.php
+++ b/src/Internal/Precondition/Service/HostSupportsRunningProcesses.php
@@ -35,8 +35,10 @@ final class HostSupportsRunningProcesses extends AbstractPrecondition implements
 
     public function getDescription(): TranslatableInterface
     {
-        return $this->t('The host must support running independent '
-            . 'PHP processes in order to run Composer and other shell commands.');
+        return $this->t(
+            // @phpcs:ignore Generic.Files.LineLength.TooLong
+            'The host must support running independent PHP processes in order to run Composer and other shell commands.',
+        );
     }
 
     protected function getFulfilledStatusMessage(): TranslatableInterface

--- a/src/Internal/Precondition/Service/NoAbsoluteSymlinksExist.php
+++ b/src/Internal/Precondition/Service/NoAbsoluteSymlinksExist.php
@@ -45,8 +45,8 @@ final class NoAbsoluteSymlinksExist extends AbstractFileIteratingPrecondition im
             throw new PreconditionException(
                 $this,
                 $this->t(
-                    'The %codebase_name directory at %codebase_root contains absolute links, '
-                    . 'which is not supported. The first one is %file.',
+                    // @phpcs:ignore Generic.Files.LineLength.TooLong
+                    'The %codebase_name directory at %codebase_root contains absolute links, which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
                         '%codebase_root' => $codebaseRoot->absolute(),

--- a/src/Internal/Precondition/Service/NoHardLinksExist.php
+++ b/src/Internal/Precondition/Service/NoHardLinksExist.php
@@ -38,8 +38,8 @@ final class NoHardLinksExist extends AbstractFileIteratingPrecondition implement
             throw new PreconditionException(
                 $this,
                 $this->t(
-                    'The %codebase_name directory at %codebase_root contains '
-                    . 'hard links, which is not supported. The first one is %file.',
+                    // @phpcs:ignore Generic.Files.LineLength.TooLong
+                    'The %codebase_name directory at %codebase_root contains hard links, which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
                         '%codebase_root' => $codebaseRoot->absolute(),

--- a/src/Internal/Precondition/Service/NoLinksExistOnWindows.php
+++ b/src/Internal/Precondition/Service/NoLinksExistOnWindows.php
@@ -53,8 +53,8 @@ final class NoLinksExistOnWindows extends AbstractFileIteratingPrecondition impl
             throw new PreconditionException(
                 $this,
                 $this->t(
-                    'The %codebase_name directory at %codebase_root contains links, '
-                    . 'which is not supported on Windows. The first one is %file.',
+                    // @phpcs:ignore Generic.Files.LineLength.TooLong
+                    'The %codebase_name directory at %codebase_root contains links, which is not supported on Windows. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
                         '%codebase_root' => $codebaseRoot->absolute(),

--- a/src/Internal/Precondition/Service/NoSymlinksPointOutsideTheCodebase.php
+++ b/src/Internal/Precondition/Service/NoSymlinksPointOutsideTheCodebase.php
@@ -43,8 +43,8 @@ final class NoSymlinksPointOutsideTheCodebase extends AbstractFileIteratingPreco
             throw new PreconditionException(
                 $this,
                 $this->t(
-                    'The %codebase_name directory at %codebase_root contains links that point outside the codebase, '
-                    . 'which is not supported. The first one is %file.',
+                    // @phpcs:ignore Generic.Files.LineLength.TooLong
+                    'The %codebase_name directory at %codebase_root contains links that point outside the codebase, which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
                         '%codebase_root' => $codebaseRoot->absolute(),

--- a/src/Internal/Precondition/Service/NoSymlinksPointToADirectory.php
+++ b/src/Internal/Precondition/Service/NoSymlinksPointToADirectory.php
@@ -75,8 +75,8 @@ final class NoSymlinksPointToADirectory extends AbstractFileIteratingPreconditio
             throw new PreconditionException(
                 $this,
                 $this->t(
-                    'The %codebase_name directory at %codebase_root contains symlinks that point to a directory, '
-                    . 'which is not supported. The first one is %file.',
+                    // @phpcs:ignore Generic.Files.LineLength.TooLong
+                    'The %codebase_name directory at %codebase_root contains symlinks that point to a directory, which is not supported. The first one is %file.',
                     $this->p([
                         '%codebase_name' => $codebaseName,
                         '%codebase_root' => $codebaseRoot->absolute(),

--- a/tools/PHPStan/Rules/Calls/ValidTranslatableStringsRule.php
+++ b/tools/PHPStan/Rules/Calls/ValidTranslatableStringsRule.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+namespace PhpTuf\ComposerStager\PHPStan\Rules\Calls;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
+
+/**
+ * Ensures that TranslatableAwareTrait::t() is only called with literal string messages.
+ *
+ * @see https://github.com/php-tuf/composer-stager/issues/123 Add support for string translation for names, descriptions, and messages
+ */
+final class ValidTranslatableStringsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof MethodCall);
+
+        if (!$this->methodCallIsInScope($node, $scope)) {
+            return [];
+        }
+
+        if ($this->messageArgIsAString($node)) {
+            return [];
+        }
+
+        // The only exception to the rule is using the error message from a caught
+        // exception, which, of course, is impossible to extract translatable strings from.
+        if ($this->messageArgIsACaughtExceptionMessage($node)) {
+            return [];
+        }
+
+        return [
+            sprintf(
+                'The "$message" argument of the "t()" method can only be a literal string--no variables, concatenation, constants, or method calls--i.e., "Scalar_String". Got "%s".',
+                $this->getArgType($node),
+            ),
+        ];
+    }
+
+    /** Determines whether the method call is in scope for analysis. */
+    private function methodCallIsInScope(MethodCall $node, Scope $scope): bool
+    {
+        if (!$this->isInSrcDir($scope)) {
+            return false;
+        }
+
+        if (!$this->usesTranslatableAwareTrait($scope)) {
+            return false;
+        }
+
+        if (!$this->isTMethod($node)) {
+            return false;
+        }
+
+        // Treat a missing "$message" argument as out of scope. Other rules will catch that.
+        if ($this->isMissingMessageArgument($node)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /** Determines whether the class is in the "src" directory. */
+    private function isInSrcDir(Scope $scope): bool
+    {
+        $filename = $scope->getFile();
+        $srcDir = dirname(__DIR__, 4) . '/src/';
+
+        return str_starts_with($filename, $srcDir);
+    }
+
+    /** Determines whether the class uses "TranslatableAwareTrait". */
+    private function usesTranslatableAwareTrait(Scope $scope): bool
+    {
+        $class = $scope->getClassReflection();
+        assert($class instanceof ClassReflection);
+
+        return $class->hasTraitUse(TranslatableAwareTrait::class);
+    }
+
+    /** Determines whether the method call is the ::t() method. */
+    private function isTMethod(MethodCall $node): bool
+    {
+        $methodName = (string) $node->name;
+
+        return $methodName === 't';
+    }
+
+    /** Determines whether the method call is missing the "$message" argument. */
+    private function isMissingMessageArgument(MethodCall $node): bool
+    {
+        $arguments = $node->getArgs();
+
+        return $arguments === [];
+    }
+
+    /** Determines whether the method call is valid. */
+    private function messageArgIsAString(MethodCall $node): bool
+    {
+        // For compatibility with Drupal's {@see https://www.drupal.org/project/potx
+        // Translation Template Extractor}, ONLY literal strings are allowed.
+        // @see https://git.drupalcode.org/project/potx/-/blob/4685dd0e85989987953ba291ea804e7b0a9a27fc/potx.inc#L906
+        return $this->getArgType($node) === 'Scalar_String';
+    }
+
+    /**
+     * Determines whether the method call is a caught exception message.
+     *
+     * Like this:
+     * ```
+     * } catch (Throwable $e) {
+     *     throw new Exception($this->t($e->getMessage()));
+     * }
+     * ```
+     */
+    private function messageArgIsACaughtExceptionMessage(MethodCall $node): bool
+    {
+        // This code may be a little clumsy, but it essentially works and minimizes false
+        // positives. It basically just checks that the method call is inside a "throw"
+        // statement. It could be improved by further verifying that the "$message" argument
+        // is specifically a call to `::getMessage()` on a caught exception variable. Until
+        // then, ANY non-string will pass this check.
+        while ($node = $node->getAttribute('parent')) {
+            if ($node instanceof Node\Stmt\Throw_) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** Gets the type of the method call argument. */
+    private function getArgType(MethodCall $node): string
+    {
+        $arguments = $node->getArgs();
+
+        // Get the first argument.
+        $argument = reset($arguments);
+        assert($argument instanceof Arg);
+
+        return $argument->value->getType();
+    }
+}


### PR DESCRIPTION
This new rule requires that all `$message` arguments to `Internal\Translation\Factory\TranslatableAwareTrait::t()` are literal strings. It also merges concatenated messages already in the codebase, because, while researching this issue, I discovered that those are not supported by Drupal's [Translation Template Extractor](https://www.drupal.org/project/potx). (Double win!)