### PR TITLE
Remove `API\Filesystem\Service\FilesystemInterface::isDirEmpty()`

### DIFF
--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -121,17 +121,6 @@ interface FilesystemInterface
     public function isDir(PathInterface $path): bool;
 
     /**
-     * Determines whether the given directory is empty.
-     *
-     * @return bool
-     *   Returns true if the directory is empty, false otherwise.
-     *
-     * @throws \PhpTuf\ComposerStager\API\Exception\IOException
-     *   If the directory does not exist or is not actually a directory.
-     */
-    public function isDirEmpty(PathInterface $path): bool;
-
-    /**
      * Determines whether the given path is a regular file.
      *
      * Unlike PHP's built-in is_file() function, this method distinguishes

--- a/src/Internal/FileSyncer/Service/PhpFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/PhpFileSyncer.php
@@ -56,7 +56,7 @@ final class PhpFileSyncer extends AbstractFileSyncer implements PhpFileSyncerInt
         PathListInterface $exclusions,
     ): void {
         // There's no reason to look for deletions if the destination is already empty.
-        if ($this->filesystem->isDirEmpty($destination)) {
+        if ($this->isDirEmpty($destination)) {
             return;
         }
 
@@ -77,6 +77,15 @@ final class PhpFileSyncer extends AbstractFileSyncer implements PhpFileSyncerInt
             // If it doesn't exist in the source, delete it from the destination.
             $this->filesystem->remove($destinationFilePath);
         }
+    }
+
+    private function isDirEmpty(PathInterface $path): bool
+    {
+        // `scandir()` can technically generate an error if a directory doesn't exist,
+        // but at this point in the code it has already been ensured that it does.
+        $scandir = @scandir($path->absolute());
+
+        return $scandir === ['.', '..'];
     }
 
     /**

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -146,21 +146,6 @@ final class Filesystem implements FilesystemInterface
         return $this->getFileType($path) === self::PATH_IS_DIRECTORY;
     }
 
-    public function isDirEmpty(PathInterface $path): bool
-    {
-        $scandir = @scandir($path->absolute());
-
-        if ($scandir === false) {
-            throw new IOException($this->t(
-                'The path does not exist or is not a directory at %path',
-                $this->p(['%path' => $path->absolute()]),
-                $this->d()->exceptions(),
-            ));
-        }
-
-        return $scandir === ['.', '..'];
-    }
-
     public function isFile(PathInterface $path): bool
     {
         return $this->getFileType($path) === self::PATH_IS_REGULAR_FILE;

--- a/tests/FileSyncer/Service/FileSyncerFunctionalTestCase.php
+++ b/tests/FileSyncer/Service/FileSyncerFunctionalTestCase.php
@@ -39,6 +39,7 @@ abstract class FileSyncerFunctionalTestCase extends TestCase
      * @covers \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer::copySourceFilesToDestination
      * @covers \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer::deleteExtraneousFilesFromDestination
      * @covers \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer::doSync
+     * @covers \PhpTuf\ComposerStager\Internal\FileSyncer\Service\PhpFileSyncer::isDirEmpty
      * @covers \PhpTuf\ComposerStager\Internal\FileSyncer\Service\RsyncFileSyncer::doSync
      *
      * @dataProvider providerBasicFunctionality

--- a/tests/Filesystem/Service/FilesystemFunctionalTest.php
+++ b/tests/Filesystem/Service/FilesystemFunctionalTest.php
@@ -203,54 +203,6 @@ final class FilesystemFunctionalTest extends TestCase
         self::assertSame("0644", $mode, 'The second code example works.');
     }
 
-    /** @covers ::isDirEmpty */
-    public function testIsDirEmptyTrue(): void
-    {
-        $directoryPath = VfsHelper::arbitraryDirPath();
-        FilesystemHelper::createDirectories($directoryPath->absolute());
-        $sut = $this->createSut();
-
-        self::assertTrue($sut->isDirEmpty($directoryPath), 'Correctly detected empty directory.');
-
-        FilesystemHelper::remove(PathHelper::testPersistentFixturesAbsolute());
-    }
-
-    /** @covers ::isDirEmpty */
-    public function testIsDirEmptyFalse(): void
-    {
-        $directoryPath = PathHelper::createPath(__DIR__);
-        $sut = $this->createSut();
-
-        self::assertFalse($sut->isDirEmpty($directoryPath), 'Correctly detected non-empty directory.');
-    }
-
-    /** @covers ::isDirEmpty */
-    public function testIsDirEmptyErrorIsNotADirectory(): void
-    {
-        $filePath = PathHelper::createPath(__FILE__);
-        $message = sprintf(
-            'The path does not exist or is not a directory at %s',
-            $filePath->absolute(),
-        );
-        $sut = $this->createSut();
-
-        self::assertTranslatableException(static function () use ($sut, $filePath): void {
-            $sut->isDirEmpty($filePath);
-        }, IOException::class, $message);
-    }
-
-    /** @covers ::isDirEmpty */
-    public function testIsDirEmptyError(): void
-    {
-        $path = VfsHelper::nonExistentFilePath();
-        $sut = $this->createSut();
-
-        $message = sprintf('The path does not exist or is not a directory at %s', $path->absolute());
-        self::assertTranslatableException(static function () use ($sut, $path): void {
-            $sut->isDirEmpty($path);
-        }, IOException::class, $message);
-    }
-
     /**
      * @covers ::fileExists
      * @covers ::getFileType

--- a/tests/TestUtils/VfsHelper.php
+++ b/tests/TestUtils/VfsHelper.php
@@ -28,6 +28,16 @@ final class VfsHelper
         return new Path($path, new Path(self::ROOT_DIR));
     }
 
+    public static function rootDirAbsolute(): string
+    {
+        return self::ROOT_DIR;
+    }
+
+    public static function rootDirPath(): PathInterface
+    {
+        return self::createPath(self::ROOT_DIR);
+    }
+
     public static function activeDirRelative(): string
     {
         return self::ACTIVE_DIR;


### PR DESCRIPTION
It's only used in one place, and it doesn't fit nicely into the design intent of "corresponding as much as possible to PHP's built-in filesystem functions".