### PR TITLE
Stop returning `self` from `API\Process\Service\ProcessInterface` methods

### DIFF
--- a/src/API/Process/Service/ProcessInterface.php
+++ b/src/API/Process/Service/ProcessInterface.php
@@ -101,5 +101,5 @@ interface ProcessInterface
      * @throws \PhpTuf\ComposerStager\API\Exception\InvalidArgumentException
      *   If the given timeout is negative.
      */
-    public function setTimeout(int $timeout = self::DEFAULT_TIMEOUT): self;
+    public function setTimeout(int $timeout = self::DEFAULT_TIMEOUT): void;
 }

--- a/src/API/Process/Service/ProcessInterface.php
+++ b/src/API/Process/Service/ProcessInterface.php
@@ -53,7 +53,7 @@ interface ProcessInterface
      *
      * @see \PhpTuf\ComposerStager\API\Process\Service\ProcessInterface::run
      */
-    public function mustRun(?OutputCallbackInterface $callback = null): self;
+    public function mustRun(?OutputCallbackInterface $callback = null): void;
 
     /**
      * Runs the process.

--- a/src/API/Process/Service/ProcessInterface.php
+++ b/src/API/Process/Service/ProcessInterface.php
@@ -89,7 +89,7 @@ interface ProcessInterface
      *
      * @see \PhpTuf\ComposerStager\API\Process\Service\ProcessInterface::getEnv
      */
