### PR TITLE
Add `$cwd` argument to `Process` creation chain

### DIFF
--- a/src/API/Process/Service/ComposerProcessRunnerInterface.php
+++ b/src/API/Process/Service/ComposerProcessRunnerInterface.php
@@ -2,6 +2,8 @@
 
 namespace PhpTuf\ComposerStager\API\Process\Service;
 
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+
 /**
  * Runs Composer commands.
  *
@@ -24,6 +26,9 @@ interface ComposerProcessRunnerInterface
      *       '--with-all-dependencies',
      *   ];
      *   ```
+     * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface|null $cwd
+     *   The current working directory (CWD) for the process. If set to null,
+     *   the CWD of the current PHP process will be used.
      * @param array<string|\Stringable> $env
      *   An array of environment variables, keyed by variable name with corresponding
      *   string or stringable values. In addition to those explicitly specified,
@@ -51,6 +56,7 @@ interface ComposerProcessRunnerInterface
      */
     public function run(
         array $command,
+        ?PathInterface $cwd = null,
         array $env = [],
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,

--- a/src/API/Process/Service/RsyncProcessRunnerInterface.php
+++ b/src/API/Process/Service/RsyncProcessRunnerInterface.php
@@ -2,6 +2,8 @@
 
 namespace PhpTuf\ComposerStager\API\Process\Service;
 
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+
 /**
  * Runs rsync commands.
  *
@@ -24,6 +26,9 @@ interface RsyncProcessRunnerInterface
      *       'path/to/destination',
      *   ];
      *   ```
+     * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface|null $cwd
+     *   The current working directory (CWD) for the process. If set to null,
+     *   the CWD of the current PHP process will be used.
      * @param array<string|\Stringable> $env
      *   An array of environment variables, keyed by variable name with corresponding
      *   string or stringable values. In addition to those explicitly specified,
@@ -51,6 +56,7 @@ interface RsyncProcessRunnerInterface
      */
     public function run(
         array $command,
+        ?PathInterface $cwd = null,
         array $env = [],
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,

--- a/src/Internal/Core/Stager.php
+++ b/src/Internal/Core/Stager.php
@@ -91,7 +91,7 @@ final class Stager implements StagerInterface
         $command = ['--working-dir=' . $stagingDir->absolute(), ...$composerCommand];
 
         try {
-            $this->composerRunner->run($command, [], $callback, $timeout);
+            $this->composerRunner->run($command, null, [], $callback, $timeout);
         } catch (ExceptionInterface $e) {
             throw new RuntimeException($e->getTranslatableMessage(), 0, $e);
         }

--- a/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
+++ b/src/Internal/FileSyncer/Service/RsyncFileSyncer.php
@@ -66,7 +66,7 @@ final class RsyncFileSyncer extends AbstractFileSyncer implements RsyncFileSynce
         $command = $this->buildCommand($exclusions, $sourceAbsolute, $destinationAbsolute);
 
         try {
-            $this->rsync->run($command, [], $callback);
+            $this->rsync->run($command, null, [], $callback);
         } catch (ExceptionInterface $e) {
             throw new IOException($e->getTranslatableMessage(), 0, $e);
         }

--- a/src/Internal/Process/Factory/SymfonyProcessFactory.php
+++ b/src/Internal/Process/Factory/SymfonyProcessFactory.php
@@ -3,6 +3,7 @@
 namespace PhpTuf\ComposerStager\Internal\Process\Factory;
 
 use PhpTuf\ComposerStager\API\Exception\LogicException;
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 use Symfony\Component\Process\Exception\ExceptionInterface as SymfonyExceptionInterface;
@@ -22,10 +23,15 @@ final class SymfonyProcessFactory implements SymfonyProcessFactoryInterface
         $this->setTranslatableFactory($translatableFactory);
     }
 
-    public function create(array $command, array $env = []): SymfonyProcess
+    public function create(array $command, ?PathInterface $cwd = null, array $env = []): SymfonyProcess
     {
+        if ($cwd instanceof PathInterface) {
+            /** @noinspection CallableParameterUseCaseInTypeContextInspection */
+            $cwd = $cwd->absolute();
+        }
+
         try {
-            return new SymfonyProcess($command, null, $env);
+            return new SymfonyProcess($command, $cwd, $env);
         } catch (SymfonyExceptionInterface $e) {
             throw new LogicException($this->t(
                 'Failed to create process: %details',

--- a/src/Internal/Process/Factory/SymfonyProcessFactoryInterface.php
+++ b/src/Internal/Process/Factory/SymfonyProcessFactoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace PhpTuf\ComposerStager\Internal\Process\Factory;
 
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
 /**
@@ -26,6 +27,9 @@ interface SymfonyProcessFactoryInterface
      *       '--with-all-dependencies',
      *   ];
      *   ```
+     * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface|null $cwd
+     *   The current working directory (CWD) for the process. If set to null,
+     *   the CWD of the current PHP process will be used.
      * @param array<string|\Stringable> $env
      *   An array of environment variables, keyed by variable name with corresponding
      *   string or stringable values. In addition to those explicitly specified,
@@ -44,5 +48,5 @@ interface SymfonyProcessFactoryInterface
      *
      * @see \Symfony\Component\Process\Process::__construct
      */
-    public function create(array $command, array $env = []): SymfonyProcess;
+    public function create(array $command, ?PathInterface $cwd = null, array $env = []): SymfonyProcess;
 }

--- a/src/Internal/Process/Service/AbstractProcessRunner.php
+++ b/src/Internal/Process/Service/AbstractProcessRunner.php
@@ -3,6 +3,7 @@
 namespace PhpTuf\ComposerStager\Internal\Process\Service;
 
 use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
+use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
@@ -37,6 +38,9 @@ abstract class AbstractProcessRunner
      *   The command arguments as separate string values, e.g.,
      *   ['require', 'example/package'] or ['source', 'destination']. The return
      *   value of ::executableName() will be automatically prepended.
+     * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface|null $cwd
+     *   The current working directory (CWD) for the process. If set to null,
+     *   the CWD of the current PHP process will be used.
      * @param \PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface|null $callback
      *   An optional PHP callback to run whenever there is process output.
      * @param array<string|\Stringable> $env
@@ -66,6 +70,7 @@ abstract class AbstractProcessRunner
      */
     public function run(
         array $command,
+        ?PathInterface $cwd = null,
         array $env = [],
         ?OutputCallbackInterface $callback = null,
         int $timeout = ProcessInterface::DEFAULT_TIMEOUT,

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -59,7 +59,7 @@ final class Process implements ProcessInterface
         array $env = [],
     ) {
         $this->setTranslatableFactory($translatableFactory);
-        $this->symfonyProcess = $this->symfonyProcessFactory->create($command, $env);
+        $this->symfonyProcess = $this->symfonyProcessFactory->create($command, null, $env);
     }
 
     public function getEnv(): array

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -65,7 +65,7 @@ final class StagerUnitTest extends TestCase
             self::INERT_COMMAND,
         ];
         $this->composerRunner
-            ->run($expectedCommand, [], null, $timeout)
+            ->run($expectedCommand, null, [], null, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
@@ -86,7 +86,7 @@ final class StagerUnitTest extends TestCase
             ->assertIsFulfilled($activeDirPath, $stagingDirPath)
             ->shouldBeCalledOnce();
         $this->composerRunner
-            ->run($expectedCommand, [], $callback, $timeout)
+            ->run($expectedCommand, null, [], $callback, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -87,7 +87,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
             ->mkdir($destinationPath)
             ->shouldBeCalledOnce();
         $this->rsync
-            ->run($command, [], $callback)
+            ->run($command, null, [], $callback)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 

--- a/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/RsyncFileSyncerUnitTest.php
@@ -8,7 +8,6 @@ use PhpTuf\ComposerStager\API\Exception\IOException;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
-use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\RsyncProcessRunnerInterface;
 use PhpTuf\ComposerStager\Internal\FileSyncer\Service\RsyncFileSyncer;
@@ -76,9 +75,9 @@ final class RsyncFileSyncerUnitTest extends TestCase
     public function testSync(
         string $source,
         string $destination,
-        ?PathListInterface $exclusions,
-        array $command,
-        ?OutputCallbackInterface $callback,
+        array $optionalArguments,
+        array $expectedCommand,
+        ?OutputCallbackInterface $expectedCallback,
     ): void {
         $sourcePath = PathHelper::createPath($source);
         $destinationPath = PathHelper::createPath($destination);
@@ -87,34 +86,48 @@ final class RsyncFileSyncerUnitTest extends TestCase
             ->mkdir($destinationPath)
             ->shouldBeCalledOnce();
         $this->rsync
-            ->run($command, null, [], $callback)
+            ->run($expectedCommand, null, [], $expectedCallback)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->sync($sourcePath, $destinationPath, $exclusions, $callback);
+        $sut->sync($sourcePath, $destinationPath, ...$optionalArguments);
     }
 
     public function providerSync(): array
     {
         return [
+            'Minimum arguments' => [
+                'source' => '/var/www/source',
+                'destination' => '/var/www/destination',
+                'optionalArguments' => [],
+                'expectedCommand' => [
+                    '--archive',
+                    '--delete-after',
+                    '--verbose',
+                    '/var/www/source/',
+                    '/var/www/destination',
+                ],
+                'expectedCallback' => null,
+            ],
             'Siblings: no exclusions given' => [
                 'source' => '/var/www/source/one',
                 'destination' => '/var/www/destination/two',
-                'exclusions' => null,
-                'command' => [
+                'optionalArguments' => [],
+                'expectedCommand' => [
                     '--archive',
                     '--delete-after',
                     '--verbose',
                     '/var/www/source/one/',
                     '/var/www/destination/two',
                 ],
-                'callback' => null,
+                'expectedCallback' => null,
             ],
+            //'Siblings: simple exclusions given' => [
             'Siblings: simple exclusions given' => [
                 'source' => '/var/www/source/two',
                 'destination' => '/var/www/destination/two',
-                'exclusions' => new PathList('three.txt', 'four.txt'),
-                'command' => [
+                'optionalArguments' => [new PathList('three.txt', 'four.txt'), new TestOutputCallback()],
+                'expectedCommand' => [
                     '--archive',
                     '--delete-after',
                     '--verbose',
@@ -123,18 +136,20 @@ final class RsyncFileSyncerUnitTest extends TestCase
                     '/var/www/source/two/',
                     '/var/www/destination/two',
                 ],
-                'callback' => new TestOutputCallback(),
+                'expectedCallback' => new TestOutputCallback(),
             ],
             'Siblings: duplicate exclusions given' => [
                 'source' => '/var/www/source/three',
                 'destination' => '/var/www/destination/three',
-                'exclusions' => new PathList(...[
-                    'four/five',
-                    'six/seven',
-                    'six/seven',
-                    'six/seven',
-                ]),
-                'command' => [
+                'optionalArguments' => [
+                    new PathList(...[
+                        'four/five',
+                        'six/seven',
+                        'six/seven',
+                        'six/seven',
+                    ]),
+                ],
+                'expectedCommand' => [
                     '--archive',
                     '--delete-after',
                     '--verbose',
@@ -143,19 +158,21 @@ final class RsyncFileSyncerUnitTest extends TestCase
                     '/var/www/source/three/',
                     '/var/www/destination/three',
                 ],
-                'callback' => null,
+                'expectedCallback' => null,
             ],
             'Siblings: Windows directory separators' => [
                 'source' => '/var/www/source/one\\two',
                 'destination' => '/var/www/destination\\one/two',
-                'exclusions' => new PathList(...[
-                    'three\\four',
-                    'five/six/seven/eight',
-                    'five/six/seven/eight',
-                    'five\\six/seven\\eight',
-                    'five/six\\seven/eight',
-                ]),
-                'command' => [
+                'optionalArguments' => [
+                    new PathList(...[
+                        'three\\four',
+                        'five/six/seven/eight',
+                        'five/six/seven/eight',
+                        'five\\six/seven\\eight',
+                        'five/six\\seven/eight',
+                    ]),
+                ],
+                'expectedCommand' => [
                     '--archive',
                     '--delete-after',
                     '--verbose',
@@ -164,26 +181,26 @@ final class RsyncFileSyncerUnitTest extends TestCase
                     '/var/www/source/one/two/',
                     '/var/www/destination/one/two',
                 ],
-                'callback' => null,
+                'expectedCallback' => null,
             ],
             'Nested: destination inside source (neither is excluded)' => [
                 'source' => '/var/www/source',
                 'destination' => '/var/www/source/destination',
-                'exclusions' => null,
-                'command' => [
+                'optionalArguments' => [],
+                'expectedCommand' => [
                     '--archive',
                     '--delete-after',
                     '--verbose',
                     '/var/www/source/',
                     '/var/www/source/destination',
                 ],
-                'callback' => null,
+                'expectedCallback' => null,
             ],
             'Nested: source inside destination (source is excluded)' => [
                 'source' => '/var/www/destination/source',
                 'destination' => '/var/www/destination',
-                'exclusions' => null,
-                'command' => [
+                'optionalArguments' => [],
+                'expectedCommand' => [
                     '--archive',
                     '--delete-after',
                     '--verbose',
@@ -192,13 +209,13 @@ final class RsyncFileSyncerUnitTest extends TestCase
                     '/var/www/destination/source/',
                     '/var/www/destination',
                 ],
-                'callback' => null,
+                'expectedCallback' => null,
             ],
             'Nested: with Windows directory separators' => [
                 'source' => '/var/www/destination\\source',
                 'destination' => '/var/www/destination',
-                'exclusions' => null,
-                'command' => [
+                'optionalArguments' => [],
+                'expectedCommand' => [
                     '--archive',
                     '--delete-after',
                     '--verbose',
@@ -207,7 +224,7 @@ final class RsyncFileSyncerUnitTest extends TestCase
                     '/var/www/destination/source/',
                     '/var/www/destination',
                 ],
-                'callback' => null,
+                'expectedCallback' => null,
             ],
         ];
     }

--- a/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
+++ b/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
@@ -8,8 +8,9 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestSpyInterface;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\TestUtils\BuiltinFunctionMocker;
+use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
 use Symfony\Component\Process\Exception\LogicException as SymfonyLogicException;
-use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Process as SymfonyProcess;
 
 /** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactory */
 final class SymfonyProcessFactoryUnitTest extends TestCase
@@ -20,15 +21,15 @@ final class SymfonyProcessFactoryUnitTest extends TestCase
      *
      * @dataProvider providerBasicFunctionality
      */
-    public function testBasicFunctionality(array $command, array $optionalArguments): void
+    public function testBasicFunctionality(array $given, array $expected): void
     {
         $translatableFactory = new TestTranslatableFactory();
         $sut = new SymfonyProcessFactory($translatableFactory);
 
-        $actualProcess = $sut->create($command, ...$optionalArguments);
+        $actual = $sut->create(...$given);
 
-        $expectedProcess = new Process($command, null, ...$optionalArguments);
-        self::assertEquals($expectedProcess, $actualProcess);
+        $expected = new SymfonyProcess(...$expected);
+        self::assertEquals($expected, $actual);
         self::assertTranslatableAware($sut);
     }
 
@@ -36,20 +37,24 @@ final class SymfonyProcessFactoryUnitTest extends TestCase
     {
         return [
             'Minimum values' => [
-                'command' => [],
-                'optionalArguments' => [[]],
+                'given' => [['one']],
+                'expected' => [['one'], null, []],
             ],
-            'Simple command' => [
-                'command' => ['one'],
-                'optionalArguments' => [],
+            'Default values' => [
+                'given' => [['one'], null, []],
+                'expected' => [['one'], null, []],
             ],
-            'Command with options' => [
-                'command' => ['one', 'two', 'three'],
-                'optionalArguments' => [],
-            ],
-            'Command plus env' => [
-                'command' => ['one'],
-                'optionalArguments' => [['TWO' => 'two']],
+            'Simple values' => [
+                'given' => [
+                    ['one'],
+                    PathHelper::arbitraryDirPath(),
+                    ['ONE' => 'one', 'TWO' => 'two'],
+                ],
+                'expected' => [
+                    ['one'],
+                    PathHelper::arbitraryDirAbsolute(),
+                    ['ONE' => 'one', 'TWO' => 'two'],
+                ],
             ],
         ];
     }

--- a/tests/Process/Service/AbstractProcessRunnerUnitTest.php
+++ b/tests/Process/Service/AbstractProcessRunnerUnitTest.php
@@ -14,6 +14,7 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Process\Service\TestOutputCallback;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Translation\Factory\TestTranslatableFactory;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Translation\Value\TestTranslatableExceptionMessage;
+use PhpTuf\ComposerStager\Tests\TestUtils\PathHelper;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
@@ -91,8 +92,8 @@ final class AbstractProcessRunnerUnitTest extends TestCase
      */
     public function testBasicFunctionality(
         string $executableName,
-        array $sutRunArguments,
-        array $factoryCreateArguments,
+        array $givenRunArguments,
+        array $expectedFactoryArguments,
         ?OutputCallbackInterface $callback,
         int $timeout,
     ): void {
@@ -109,12 +110,12 @@ final class AbstractProcessRunnerUnitTest extends TestCase
             ->shouldBeCalledOnce()
             ->willReturn($this->process);
         $this->processFactory
-            ->create(...$factoryCreateArguments)
+            ->create(...$expectedFactoryArguments)
             ->shouldBeCalledOnce()
             ->willReturn($this->process);
         $sut = $this->createSut($executableName);
 
-        $sut->run(...$sutRunArguments);
+        $sut->run(...$givenRunArguments);
     }
 
     public function providerBasicFunctionality(): array
@@ -122,21 +123,22 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         return [
             'Minimum values' => [
                 'executableName' => 'one',
-                'sutRunArguments' => [[]],
-                'factoryCreateArguments' => [['one'], []],
+                'givenRunArguments' => [[]],
+                'expectedFactoryArguments' => [['one'], []],
                 'callback' => null,
                 'timeout' => ProcessInterface::DEFAULT_TIMEOUT,
             ],
             'Simple values' => [
                 'executableName' => 'two',
-                'sutRunArguments' => [
-                    [],
+                'givenRunArguments' => [
+                    ['three', 'four'],
+                    PathHelper::arbitraryDirPath(),
                     ['ONE' => 'one', 'TWO' => 'two'],
                     new TestOutputCallback(),
                     100,
                 ],
-                'factoryCreateArguments' => [
-                    ['two'],
+                'expectedFactoryArguments' => [
+                    ['two', 'three', 'four'],
                     ['ONE' => 'one', 'TWO' => 'two'],
                 ],
                 'callback' => new TestOutputCallback(),

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -54,8 +54,9 @@ final class ProcessUnitTest extends TestCase
             ->willReturn($this->symfonyProcess);
     }
 
-    private function createSut(array $givenConstructorArguments = [], array $expectedCommand = []): Process
+    private function createSut(array $givenConstructorArguments = [['executable']]): Process
     {
+        $expectedCommand = reset($givenConstructorArguments);
         $symfonyProcess = $this->symfonyProcess->reveal();
         $this->symfonyProcessFactory
             ->create($expectedCommand, Argument::cetera())
@@ -82,7 +83,6 @@ final class ProcessUnitTest extends TestCase
      */
     public function testBasicFunctionality(
         array $givenConstructorArguments,
-        array $expectedCommand,
         array $givenRunArguments,
         ?OutputCallbackAdapterInterface $expectedRunArgument,
         array $envVars,
@@ -90,6 +90,7 @@ final class ProcessUnitTest extends TestCase
         string $output,
         string $errorOutput,
     ): void {
+        $expectedCommand = reset($givenConstructorArguments);
         $expectedRunReturn = 0;
         $this->symfonyProcess
             ->getEnv()
@@ -122,7 +123,7 @@ final class ProcessUnitTest extends TestCase
         $this->symfonyProcessFactory
             ->create($expectedCommand, Argument::cetera())
             ->shouldBeCalledOnce();
-        $sut = $this->createSut($givenConstructorArguments, $expectedCommand);
+        $sut = $this->createSut($givenConstructorArguments);
 
         $actualSetEnvReturn = $sut->setEnv($envVars);
         $actualEnv = $sut->getEnv();
@@ -145,8 +146,7 @@ final class ProcessUnitTest extends TestCase
     {
         return [
             'Minimum arguments' => [
-                'givenConstructorArguments' => [],
-                'expectedCommand' => [],
+                'givenConstructorArguments' => [[]],
                 'givenRunArguments' => [],
                 'expectedRunArgument' => new OutputCallbackAdapter(null),
                 'envVars' => [],
@@ -156,7 +156,6 @@ final class ProcessUnitTest extends TestCase
             ],
             'Nullable arguments' => [
                 'givenConstructorArguments' => [['nullable', 'arguments']],
-                'expectedCommand' => ['nullable', 'arguments'],
                 'givenRunArguments' => [null],
                 'expectedRunArgument' => new OutputCallbackAdapter(null),
                 'envVars' => [],
@@ -166,7 +165,6 @@ final class ProcessUnitTest extends TestCase
             ],
             'Simple arguments' => [
                 'givenConstructorArguments' => [['simple', 'arguments']],
-                'expectedCommand' => ['simple', 'arguments'],
                 'givenRunArguments' => [new TestOutputCallback()],
                 'expectedRunArgument' => new OutputCallbackAdapter(new TestOutputCallback()),
                 'envVars' => [


### PR DESCRIPTION
This enables the direct setting of the current working directory (`$env`) via the constructor and invocation methods of the `Process` creation chain (which cannot currently be accomplished by any other means):

- `AbstractProcessRunner::run()`
- `ProcessFactory::create()`.
- `Process::__construct()`
- `SymfonyProcessFactory::create()`