### PR TITLE
Stop trying to convert `fileperms()` result in `Internal\Filesystem\Service\Filesystem::filePerms()`

### DIFF
--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -49,8 +49,8 @@ interface FilesystemInterface
      *   The path to get permissions for.
      *
      * @return int
-     *   Returns the file's permissions as a numeric mode, e.g., 644 or 775.
-     *   See {@see https://www.php.net/manual/en/function.fileperms.php}.
+     *   Returns the file's permissions. See
+     *   {@see https://www.php.net/manual/en/function.fileperms.php}.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\IOException
      *    If case of failure.

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -93,9 +93,7 @@ final class Filesystem implements FilesystemInterface
         $permissions = @fileperms($pathAbsolute);
 
         if (is_int($permissions)) {
-            $permissions = substr(sprintf('%o', $permissions), -4);
-
-            return (int) octdec($permissions);
+            return $permissions;
         }
 
         if (!$this->symfonyFilesystem->exists($pathAbsolute)) {

--- a/tests/Filesystem/Service/FilesystemFunctionalTest.php
+++ b/tests/Filesystem/Service/FilesystemFunctionalTest.php
@@ -55,26 +55,30 @@ final class FilesystemFunctionalTest extends TestCase
      *
      * @group no_windows
      */
-    public function testFilePerms(int $permissions): void
+    public function testFilePerms(int $mode, int $expected): void
     {
         $file = PathHelper::createPath('file.txt', PathHelper::sourceDirAbsolute());
         $fileAbsolute = $file->absolute();
         touch($fileAbsolute);
-        chmod($fileAbsolute, $permissions);
+        chmod($fileAbsolute, $mode);
         $sut = $this->createSut();
 
         $actual = $sut->filePerms($file);
 
-        self::assertSame($permissions, $actual, 'Got correct permissions.');
+        self::assertSame($expected, $actual, 'Got correct permissions.');
     }
 
     public function providerFilePerms(): array
     {
         return [
-            [644],
-            [666],
-            [755],
-            [775],
+            // Decimal modes.
+            [644, 33_412],
+            [755, 33_523],
+            [775, 33_543],
+            // Octal modes.
+            [0644, 33_188],
+            [0755, 33_261],
+            [0775, 33_277],
         ];
     }
 


### PR DESCRIPTION
`Filesystem::filePerms()` currently tries to convert the result of `fileperms()` into a three digit mode value, but this turns out to be unreliable given octal permissions--and it diverges from the behavior of its corresponding PHP core function, `fileperms()`, anyway. Just stop doing any conversion at all.