### PR TITLE
Make sure active and staging directories are actually directories

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,7 +18,7 @@ parameters:
         - src
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: c94a25d898315306a818795981d279b3
+    preconditionSystemHash: b4690c6f94d8615ca04a0aeaa999cf2d
     translationSystemHash: dec82389af17442fa61cc1fcc6f89c3e
     gitattributesExportInclude:
         - composer.json

--- a/src/Internal/Precondition/Service/ActiveDirExists.php
+++ b/src/Internal/Precondition/Service/ActiveDirExists.php
@@ -55,5 +55,13 @@ final class ActiveDirExists extends AbstractPrecondition implements ActiveDirExi
                 $this->d()->exceptions(),
             ));
         }
+
+        if (!$this->filesystem->isDir($activeDir)) {
+            throw new PreconditionException($this, $this->t(
+                'The active directory is not actually a directory.',
+                null,
+                $this->d()->exceptions(),
+            ));
+        }
     }
 }

--- a/src/Internal/Precondition/Service/StagingDirExists.php
+++ b/src/Internal/Precondition/Service/StagingDirExists.php
@@ -55,5 +55,13 @@ final class StagingDirExists extends AbstractPrecondition implements StagingDirE
                 $this->d()->exceptions(),
             ));
         }
+
+        if (!$this->filesystem->isDir($stagingDir)) {
+            throw new PreconditionException($this, $this->t(
+                'The staging directory is not actually a directory.',
+                null,
+                $this->d()->exceptions(),
+            ));
+        }
     }
 }

--- a/tests/Precondition/Service/ActiveDirExistsUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirExistsUnitTest.php
@@ -23,6 +23,12 @@ final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->filesystem
+            ->fileExists(self::activeDirPath())
+            ->willReturn(true);
+        $this->filesystem
+            ->isDir(self::activeDirPath())
+            ->willReturn(true);
 
         parent::setUp();
     }
@@ -46,16 +52,30 @@ final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
             ->fileExists(self::activeDirPath())
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn(true);
+        $this->filesystem
+            ->isDir(self::activeDirPath())
+            ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
 
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
     /** @covers ::doAssertIsFulfilled */
-    public function testUnfulfilled(): void
+    public function testDoesNotExist(): void
     {
         $message = 'The active directory does not exist.';
         $this->filesystem
             ->fileExists(self::activeDirPath())
+            ->willReturn(false);
+
+        $this->doTestUnfulfilled($message);
+    }
+
+    /** @covers ::doAssertIsFulfilled */
+    public function testIsNotADirectory(): void
+    {
+        $message = 'The active directory is not actually a directory.';
+        $this->filesystem
+            ->isDir(self::activeDirPath())
             ->willReturn(false);
 
         $this->doTestUnfulfilled($message);

--- a/tests/Precondition/Service/StagingDirExistsUnitTest.php
+++ b/tests/Precondition/Service/StagingDirExistsUnitTest.php
@@ -10,7 +10,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirExists
  *
  * @covers ::__construct
- * @covers ::doAssertIsFulfilled
  * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
  */
 final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
@@ -24,6 +23,12 @@ final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->filesystem
+            ->fileExists(self::stagingDirPath())
+            ->willReturn(true);
+        $this->filesystem
+            ->isDir(self::stagingDirPath())
+            ->willReturn(true);
 
         parent::setUp();
     }
@@ -47,16 +52,30 @@ final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
             ->fileExists(self::stagingDirPath())
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
             ->willReturn(true);
+        $this->filesystem
+            ->isDir(self::stagingDirPath())
+            ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
 
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
     /** @covers ::doAssertIsFulfilled */
-    public function testUnfulfilled(): void
+    public function testDoesNotExist(): void
     {
         $message = 'The staging directory does not exist.';
         $this->filesystem
             ->fileExists(self::stagingDirPath())
+            ->willReturn(false);
+
+        $this->doTestUnfulfilled($message);
+    }
+
+    /** @covers ::doAssertIsFulfilled */
+    public function testIsNotADirectory(): void
+    {
+        $message = 'The staging directory is not actually a directory.';
+        $this->filesystem
+            ->isDir(self::stagingDirPath())
             ->willReturn(false);
 
         $this->doTestUnfulfilled($message);


### PR DESCRIPTION
The `ActiveDirExists` and `StagingDirExists` preconditions currently assert that the paths exist but not that they're actually directories (as opposed to regular files, for example).