### PR TITLE
Add `$env` argument to `Process` creation chain

### DIFF
--- a/src/API/Process/Factory/ProcessFactoryInterface.php
+++ b/src/API/Process/Factory/ProcessFactoryInterface.php
@@ -26,9 +26,21 @@ interface ProcessFactoryInterface
      *       '--with-all-dependencies',
      *   ];
      *   ```
+     * @param array<string|\Stringable> $env
+     *   An array of environment variables, keyed by variable name with corresponding
+     *   string or stringable values. In addition to those explicitly specified,
+     *   environment variables set on your system will be inherited. You can
+     *   prevent this by setting to `false` variables you want to remove. Example:
+     *   ```php
+     *   $process->setEnv(
+     *       'STRING_VAR' => 'a string',
+     *       'STRINGABLE_VAR' => new StringableObject(),
+     *       'REMOVE_ME' => false,
+     *   );
+     *   ```
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\LogicException
      *   If the process cannot be created due to host configuration.
      */
-    public function create(array $command): ProcessInterface;
+    public function create(array $command, array $env = []): ProcessInterface;
 }

--- a/src/API/Process/Service/ComposerProcessRunnerInterface.php
+++ b/src/API/Process/Service/ComposerProcessRunnerInterface.php
@@ -24,6 +24,18 @@ interface ComposerProcessRunnerInterface
      *       '--with-all-dependencies',
      *   ];
      *   ```
+     * @param array<string|\Stringable> $env
+     *   An array of environment variables, keyed by variable name with corresponding
+     *   string or stringable values. In addition to those explicitly specified,
+     *   environment variables set on your system will be inherited. You can
+     *   prevent this by setting to `false` variables you want to remove. Example:
+     *   ```php
+     *   $process->setEnv(
+     *       'STRING_VAR' => 'a string',
+     *       'STRINGABLE_VAR' => new StringableObject(),
+     *       'REMOVE_ME' => false,
+     *   );
+     *   ```
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int $timeout
@@ -39,6 +51,7 @@ interface ComposerProcessRunnerInterface
      */
     public function run(
         array $command,
+        array $env = [],
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;

--- a/src/API/Process/Service/RsyncProcessRunnerInterface.php
+++ b/src/API/Process/Service/RsyncProcessRunnerInterface.php
@@ -24,6 +24,18 @@ interface RsyncProcessRunnerInterface
      *       'path/to/destination',
      *   ];
      *   ```
+     * @param array<string|\Stringable> $env
+     *   An array of environment variables, keyed by variable name with corresponding
+     *   string or stringable values. In addition to those explicitly specified,
+     *   environment variables set on your system will be inherited. You can
+     *   prevent this by setting to `false` variables you want to remove. Example:
+     *   ```php
+     *   $process->setEnv(
+     *       'STRING_VAR' => 'a string',
+     *       'STRINGABLE_VAR' => new StringableObject(),
+     *       'REMOVE_ME' => false,
+     *   );
+     *   ```
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param int $timeout
@@ -39,6 +51,7 @@ interface RsyncProcessRunnerInterface
      */
     public function run(
         array $command,
+        array $env = [],
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void;

--- a/src/Internal/Core/Stager.php
+++ b/src/Internal/Core/Stager.php
@@ -91,7 +91,7 @@ final class Stager implements StagerInterface
         $command = ['--working-dir=' . $stagingDir->absolute(), ...$composerCommand];
 
         try {
-            $this->composerRunner->run($command, $callback, $timeout);
+            $this->composerRunner->run($command, [], $callback, $timeout);
         } catch (ExceptionInterface $e) {
             throw new RuntimeException($e->getTranslatableMessage(), 0, $e);
         }

--- a/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
@@ -66,7 +66,7 @@ final class RsyncFileSyncer extends AbstractFileSyncer implements RsyncFileSynce
         $command = $this->buildCommand($exclusions, $sourceAbsolute, $destinationAbsolute);
 
         try {
-            $this->rsync->run($command, $callback);
+            $this->rsync->run($command, [], $callback);
         } catch (ExceptionInterface $e) {
             throw new IOException($e->getTranslatableMessage(), 0, $e);
         }

--- a/src/Internal/Process/Factory/ProcessFactory.php
+++ b/src/Internal/Process/Factory/ProcessFactory.php
@@ -20,8 +20,8 @@ final class ProcessFactory implements ProcessFactoryInterface
     ) {
     }
 
-    public function create(array $command): ProcessInterface
+    public function create(array $command, array $env = []): ProcessInterface
     {
-        return new Process($this->symfonyProcessFactory, $this->translatableFactory, $command);
+        return new Process($this->symfonyProcessFactory, $this->translatableFactory, $command, $env);
     }
 }

--- a/src/Internal/Process/Factory/SymfonyProcessFactory.php
+++ b/src/Internal/Process/Factory/SymfonyProcessFactory.php
@@ -22,10 +22,10 @@ final class SymfonyProcessFactory implements SymfonyProcessFactoryInterface
         $this->setTranslatableFactory($translatableFactory);
     }
 
-    public function create(array $command): SymfonyProcess
+    public function create(array $command, array $env = []): SymfonyProcess
     {
         try {
-            return new SymfonyProcess($command);
+            return new SymfonyProcess($command, null, $env);
         } catch (SymfonyExceptionInterface $e) {
             throw new LogicException($this->t(
                 'Failed to create process: %details',

--- a/src/Internal/Process/Factory/SymfonyProcessFactoryInterface.php
+++ b/src/Internal/Process/Factory/SymfonyProcessFactoryInterface.php
@@ -26,11 +26,23 @@ interface SymfonyProcessFactoryInterface
      *       '--with-all-dependencies',
      *   ];
      *   ```
