### PR TITLE
Rename `FilesystemInterface::exists()` to `::fileExists()`

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,7 +18,7 @@ parameters:
         - src
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: 7e28694cff723f06c55f41e37c733791
+    preconditionSystemHash: 4940948a7d37d84c42062ddc519aec4f
     translationSystemHash: 0df1e2f49634b4bf0b655f2eada7f493
     gitattributesExportInclude:
         - composer.json

--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -9,6 +9,9 @@ use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 /**
  * Provides basic utilities for interacting with the file system.
  *
+ * Developer's note: This interface and its method names should correspond as much as possible to
+ * PHP's built-in filesystem functions at {@see https://www.php.net/manual/en/book.filesystem.php}.
+ *
  * @package Filesystem
  *
  * @api This interface is subject to our backward compatibility promise and may be safely depended upon.
@@ -57,7 +60,7 @@ interface FilesystemInterface
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $path
      *   A path to test.
      */
-    public function exists(PathInterface $path): bool;
+    public function fileExists(PathInterface $path): bool;
 
     /**
      * Gets the mode (permissions) of a given file or directory.

--- a/src/Internal/FileSyncer/Service/PhpFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/PhpFileSyncer.php
@@ -70,7 +70,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
     /** @throws \PhpTuf\ComposerStager\API\Exception\LogicException */
     private function assertSourceExists(PathInterface $source): void
     {
-        if (!$this->filesystem->exists($source)) {
+        if (!$this->filesystem->fileExists($source)) {
             throw new LogicException($this->t(
                 'The source directory does not exist at %path',
                 $this->p(['%path' => $source->absolute()]),
@@ -104,7 +104,7 @@ final class PhpFileSyncer implements PhpFileSyncerInterface
             $relativePathname = self::getRelativePath($destinationAbsolute, $destinationFilePathname);
             $sourceFilePath = $this->pathFactory->create($relativePathname, $source);
 
-            if ($this->filesystem->exists($sourceFilePath)) {
+            if ($this->filesystem->fileExists($sourceFilePath)) {
                 continue;
             }
 

--- a/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
@@ -77,7 +77,7 @@ final class RsyncFileSyncer implements RsyncFileSyncerInterface
     /** @throws \PhpTuf\ComposerStager\API\Exception\LogicException */
     private function assertSourceExists(PathInterface $source): void
     {
-        if (!$this->filesystem->exists($source)) {
+        if (!$this->filesystem->fileExists($source)) {
             throw new LogicException($this->t(
                 'The source directory does not exist at %path',
                 $this->p(['%path' => $source->absolute()]),

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -113,7 +113,7 @@ final class Filesystem implements FilesystemInterface
         }
     }
 
-    public function exists(PathInterface $path): bool
+    public function fileExists(PathInterface $path): bool
     {
         return $this->getFileType($path) !== self::PATH_DOES_NOT_EXIST;
     }

--- a/src/Internal/Precondition/Service/AbstractFileIteratingPrecondition.php
+++ b/src/Internal/Precondition/Service/AbstractFileIteratingPrecondition.php
@@ -97,7 +97,7 @@ abstract class AbstractFileIteratingPrecondition extends AbstractPrecondition
     private function findFiles(PathInterface $path, PathListInterface $exclusions): array
     {
         // Ignore non-existent directories.
-        if (!$this->filesystem->exists($path)) {
+        if (!$this->filesystem->fileExists($path)) {
             return [];
         }
 

--- a/src/Internal/Precondition/Service/ActiveDirExists.php
+++ b/src/Internal/Precondition/Service/ActiveDirExists.php
@@ -48,7 +48,7 @@ final class ActiveDirExists extends AbstractPrecondition implements ActiveDirExi
         ?PathListInterface $exclusions = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        if (!$this->filesystem->exists($activeDir)) {
+        if (!$this->filesystem->fileExists($activeDir)) {
             throw new PreconditionException($this, $this->t(
                 'The active directory does not exist.',
                 null,

--- a/src/Internal/Precondition/Service/StagingDirDoesNotExist.php
+++ b/src/Internal/Precondition/Service/StagingDirDoesNotExist.php
@@ -48,7 +48,7 @@ final class StagingDirDoesNotExist extends AbstractPrecondition implements Stagi
         ?PathListInterface $exclusions = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        if ($this->filesystem->exists($stagingDir)) {
+        if ($this->filesystem->fileExists($stagingDir)) {
             throw new PreconditionException($this, $this->t(
                 'The staging directory already exists.',
                 null,

--- a/src/Internal/Precondition/Service/StagingDirExists.php
+++ b/src/Internal/Precondition/Service/StagingDirExists.php
@@ -48,7 +48,7 @@ final class StagingDirExists extends AbstractPrecondition implements StagingDirE
         ?PathListInterface $exclusions = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
-        if (!$this->filesystem->exists($stagingDir)) {
+        if (!$this->filesystem->fileExists($stagingDir)) {
             throw new PreconditionException($this, $this->t(
                 'The staging directory does not exist.',
                 null,

--- a/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/PhpFileSyncerUnitTest.php
@@ -34,7 +34,7 @@ final class PhpFileSyncerUnitTest extends FileSyncerUnitTestCase
         $this->fileFinder = $this->prophesize(FileFinderInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
-            ->exists(Argument::any())
+            ->fileExists(Argument::any())
             ->willReturn(true);
         $this->filesystem
             ->isDirEmpty(Argument::any())
@@ -60,7 +60,7 @@ final class PhpFileSyncerUnitTest extends FileSyncerUnitTestCase
     public function testSyncSourceNotFound(): void
     {
         $this->filesystem
-            ->exists(PathHelper::sourceDirPath())
+            ->fileExists(PathHelper::sourceDirPath())
             ->willReturn(false);
         $sut = $this->createSut();
 

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -43,7 +43,7 @@ final class RsyncFileSyncerUnitTest extends FileSyncerUnitTestCase
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
-            ->exists(Argument::any())
+            ->fileExists(Argument::any())
             ->willReturn(true);
         $this->filesystem
             ->mkdir(Argument::any());
@@ -243,7 +243,7 @@ final class RsyncFileSyncerUnitTest extends FileSyncerUnitTestCase
     public function testSyncSourceDirectoryNotFound(): void
     {
         $this->filesystem
-            ->exists(Argument::any())
+            ->fileExists(Argument::any())
             ->willReturn(false);
         $sut = $this->createSut();
 

--- a/tests/Filesystem/Service/FilesystemFunctionalTest.php
+++ b/tests/Filesystem/Service/FilesystemFunctionalTest.php
@@ -248,7 +248,7 @@ final class FilesystemFunctionalTest extends TestCase
     }
 
     /**
-     * @covers ::exists
+     * @covers ::fileExists
      * @covers ::getFileType
      * @covers ::isDir
      * @covers ::isFile
@@ -278,7 +278,7 @@ final class FilesystemFunctionalTest extends TestCase
         $subject = PathHelper::createPath($subject, PathHelper::sourceDirAbsolute());
         $sut = $this->createSut();
 
-        $actualExists = $sut->exists($subject);
+        $actualExists = $sut->fileExists($subject);
         $actualIsDir = $sut->isDir($subject);
         $actualIsFile = $sut->isFile($subject);
         $actualIsLink = $sut->isLink($subject);

--- a/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
+++ b/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
@@ -38,7 +38,7 @@ final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreco
             ->willReturn([]);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
-            ->exists(Argument::type(PathInterface::class))
+            ->fileExists(Argument::type(PathInterface::class))
             ->willReturn(true);
         $this->pathFactory = $this->prophesize(PathFactoryInterface::class);
 
@@ -117,7 +117,7 @@ final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreco
         $stagingDirPath = PathHelper::stagingDirPath();
 
         $this->filesystem
-            ->exists(Argument::cetera())
+            ->fileExists(Argument::cetera())
             ->shouldNotBeCalled();
         $this->fileFinder
             ->find(Argument::cetera())

--- a/tests/Precondition/Service/ActiveDirExistsUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirExistsUnitTest.php
@@ -45,7 +45,7 @@ final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
     public function testFulfilled(): void
     {
         $this->filesystem
-            ->exists(PathHelper::activeDirPath())
+            ->fileExists(PathHelper::activeDirPath())
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn(true);
 
@@ -57,7 +57,7 @@ final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
     {
         $message = 'The active directory does not exist.';
         $this->filesystem
-            ->exists(PathHelper::activeDirPath())
+            ->fileExists(PathHelper::activeDirPath())
             ->willReturn(false);
 
         $this->doTestUnfulfilled($message);

--- a/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
+++ b/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
@@ -42,7 +42,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
             ->willReturn([]);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
-            ->exists(Argument::type(PathInterface::class))
+            ->fileExists(Argument::type(PathInterface::class))
             ->willReturn(true);
         $this->pathFactory = $this->prophesize(PathFactoryInterface::class);
 
@@ -53,7 +53,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
     public function testExitEarly(): void
     {
         $this->filesystem
-            ->exists(Argument::cetera())
+            ->fileExists(Argument::cetera())
             ->shouldNotBeCalled();
         $this->fileFinder
             ->find(Argument::cetera())
@@ -122,7 +122,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         $stagingDirPath = PathHelper::stagingDirPath();
 
         $this->filesystem
-            ->exists($activeDirPath)
+            ->fileExists($activeDirPath)
             ->willReturn(false);
         $sut = $this->createSut();
 
@@ -139,7 +139,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         $stagingDirPath = PathHelper::stagingDirPath();
 
         $this->filesystem
-            ->exists($stagingDirPath)
+            ->fileExists($stagingDirPath)
             ->willReturn(false);
         $sut = $this->createSut();
 

--- a/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
+++ b/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
@@ -55,7 +55,7 @@ final class NoLinksExistOnWindowsUnitTest extends FileIteratingPreconditionUnitT
             ->isWindows()
             ->willReturn(false);
         $this->filesystem
-            ->exists(Argument::cetera())
+            ->fileExists(Argument::cetera())
             ->shouldNotBeCalled();
         $this->fileFinder
             ->find(Argument::cetera())

--- a/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
@@ -32,7 +32,7 @@ final class NoSymlinksPointOutsideTheCodebaseUnitTest extends FileIteratingPreco
             ->willReturn([]);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
-            ->exists(Argument::type(PathInterface::class))
+            ->fileExists(Argument::type(PathInterface::class))
             ->willReturn(true);
         $this->pathFactory = $this->prophesize(PathFactoryInterface::class);
 

--- a/tests/Precondition/Service/NoSymlinksPointToADirectoryUnitTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointToADirectoryUnitTest.php
@@ -42,7 +42,7 @@ final class NoSymlinksPointToADirectoryUnitTest extends FileIteratingPreconditio
             ->willReturn([]);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->filesystem
-            ->exists(Argument::type(PathInterface::class))
+            ->fileExists(Argument::type(PathInterface::class))
             ->willReturn(true);
         $this->fileSyncer = $this->prophesize(PhpFileSyncerInterface::class);
         $this->fileSyncerFactory = $this->prophesize(FileSyncerFactoryInterface::class);
@@ -73,7 +73,7 @@ final class NoSymlinksPointToADirectoryUnitTest extends FileIteratingPreconditio
 
         $this->fileSyncer = $this->prophesize(RsyncFileSyncerInterface::class);
         $this->filesystem
-            ->exists(Argument::cetera())
+            ->fileExists(Argument::cetera())
             ->shouldNotBeCalled();
         $this->fileFinder
             ->find(Argument::cetera())

--- a/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
+++ b/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
@@ -46,7 +46,7 @@ final class StagingDirDoesNotExistUnitTest extends PreconditionUnitTestCase
     public function testFulfilled(): void
     {
         $this->filesystem
-            ->exists(PathHelper::stagingDirPath())
+            ->fileExists(PathHelper::stagingDirPath())
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn(false);
 
@@ -58,7 +58,7 @@ final class StagingDirDoesNotExistUnitTest extends PreconditionUnitTestCase
     {
         $message = 'The staging directory already exists.';
         $this->filesystem
-            ->exists(PathHelper::stagingDirPath())
+            ->fileExists(PathHelper::stagingDirPath())
             ->willReturn(true);
 
         $this->doTestUnfulfilled($message);

--- a/tests/Precondition/Service/StagingDirExistsUnitTest.php
+++ b/tests/Precondition/Service/StagingDirExistsUnitTest.php
@@ -46,7 +46,7 @@ final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
     public function testFulfilled(): void
     {
         $this->filesystem
-            ->exists(PathHelper::stagingDirPath())
+            ->fileExists(PathHelper::stagingDirPath())
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn(true);
 
@@ -58,7 +58,7 @@ final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
     {
         $message = 'The staging directory does not exist.';
         $this->filesystem
-            ->exists(PathHelper::stagingDirPath())
+            ->fileExists(PathHelper::stagingDirPath())
             ->willReturn(false);
 
         $this->doTestUnfulfilled($message);


### PR DESCRIPTION
...for closer correspondence to [PHP's built-in filesystem function names](https://www.php.net/manual/en/ref.filesystem.php).