### PR TITLE
Rename `Internal\Filesystem\Service\Filesystem::remote()` to `::rm()`

### DIFF
--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -229,10 +229,10 @@ interface FilesystemInterface
     public function readLink(PathInterface $path): PathInterface;
 
     /**
-     * Removes the given path.
+     * Recursively deletes a file or directory at the given path.
      *
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $path
-     *   A path to remove.
+     *   A path to delete.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int $timeout
@@ -240,9 +240,12 @@ interface FilesystemInterface
      *   zero (0), no time limit is imposed.
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\IOException
-     *   If the file cannot be removed.
+     *   If the path cannot be deleted.
+     *
+     * @see https://www.php.net/manual/en/function.rmdir.php
+     * @see https://www.php.net/manual/en/function.unlink.php
      */
-    public function remove(
+    public function rm(
         PathInterface $path,
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,

--- a/src/Internal/Core/Cleaner.php
+++ b/src/Internal/Core/Cleaner.php
@@ -33,7 +33,7 @@ final class Cleaner implements CleanerInterface
         $this->preconditions->assertIsFulfilled($activeDir, $stagingDir, null, $timeout);
 
         try {
-            $this->filesystem->remove($stagingDir, $callback, $timeout);
+            $this->filesystem->rm($stagingDir, $callback, $timeout);
         } catch (IOException $e) {
             throw new RuntimeException($e->getTranslatableMessage(), 0, $e);
         }

--- a/src/Internal/FileSyncer/Service/PhpFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/PhpFileSyncer.php
@@ -79,7 +79,7 @@ final class PhpFileSyncer extends AbstractFileSyncer implements PhpFileSyncerInt
             }
 
             // If it doesn't exist in the source, delete it from the destination.
-            $this->filesystem->remove($destinationFilePath);
+            $this->filesystem->rm($destinationFilePath);
         }
     }
 

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -210,7 +210,7 @@ final class Filesystem implements FilesystemInterface
         return $this->pathFactory->create($target, $basePath);
     }
 
-    public function remove(
+    public function rm(
         PathInterface $path,
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,

--- a/tests/Core/CleanerUnitTest.php
+++ b/tests/Core/CleanerUnitTest.php
@@ -50,7 +50,7 @@ final class CleanerUnitTest extends TestCase
             ->assertIsFulfilled(PathHelper::activeDirPath(), PathHelper::stagingDirPath(), null, $timeout)
             ->shouldBeCalledOnce();
         $this->filesystem
-            ->remove(PathHelper::stagingDirPath(), null, $timeout)
+            ->rm(PathHelper::stagingDirPath(), null, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -69,7 +69,7 @@ final class CleanerUnitTest extends TestCase
             ->assertIsFulfilled(PathHelper::activeDirPath(), $path, null, $timeout)
             ->shouldBeCalledOnce();
         $this->filesystem
-            ->remove($path, $callback, $timeout)
+            ->rm($path, $callback, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -113,7 +113,7 @@ final class CleanerUnitTest extends TestCase
         $message = new TestTranslatableExceptionMessage(__METHOD__);
         $previous = new IOException($message);
         $this->filesystem
-            ->remove(Argument::cetera())
+            ->rm(Argument::cetera())
             ->willThrow($previous);
         $sut = $this->createSut();
 

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -337,7 +337,7 @@ final class FilesystemUnitTest extends TestCase
     }
 
     /**
-     * @covers ::remove
+     * @covers ::rm
      *
      * @dataProvider providerRemove
      */
@@ -351,7 +351,7 @@ final class FilesystemUnitTest extends TestCase
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->remove($stagingDir, $callback, $timeout);
+        $sut->rm($stagingDir, $callback, $timeout);
     }
 
     public function providerRemove(): array
@@ -370,7 +370,7 @@ final class FilesystemUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::remove */
+    /** @covers ::rm */
     public function testRemoveException(): void
     {
         $message = 'Failed to remove directory.';
@@ -381,7 +381,7 @@ final class FilesystemUnitTest extends TestCase
         $sut = $this->createSut();
 
         self::assertTranslatableException(static function () use ($sut): void {
-            $sut->remove(PathHelper::stagingDirPath());
+            $sut->rm(PathHelper::stagingDirPath());
         }, IOException::class, $message, null, $previous::class);
     }
 }


### PR DESCRIPTION
...for closer correspondence to [PHP's built-in filesystem function names](https://www.php.net/manual/en/ref.filesystem.php).