-    public function setEnv(array $env): self;
+    public function setEnv(array $env): void;
 
     /**
      * Sets the process timeout (max. runtime) in seconds.

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -98,7 +98,7 @@ final class Process implements ProcessInterface
         }
     }
 
-    public function mustRun(?OutputCallbackInterface $callback = null): self
+    public function mustRun(?OutputCallbackInterface $callback = null): void
     {
         try {
             $callbackAdapter = new OutputCallbackAdapter($callback);
@@ -110,8 +110,6 @@ final class Process implements ProcessInterface
                 $this->d()->exceptions(),
             ), 0, $e);
         }
-
-        return $this;
     }
 
     public function run(?OutputCallbackInterface $callback = null): int

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -129,12 +129,10 @@ final class Process implements ProcessInterface
         }
     }
 
-    public function setEnv(array $env): ProcessInterface
+    public function setEnv(array $env): void
     {
         $this->assertValidEnv($env);
         $this->symfonyProcess->setEnv($env);
-
-        return $this;
     }
 
     public function setTimeout(int $timeout = self::DEFAULT_TIMEOUT): self

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -135,7 +135,7 @@ final class Process implements ProcessInterface
         $this->symfonyProcess->setEnv($env);
     }
 
-    public function setTimeout(int $timeout = self::DEFAULT_TIMEOUT): self
+    public function setTimeout(int $timeout = self::DEFAULT_TIMEOUT): void
     {
         try {
             $this->symfonyProcess->setTimeout($timeout);
@@ -146,8 +146,6 @@ final class Process implements ProcessInterface
                 $this->d()->exceptions(),
             ), 0, $e);
         }
-
-        return $this;
     }
 
     /**

--- a/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
@@ -41,8 +41,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
         $this->processFactory = $this->prophesize(ProcessFactoryInterface::class);
         $this->process = $this->prophesize(ProcessInterface::class);
         $this->process
-            ->mustRun()
-            ->willReturn($this->process);
+            ->mustRun();
         $this->process
             ->getOutput()
             ->willReturn(json_encode([

--- a/tests/Precondition/Service/RsyncIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/RsyncIsAvailableUnitTest.php
@@ -41,8 +41,7 @@ final class RsyncIsAvailableUnitTest extends PreconditionUnitTestCase
         $this->processFactory = $this->prophesize(ProcessFactoryInterface::class);
         $this->process = $this->prophesize(ProcessInterface::class);
         $this->process
-            ->mustRun()
-            ->willReturn($this->process);
+            ->mustRun();
         $this->process
             ->getOutput()
             ->willReturn('');

--- a/tests/Process/Service/AbstractProcessRunnerUnitTest.php
+++ b/tests/Process/Service/AbstractProcessRunnerUnitTest.php
@@ -37,8 +37,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         $this->processFactory = $this->prophesize(ProcessFactoryInterface::class);
         $this->process = $this->prophesize(ProcessInterface::class);
         $this->process
-            ->mustRun(Argument::any())
-            ->willReturn($this->process);
+            ->mustRun(Argument::any());
         $this->process
             ->setTimeout(Argument::any());
     }
@@ -102,8 +101,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
             ->shouldBeCalledOnce();
         $this->process
             ->mustRun($callback)
-            ->shouldBeCalledOnce()
-            ->willReturn($this->process);
+            ->shouldBeCalledOnce();
         $this->processFactory
             ->create(...$expectedFactoryArguments)
             ->shouldBeCalledOnce()

--- a/tests/Process/Service/AbstractProcessRunnerUnitTest.php
+++ b/tests/Process/Service/AbstractProcessRunnerUnitTest.php
@@ -40,8 +40,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
             ->mustRun(Argument::any())
             ->willReturn($this->process);
         $this->process
-            ->setTimeout(Argument::any())
-            ->willReturn($this->process);
+            ->setTimeout(Argument::any());
     }
 
     private function createSut($executableName = null): AbstractProcessRunner
@@ -100,8 +99,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
             ->shouldBeCalledOnce();
         $this->process
             ->setTimeout($timeout)
-            ->shouldBeCalledOnce()
-            ->willReturn($this->process);
+            ->shouldBeCalledOnce();
         $this->process
             ->mustRun($callback)
             ->shouldBeCalledOnce()

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -124,7 +124,7 @@ final class ProcessUnitTest extends TestCase
             ->shouldBeCalledOnce();
         $sut = $this->createSut($givenConstructorArguments);
 
-        $actualSetEnvReturn = $sut->setEnv($envVars);
+        $sut->setEnv($envVars);
         $actualEnv = $sut->getEnv();
         $actualOutput = $sut->getOutput();
         $actualErrorOutput = $sut->getErrorOutput();
@@ -137,7 +137,6 @@ final class ProcessUnitTest extends TestCase
         self::assertSame($errorOutput, $actualErrorOutput, 'Returned correct error output.');
         self::assertSame($sut, $actualMustRunReturn, 'Returned "self" from ::mustRun().');
         self::assertSame($expectedRunReturn, $actualRunReturn, 'Returned correct status code from ::run().');
-        self::assertSame($sut, $actualSetEnvReturn, 'Returned "self" from ::setEnv().');
         self::assertSame($sut, $actualSetTimeoutReturn, 'Returned "self" from ::setTimeout().');
     }
 

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -130,14 +130,13 @@ final class ProcessUnitTest extends TestCase
         $actualErrorOutput = $sut->getErrorOutput();
         $actualMustRunReturn = $sut->mustRun(...$givenRunArguments);
         $actualRunReturn = $sut->run(...$givenRunArguments);
-        $actualSetTimeoutReturn = $sut->setTimeout(...$givenSetTimeoutArguments);
+        $sut->setTimeout(...$givenSetTimeoutArguments);
 
         self::assertSame($actualEnv, $envVars, 'Returned correct output.');
         self::assertSame($output, $actualOutput, 'Returned correct output.');
         self::assertSame($errorOutput, $actualErrorOutput, 'Returned correct error output.');
         self::assertSame($sut, $actualMustRunReturn, 'Returned "self" from ::mustRun().');
         self::assertSame($expectedRunReturn, $actualRunReturn, 'Returned correct status code from ::run().');
-        self::assertSame($sut, $actualSetTimeoutReturn, 'Returned "self" from ::setTimeout().');
     }
 
     public function providerBasicFunctionality(): array

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -128,14 +128,13 @@ final class ProcessUnitTest extends TestCase
         $actualEnv = $sut->getEnv();
         $actualOutput = $sut->getOutput();
         $actualErrorOutput = $sut->getErrorOutput();
-        $actualMustRunReturn = $sut->mustRun(...$givenRunArguments);
+        $sut->mustRun(...$givenRunArguments);
         $actualRunReturn = $sut->run(...$givenRunArguments);
         $sut->setTimeout(...$givenSetTimeoutArguments);
 
         self::assertSame($actualEnv, $envVars, 'Returned correct output.');
         self::assertSame($output, $actualOutput, 'Returned correct output.');
         self::assertSame($errorOutput, $actualErrorOutput, 'Returned correct error output.');
-        self::assertSame($sut, $actualMustRunReturn, 'Returned "self" from ::mustRun().');
         self::assertSame($expectedRunReturn, $actualRunReturn, 'Returned correct status code from ::run().');
     }
 


### PR DESCRIPTION
Making `API\Process\Service\ProcessInterface` methods fluid and returning `self`, following the lead of `symfony/process` seemed like a good idea at the time, but in retrospect probably provides negligible benefit, and it complicates unit tests, not to mention being the only part of the codebase that uses the pattern. This changes the methods to return `void`.