### PR TITLE
Replace `API\Filesystem\Service\FilesystemInterface::filePerms()` with `::fileMode()`

### DIFF
--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -59,41 +59,36 @@ interface FilesystemInterface
     public function exists(PathInterface $path): bool;
 
     /**
-     * Gets file permissions for a given path.
+     * Gets the mode (permissions) of a given file or directory.
      *
-     * This function returns permissions exactly as PHP's built-in `fileperms()` function, which is not necessarily
-     * intuitive. Specifically, it returns an integer with no obvious relationship to any value usable with `chmod()`.
-     *
-     * For logical and comparison purposes, use an octal value:
+     * This function returns the file mode in octal form, e.g., 0644 or
+     * 0775. It can be used directly for comparison, for example:
      *   ```php
-     *   chmod($file, 0644);
-     *   $permissions = $sut->filePerms($file);
-     *   $octal = $permissions & 0777; // This is always and only 0777.
-     *   assert($octal === 0644); // true
+     *   chmod($fileAbsolute, 0644);
+     *   $mode = $filesystem->fileMode($filePath);
+     *   assert($mode === 0644); // true
      *   ```
      *
-     * For human-readable display purposes, use a string:
+     * For human-readable display purposes, convert it to a string:
      *   ```php
-     *   chmod($file, 0644);
-     *   $permissions = $sut->filePerms($file);
-     *   $string = substr(sprintf('%o', $permissions), -4)
-     *   assert($string === "0644"); // true
+     *   chmod($fileAbsolute, 0644);
+     *   $mode = $filesystem->fileMode($filePath);
+     *   $mode = substr(sprintf('0%o', $mode), -4);
+     *   assert($mode === "0644"); // true
      *   ```
      *
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $path
-     *   The path to get permissions for.
+     *   The path to get the mode for.
      *
      * @return int
-     *   Returns the file's permissions. See above.
+     *   Returns the file's mode. See above.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\IOException
      *    If case of failure.
      * @throws \PhpTuf\ComposerStager\API\Exception\LogicException
      *    If the file does not exist.
-     *
-     * @see https://www.php.net/manual/en/function.fileperms.php for more on return values.
      */
-    public function filePerms(PathInterface $path): int;
+    public function fileMode(PathInterface $path): int;
 
     /**
      * Determines whether the given path is a directory.

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -111,14 +111,14 @@ final class Filesystem implements FilesystemInterface
         return $this->getFileType($path) !== self::PATH_DOES_NOT_EXIST;
     }
 
-    public function filePerms(PathInterface $path): int
+    public function fileMode(PathInterface $path): int
     {
         $pathAbsolute = $path->absolute();
 
         $permissions = @fileperms($pathAbsolute);
 
         if (is_int($permissions)) {
-            return $permissions;
+            return $permissions & 0777;
         }
 
         if (!$this->symfonyFilesystem->exists($pathAbsolute)) {

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -145,11 +145,11 @@ final class FilesystemUnitTest extends TestCase
     }
 
     /**
-     * @covers ::filePerms
+     * @covers ::fileMode
      *
      * @runInSeparateProcess
      */
-    public function testFilePermsFailure(): void
+    public function testFileModeFailure(): void
     {
         $this->mockGlobalFunctions();
 
@@ -167,7 +167,7 @@ final class FilesystemUnitTest extends TestCase
 
         $message = sprintf('Failed to get permissions on path at %s', $path->absolute());
         self::assertTranslatableException(static function () use ($sut, $path): void {
-            $sut->filePerms($path);
+            $sut->fileMode($path);
         }, IOException::class, $message);
     }
 

--- a/tests/TestUtils/AssertTrait.php
+++ b/tests/TestUtils/AssertTrait.php
@@ -68,14 +68,18 @@ trait AssertTrait
         self::assertEquals($expected, $actual, $message);
     }
 
-    protected static function assertFilePerms(string $path, int $permissions): void
+    protected static function assertFileMode(string $path, int $mode): void
     {
         assert(PathHelper::isAbsolute($path));
         assert(FilesystemHelper::exists($path));
 
-        $actual = FilesystemHelper::filePerms($path);
+        $actual = FilesystemHelper::fileMode($path);
 
-        self::assertSame($permissions, $actual, sprintf('File has expected permissions (%d).', $permissions));
+        self::assertSame(
+            substr(sprintf('0%o', $mode), -4),
+            substr(sprintf('0%o', $actual), -4),
+            sprintf('File has expected permissions (0%o).', $mode),
+        );
     }
 
     /** Asserts that two translatables are equivalent, i.e., have the same properties. */


### PR DESCRIPTION
File permissions as returned by PHP's built-in `fileperms()` function turn out to be very unintuitive and require a lot of boilerplate to make them actually useful. This replaces the "pass-through" `::filePerms()` method with a more useful `::fileMode()` that returns an actual octal value.