### PR TITLE
Make `ComposerIsAvailable` use `ComposerProcessRunner` instead of `ProcessFactory`

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,7 +18,7 @@ parameters:
         - src
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: 282aea28dca092b4141a77e48da90a80
+    preconditionSystemHash: a1e282c0d8f27e3cfee856b943543e31
     translationSystemHash: dec82389af17442fa61cc1fcc6f89c3e
     gitattributesExportInclude:
         - composer.json

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,7 +18,7 @@ parameters:
         - src
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
-    preconditionSystemHash: a1e282c0d8f27e3cfee856b943543e31
+    preconditionSystemHash: 8dfddc6171adcfe004a0bfaea2545f8e
     translationSystemHash: dec82389af17442fa61cc1fcc6f89c3e
     gitattributesExportInclude:
         - composer.json

--- a/src/Internal/Precondition/Service/ComposerIsAvailable.php
+++ b/src/Internal/Precondition/Service/ComposerIsAvailable.php
@@ -11,7 +11,8 @@ use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ComposerIsAvailableInterface;
-use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ComposerProcessRunnerInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
@@ -26,9 +27,10 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
     private string $executablePath;
 
     public function __construct(
+        private readonly ComposerProcessRunnerInterface $composerProcessRunner,
         EnvironmentInterface $environment,
         private readonly ExecutableFinderInterface $executableFinder,
-        private readonly ProcessFactoryInterface $processFactory,
+        private readonly OutputCallbackInterface $outputCallback,
         TranslatableFactoryInterface $translatableFactory,
     ) {
         parent::__construct($environment, $translatableFactory);
@@ -76,9 +78,7 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
     /** @throws \PhpTuf\ComposerStager\API\Exception\PreconditionException */
     private function assertIsActuallyComposer(): void
     {
-        $process = $this->getProcess();
-
-        if (!$this->isValidExecutable($process)) {
+        if (!$this->isValidExecutable()) {
             throw new PreconditionException($this, $this->t(
                 'The Composer executable at %name is invalid.',
                 $this->p(['%name' => $this->executablePath]),
@@ -87,36 +87,12 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
         }
     }
 
-    /** @throws \PhpTuf\ComposerStager\API\Exception\PreconditionException */
-    private function getProcess(): ProcessInterface
+    private function isValidExecutable(): bool
     {
         try {
-            return $this->processFactory->create([
-                $this->executablePath,
-                'list',
-                '--format=json',
-            ]);
-        } catch (LogicException $e) {
-            throw new PreconditionException($this, $this->t(
-                'Cannot check for Composer due to a host configuration problem: %details',
-                $this->p(['%details' => $e->getMessage()]),
-                $this->d()->exceptions(),
-            ), 0, $e);
-        }
-    }
-
-    private function isValidExecutable(ProcessInterface $process): bool
-    {
-        try {
-            $process->mustRun();
-            $output = $process->getOutput();
-        } catch (ExceptionInterface) {
-            return false;
-        }
-
-        try {
+            $output = $this->getComposerOutput();
             $data = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
+        } catch (ExceptionInterface|JsonException) {
             return false;
         }
 
@@ -125,5 +101,19 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
         }
 
         return $data['application']['name'] === 'Composer';
+    }
+
+    /** @throws \PhpTuf\ComposerStager\API\Exception\ExceptionInterface */
+    private function getComposerOutput(): string
+    {
+        $this->composerProcessRunner->run([
+            'list',
+            '--format=json',
+        ], null, [], $this->outputCallback);
+
+        $output = $this->outputCallback->getOutput();
+        $this->outputCallback->clearOutput();
+
+        return implode('', $output);
     }
 }

--- a/src/Internal/Precondition/Service/ComposerIsAvailable.php
+++ b/src/Internal/Precondition/Service/ComposerIsAvailable.php
@@ -106,10 +106,7 @@ final class ComposerIsAvailable extends AbstractPrecondition implements Composer
     /** @throws \PhpTuf\ComposerStager\API\Exception\ExceptionInterface */
     private function getComposerOutput(): string
     {
-        $this->composerProcessRunner->run([
-            'list',
-            '--format=json',
-        ], null, [], $this->outputCallback);
+        $this->composerProcessRunner->run(['--format=json'], null, [], $this->outputCallback);
 
         $output = $this->outputCallback->getOutput();
         $this->outputCallback->clearOutput();

--- a/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
@@ -80,10 +80,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
             ->find('composer')
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
         $this->composerProcessRunner
-            ->run([
-                'list',
-                '--format=json',
-            ], Argument::cetera())
+            ->run(['--format=json'], Argument::cetera())
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
 
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);

--- a/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
@@ -4,9 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
+use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
-use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
-use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
+use PhpTuf\ComposerStager\API\Process\Service\ComposerProcessRunnerInterface;
+use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ComposerIsAvailable;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -17,7 +18,6 @@ use Prophecy\Prophecy\ObjectProphecy;
  * @covers ::__construct
  * @covers ::assertExecutableExists
  * @covers ::assertIsActuallyComposer
- * @covers ::getProcess
  * @covers ::isValidExecutable
  */
 final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
@@ -28,44 +28,43 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
 
     private const COMPOSER_PATH = '/usr/bin/composer';
 
+    private ComposerProcessRunnerInterface|ObjectProphecy $composerProcessRunner;
     private ExecutableFinderInterface|ObjectProphecy $executableFinder;
-    private ProcessFactoryInterface|ObjectProphecy $processFactory;
-    private ProcessInterface|ObjectProphecy $process;
+    private OutputCallbackInterface|ObjectProphecy $outputCallback;
 
     protected function setUp(): void
     {
+        $this->composerProcessRunner = $this->prophesize(ComposerProcessRunnerInterface::class);
         $this->executableFinder = $this->prophesize(ExecutableFinderInterface::class);
         $this->executableFinder
             ->find('composer')
             ->willReturn(self::COMPOSER_PATH);
-        $this->processFactory = $this->prophesize(ProcessFactoryInterface::class);
-        $this->process = $this->prophesize(ProcessInterface::class);
-        $this->process
-            ->mustRun();
-        $this->process
+        $this->outputCallback = $this->prophesize(OutputCallbackInterface::class);
+        $this->outputCallback
+            ->clearOutput();
+        $this->outputCallback
             ->getOutput()
-            ->willReturn(json_encode([
-                'application' => [
-                    'name' => 'Composer',
-                    'version' => '2.0.0',
-                ],
-            ], JSON_THROW_ON_ERROR));
+            ->willReturn([
+                json_encode([
+                    'application' => [
+                        'name' => 'Composer',
+                        'version' => '2.0.0',
+                    ],
+                ], JSON_THROW_ON_ERROR),
+            ]);
 
         parent::setUp();
     }
 
     protected function createSut(): ComposerIsAvailable
     {
-        $environment = $this->environment->reveal();
-        $executableFinder = $this->executableFinder->reveal();
-        $process = $this->process->reveal();
-        $this->processFactory
-            ->create(Argument::cetera())
-            ->willReturn($process);
-        $processFactory = $this->processFactory->reveal();
-        $translatableFactory = self::createTranslatableFactory();
-
-        return new ComposerIsAvailable($environment, $executableFinder, $processFactory, $translatableFactory);
+        return new ComposerIsAvailable(
+            $this->composerProcessRunner->reveal(),
+            $this->environment->reveal(),
+            $this->executableFinder->reveal(),
+            $this->outputCallback->reveal(),
+            self::createTranslatableFactory(),
+        );
     }
 
     /**
@@ -73,7 +72,6 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
      * @covers ::assertIsActuallyComposer
      * @covers ::doAssertIsFulfilled
      * @covers ::getFulfilledStatusMessage
-     * @covers ::getProcess
      * @covers ::isValidExecutable
      */
     public function testFulfilled(): void
@@ -81,147 +79,33 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
         $this->executableFinder
             ->find('composer')
             ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
-        $this->process
-            ->mustRun()
-            ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
-        $this->processFactory
-            ->create([
-                self::COMPOSER_PATH,
+        $this->composerProcessRunner
+            ->run([
                 'list',
                 '--format=json',
-            ])
-            ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE)
-            ->willReturn($this->process->reveal());
+            ], Argument::cetera())
+            ->shouldBeCalledTimes(self::EXPECTED_CALLS_MULTIPLE);
 
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::assertExecutableExists */
-    public function testExecutableNotFound(): void
+    /** @dataProvider providerComposerProcessRunnerException */
+    public function testComposerProcessRunnerException(string $exception): void
     {
-        $activeDirPath = self::activeDirPath();
-        $stagingDirPath = self::stagingDirPath();
-
-        $previous = LogicException::class;
-        $this->executableFinder
-            ->find('composer')
-            ->willThrow($previous);
+        $this->expectException(PreconditionException::class);
+        $this->composerProcessRunner
+            ->run(Argument::cetera())
+            ->willThrow($exception);
         $sut = $this->createSut();
 
-        $message = 'Cannot find Composer.';
-        self::assertTranslatableMessage(
-            $message,
-            $sut->getStatusMessage($activeDirPath, $stagingDirPath, $this->exclusions),
-        );
-        self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath): void {
-            $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
-        }, PreconditionException::class, $message, null, $previous);
+        $sut->assertIsFulfilled(self::activeDirPath(), self::stagingDirPath());
     }
 
