### PR TITLE
Make `API\Filesystem\Service\FilesystemInterface::isDir()` and `::isFile()` resolve links like their PHP built-in counterparts

### DIFF
--- a/src/API/Filesystem/Service/FilesystemInterface.php
+++ b/src/API/Filesystem/Service/FilesystemInterface.php
@@ -34,34 +34,38 @@ interface FilesystemInterface
     /**
      * Determines whether the given path is a directory.
      *
-     * Unlike PHP's built-in is_dir() function, this method distinguishes
-     * between directories and LINKS to directories. In other words, if the path
-     * is a link, even if the target is a directory, this method will return false.
+     * Like PHP's built-in
+     * {@see https://www.php.net/manual/en/function.is-dir.php `is_dir()`}
+     * function, if the given path is a symbolic or hard link, then the link
+     * will be resolved and checked. In other words, even if the path is a link,
+     * if the target is a directory, this method will return true. If the
+     * distinction matters to you, check {@see FilesystemInterface::isLink()}
+     * first.
      *
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $path
      *   A path to test.
      *
      * @return bool
-     *   Returns true if the path exists and is a directory.
-     *
-     * @see https://www.php.net/manual/en/function.is-dir.php
+     *   Returns true if the path exists and is or points to a directory.
      */
     public function isDir(PathInterface $path): bool;
 
     /**
      * Determines whether the given path is a regular file.
      *
-     * Unlike PHP's built-in is_file() function, this method distinguishes
-     * between regular files and LINKS to files. In other words, if the path is
-     * a link, even if the target is a regular file, this method will return false.
+     * Like PHP's built-in
+     * {@see https://www.php.net/manual/en/function.is-file.php `is_file()`}
+     * function, if the given path is a symbolic or hard link, then the link
+     * will be resolved and checked. In other words, even if the path is a link,
+     * if the target is a regular file, this method will return true. If the
+     * distinction matters to you, check {@see FilesystemInterface::isLink()}
+     * first.
      *
      * @param \PhpTuf\ComposerStager\API\Path\Value\PathInterface $path
      *   A path to test.
      *
      * @return bool
-     *   Returns true if the path exists and is a regular file.
-     *
-     * @see https://www.php.net/manual/en/function.is-file.php
+     *   Returns true if the path exists and is or points to a regular file.
      */
     public function isFile(PathInterface $path): bool;
 

--- a/src/Internal/Filesystem/Service/Filesystem.php
+++ b/src/Internal/Filesystem/Service/Filesystem.php
@@ -52,7 +52,7 @@ final class Filesystem implements FilesystemInterface
 
     public function isDir(PathInterface $path): bool
     {
-        return $this->getFileType($path) === self::PATH_IS_DIRECTORY;
+        return is_dir($path->absolute());
     }
 
     public function isFile(PathInterface $path): bool

--- a/tests/Filesystem/Service/FilesystemFunctionalTest.php
+++ b/tests/Filesystem/Service/FilesystemFunctionalTest.php
@@ -100,7 +100,7 @@ final class FilesystemFunctionalTest extends TestCase
                 'hardLinks' => [],
                 'subject' => 'directory_link',
                 'exists' => true,
-                'isDir' => false,
+                'isDir' => true,
                 'isFile' => false,
                 'isLink' => true,
                 'isHardLink' => false,


### PR DESCRIPTION
Actually, `::isFile()` already does, but its docblock says it doesn't (so fix that).