+     * @param array<string|\Stringable> $env
+     *   An array of environment variables, keyed by variable name with corresponding
+     *   string or stringable values. In addition to those explicitly specified,
+     *   environment variables set on your system will be inherited. You can
+     *   prevent this by setting to `false` variables you want to remove. Example:
+     *   ```php
+     *   $process->setEnv(
+     *       'STRING_VAR' => 'a string',
+     *       'STRINGABLE_VAR' => new StringableObject(),
+     *       'REMOVE_ME' => false,
+     *   );
+     *   ```
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\LogicException
      *   If the process cannot be created due to host configuration.
      *
      * @see \Symfony\Component\Process\Process::__construct
      */
-    public function create(array $command): SymfonyProcess;
+    public function create(array $command, array $env = []): SymfonyProcess;
 }

--- a/src/Internal/Process/Service/AbstractProcessRunner.php
+++ b/src/Internal/Process/Service/AbstractProcessRunner.php
@@ -39,6 +39,18 @@ abstract class AbstractProcessRunner
      *   value of ::executableName() will be automatically prepended.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
+     * @param array<string|\Stringable> $env
+     *   An array of environment variables, keyed by variable name with corresponding
+     *   string or stringable values. In addition to those explicitly specified,
+     *   environment variables set on your system will be inherited. You can
+     *   prevent this by setting to `false` variables you want to remove. Example:
+     *   ```php
+     *   $process->setEnv(
+     *       'STRING_VAR' => 'a string',
+     *       'STRINGABLE_VAR' => new StringableObject(),
+     *       'REMOVE_ME' => false,
+     *   );
+     *   ```
      * @param int $timeout
      *    An optional process timeout (maximum runtime) in seconds. If set to
      *    zero (0), no time limit is imposed.