-    /**
-     * @covers ::assertExecutableExists
-     * @covers ::assertIsActuallyComposer
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getProcess
-     */
-    public function testFailedToCreateProcess(): void
-    {
-        $message = __METHOD__;
-        $previous = new LogicException(self::createTranslatableMessage($message));
-        $this->processFactory
-            ->create(Argument::type('array'))
-            ->willThrow($previous);
-
-        $this->doTestUnfulfilled(sprintf(
-            'Cannot check for Composer due to a host configuration problem: %s',
-            $message,
-        ), $previous::class);
-    }
-
-    /** @covers ::getProcess */
-    public function testFailedToRunProcess(): void
-    {
-        $activeDirPath = self::activeDirPath();
-        $stagingDirPath = self::stagingDirPath();
-
-        $this->process
-            ->mustRun()
-            ->willThrow(LogicException::class);
-        $sut = $this->createSut();
-
-        $message = $this->invalidComposerErrorMessage();
-        self::assertTranslatableMessage(
-            $message,
-            $sut->getStatusMessage($activeDirPath, $stagingDirPath, $this->exclusions),
-        );
-        self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath): void {
-            $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
-        }, PreconditionException::class, $message);
-    }
-
-    /** @covers ::isValidExecutable */
-    public function testFailedToGetOutput(): void
-    {
-        $activeDirPath = self::activeDirPath();
-        $stagingDirPath = self::stagingDirPath();
-
-        $previous = LogicException::class;
-        $this->process
-            ->getOutput()
-            ->willThrow($previous);
-        $sut = $this->createSut();
-
-        $message = $this->invalidComposerErrorMessage();
-        self::assertTranslatableMessage(
-            $message,
-            $sut->getStatusMessage($activeDirPath, $stagingDirPath, $this->exclusions),
-        );
-        self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath): void {
-            $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
-        }, PreconditionException::class, $message);
-    }
-
-    /** @dataProvider providerInvalidOutput */
-    public function testInvalidOutput(string $output): void
-    {
-        $activeDirPath = self::activeDirPath();
-        $stagingDirPath = self::stagingDirPath();
-
-        $this->process
-            ->getOutput()
-            ->willReturn($output);
-        $sut = $this->createSut();
-
-        $message = $this->invalidComposerErrorMessage();
-        self::assertTranslatableMessage(
-            $message,
-            $sut->getStatusMessage($activeDirPath, $stagingDirPath, $this->exclusions),
-        );
-        self::assertTranslatableException(function () use ($sut, $activeDirPath, $stagingDirPath): void {
-            $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions);
-        }, PreconditionException::class, $message);
-    }
-
-    public function providerInvalidOutput(): array
+    public function providerComposerProcessRunnerException(): array
     {
         return [
-            'No output' => [''],
-            'Empty JSON object' => ['{}'],
-            'Missing application name' => [
-                json_encode((object) [
-                    'application' => [],
-                ], JSON_THROW_ON_ERROR),
-            ],
-            'Incorrect application name' => [
-                json_encode((object) [
-                    'application' => ['name' => 'Incorrect'],
-                ], JSON_THROW_ON_ERROR),
-            ],
+            [LogicException::class],
+            [RuntimeException::class],
         ];
-    }
-
-    private function invalidComposerErrorMessage(): string
-    {
-        return sprintf('The Composer executable at %s is invalid.', self::COMPOSER_PATH);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/php-tuf/composer-stager/issues/348

This makes it possible to modify Composer command behavior everywhere (e.g., by adding environment variables) by just overriding `ComposerProcessRunner` once.