@@ -54,11 +66,12 @@ abstract class AbstractProcessRunner
      */
     public function run(
         array $command,
+        array $env = [],
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,
     ): void {
         array_unshift($command, $this->findExecutable());
-        $process = $this->processFactory->create($command);
+        $process = $this->processFactory->create($command, $env);
         $process->setTimeout($timeout);
         $process->mustRun($callback);
     }

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -36,6 +36,18 @@ final class Process implements ProcessInterface
      *       '--with-all-dependencies',
      *   ];
      *   ```
+     * @param array<string|\Stringable> $env
+     *   An array of environment variables, keyed by variable name with corresponding
+     *   string or stringable values. In addition to those explicitly specified,
+     *   environment variables set on your system will be inherited. You can
+     *   prevent this by setting to `false` variables you want to remove. Example:
+     *   ```php
+     *   $process->setEnv(
+     *       'STRING_VAR' => 'a string',
+     *       'STRINGABLE_VAR' => new StringableObject(),
+     *       'REMOVE_ME' => false,
+     *   );
+     *   ```
      *
      * @throws \PhpTuf\ComposerStager\API\Exception\LogicException
      *   If the process cannot be created due to host configuration.
@@ -44,9 +56,10 @@ final class Process implements ProcessInterface
         private readonly SymfonyProcessFactoryInterface $symfonyProcessFactory,
         TranslatableFactoryInterface $translatableFactory,
         array $command = [],
+        ?array $env = null,
     ) {
         $this->setTranslatableFactory($translatableFactory);
-        $this->symfonyProcess = $this->symfonyProcessFactory->create($command);
+        $this->symfonyProcess = $this->symfonyProcessFactory->create($command, $env);
     }
 
     public function getEnv(): array

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -56,7 +56,7 @@ final class Process implements ProcessInterface
         private readonly SymfonyProcessFactoryInterface $symfonyProcessFactory,
         TranslatableFactoryInterface $translatableFactory,
         array $command = [],
-        ?array $env = null,
+        array $env = [],
     ) {
         $this->setTranslatableFactory($translatableFactory);
         $this->symfonyProcess = $this->symfonyProcessFactory->create($command, $env);

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -65,7 +65,7 @@ final class StagerUnitTest extends TestCase
             self::INERT_COMMAND,
         ];
         $this->composerRunner
-            ->run($expectedCommand, null, $timeout)
+            ->run($expectedCommand, [], null, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -86,7 +86,7 @@ final class StagerUnitTest extends TestCase
             ->assertIsFulfilled($activeDirPath, $stagingDirPath)
             ->shouldBeCalledOnce();
         $this->composerRunner
-            ->run($expectedCommand, $callback, $timeout)
+            ->run($expectedCommand, [], $callback, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -87,7 +87,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
             ->mkdir($destinationPath)
             ->shouldBeCalledOnce();
         $this->rsync
-            ->run($command, $callback)
+            ->run($command, [], $callback)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 

--- a/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
+++ b/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
@@ -20,24 +20,37 @@ final class SymfonyProcessFactoryUnitTest extends TestCase
      *
      * @dataProvider providerBasicFunctionality
      */
-    public function testBasicFunctionality(array $command): void
+    public function testBasicFunctionality(array $command, array $optionalArguments): void
     {
         $translatableFactory = new TestTranslatableFactory();
         $sut = new SymfonyProcessFactory($translatableFactory);
 
-        $actual = $sut->create($command);
+        $actualProcess = $sut->create($command, ...$optionalArguments);
 
-        $expected = new Process($command);
-        self::assertEquals($expected, $actual);
+        $expectedProcess = new Process($command, null, ...$optionalArguments);
+        self::assertEquals($expectedProcess, $actualProcess);
         self::assertTranslatableAware($sut);
     }
 
     public function providerBasicFunctionality(): array
     {
         return [
-            'Empty command' => [[]],
-            'Simple command' => [['one']],
-            'Command with options' => [['one', 'two', 'three']],
+            'Minimum values' => [
+                'command' => [],
+                'optionalArguments' => [[]],
+            ],
+            'Simple command' => [
+                'command' => ['one'],
+                'optionalArguments' => [],
+            ],
+            'Command with options' => [
+                'command' => ['one', 'two', 'three'],
+                'optionalArguments' => [],
+            ],
+            'Command plus env' => [
+                'command' => ['one'],
+                'optionalArguments' => [['TWO' => 'two']],
+            ],
         ];
     }
 

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -58,7 +58,7 @@ final class ProcessUnitTest extends TestCase
     {
         $symfonyProcess = $this->symfonyProcess->reveal();
         $this->symfonyProcessFactory
-            ->create($expectedCommand)
+            ->create($expectedCommand, Argument::cetera())
             ->willReturn($symfonyProcess);
         $symfonyProcessFactory = $this->symfonyProcessFactory->reveal();
         $translatableFactory = new TestTranslatableFactory();
@@ -120,7 +120,7 @@ final class ProcessUnitTest extends TestCase
             ->shouldBeCalledOnce()
             ->willReturn($this->symfonyProcess);
         $this->symfonyProcessFactory
-            ->create($expectedCommand)
+            ->create($expectedCommand, Argument::cetera())
             ->shouldBeCalledOnce();
         $sut = $this->createSut($givenConstructorArguments, $expectedCommand);
 
@@ -206,11 +206,6 @@ final class ProcessUnitTest extends TestCase
         return [
             'No env argument' => [
                 'optionalArguments' => [],
-                'expectedInitialEnv' => [],
-                'givenNewEnv' => [],
-            ],
-            'Null argument' => [
-                'optionalArguments' => [null],
                 'expectedInitialEnv' => [],
                 'givenNewEnv' => [],
             ],

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -7,6 +7,7 @@ use PhpTuf\ComposerStager\API\Exception\InvalidArgumentException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
+use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactory;
 use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapterInterface;
@@ -15,6 +16,7 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestStringable;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Translation\Factory\TestTranslatableFactory;
+use PhpTuf\ComposerStager\Tests\TestUtils\ContainerHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\ProcessHelper;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -174,6 +176,64 @@ final class ProcessUnitTest extends TestCase
                 'givenSetTimeoutArguments' => [42],
                 'output' => 'Simple arguments output',
                 'errorOutput' => 'Simple arguments error output',
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getEnv
+     * @covers ::setEnv
+     *
+     * @dataProvider providerEnv
+     */
+    public function testEnv(array $optionalArguments, array $expectedInitialEnv, array $givenNewEnv): void
+    {
+        $symfonyProcessFactory = ContainerHelper::get(SymfonyProcessFactory::class);
+        $translatableFactory = new TestTranslatableFactory();
+        $sut = new Process($symfonyProcessFactory, $translatableFactory, ['arbitrary_command'], ...$optionalArguments);
+
+        $actualInitialEnv = $sut->getEnv();
+        $sut->setEnv($givenNewEnv);
+        $actualUpdatedEnv = $sut->getEnv();
+
+        self::assertSame($expectedInitialEnv, $actualInitialEnv);
+        self::assertSame($givenNewEnv, $actualUpdatedEnv);
+    }
+
+    public function providerEnv(): array
+    {
+        return [
+            'No env argument' => [
+                'optionalArguments' => [],
+                'expectedInitialEnv' => [],
+                'givenNewEnv' => [],
+            ],
+            'Null argument' => [
+                'optionalArguments' => [null],
+                'expectedInitialEnv' => [],
+                'givenNewEnv' => [],
+            ],
+            'Initial env, no change' => [
+                'optionalArguments' => [
+                    [
+                        'ONE' => 'one',
+                        'TWO' => 'two',
+                    ],
+                ],
+                'expectedInitialEnv' => [
+                    'ONE' => 'one',
+                    'TWO' => 'two',
+                ],
+                'givenNewEnv' => [],
+            ],
+            'No env argument, changed' => [
+                'optionalArguments' => [['one' => 'two']],
+                'expectedInitialEnv' => ['one' => 'two'],
+                'givenNewEnv' => [
+                    'ONE' => 'one',
+                    'TWO' => 'two',
+                ],
             ],
         ];
     }


### PR DESCRIPTION
This enables the direct setting of environment variables (`$env`) via the constructor and invocation methods of the `Process` creation chain (as opposed to depending solely on the `::setEnv()` method on the `Process` class itself):

- `AbstractProcessRunner::run()`
- `ProcessFactory::create()`.
- `Process::__construct()`
- `SymfonyProcessFactory::create()`