### PR TITLE
Outright fork Symfony Process

### DIFF
--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -3,6 +3,9 @@
     "source": {
         "directories": [
             "src"
+        ],
+        "excludes": [
+            "Internal/SymfonyProcess"
         ]
     },
     "timeout": 30,

--- a/src/Internal/Finder/Service/ExecutableFinder.php
+++ b/src/Internal/Finder/Service/ExecutableFinder.php
@@ -5,8 +5,8 @@ namespace PhpTuf\ComposerStager\Internal\Finder\Service;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Service\ExecutableFinder as SymfonyExecutableFinder;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
-use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
 
 /**
  * @package Finder

--- a/src/Internal/Process/Factory/SymfonyProcessFactory.php
+++ b/src/Internal/Process/Factory/SymfonyProcessFactory.php
@@ -5,9 +5,9 @@ namespace PhpTuf\ComposerStager\Internal\Process\Factory;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
-use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\FixedSymfonyProcess as SymfonyProcess;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\ExceptionInterface as SymfonyExceptionInterface;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
-use Symfony\Component\Process\Exception\ExceptionInterface as SymfonyExceptionInterface;
 
 /**
  * @package Process

--- a/src/Internal/Process/Factory/SymfonyProcessFactoryInterface.php
+++ b/src/Internal/Process/Factory/SymfonyProcessFactoryInterface.php
@@ -3,7 +3,7 @@
 namespace PhpTuf\ComposerStager\Internal\Process\Factory;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
-use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\FixedSymfonyProcess as SymfonyProcess;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 
 /**
  * Creates Symfony Process objects.
@@ -46,7 +46,7 @@ interface SymfonyProcessFactoryInterface
      * @throws \PhpTuf\ComposerStager\API\Exception\LogicException
      *   If the process cannot be created due to host configuration.
      *
-     * @see \Symfony\Component\Process\Process::__construct
+     * @see \PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process::__construct
      */
     public function create(array $command, ?PathInterface $cwd = null, array $env = []): SymfonyProcess;
 }

--- a/src/Internal/Process/Service/OutputCallbackAdapter.php
+++ b/src/Internal/Process/Service/OutputCallbackAdapter.php
@@ -4,7 +4,7 @@ namespace PhpTuf\ComposerStager\Internal\Process\Service;
 
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
-use Symfony\Component\Process\Process as SymfonyProcess;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 
 /**
  * @package Process

--- a/src/Internal/Process/Service/OutputCallbackAdapterInterface.php
+++ b/src/Internal/Process/Service/OutputCallbackAdapterInterface.php
@@ -13,6 +13,6 @@ namespace PhpTuf\ComposerStager\Internal\Process\Service;
  */
 interface OutputCallbackAdapterInterface
 {
-    /** @see \Symfony\Component\Process\Process::readPipes */
+    /** @see \PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process::readPipes */
     public function __invoke(string $type, string $buffer): void;
 }

--- a/src/Internal/Process/Service/Process.php
+++ b/src/Internal/Process/Service/Process.php
@@ -10,7 +10,7 @@ use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactoryInterface;
-use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\FixedSymfonyProcess as SymfonyProcess;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 use Throwable;
 

--- a/src/Internal/SymfonyProcess/LICENSE
+++ b/src/Internal/SymfonyProcess/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Internal/SymfonyProcess/README.md
+++ b/src/Internal/SymfonyProcess/README.md
@@ -1,0 +1,6 @@
+# Symfony Process
+
+This directory contains a fork of the Symfony Process component at `v6.4.8`. See these issues for details:
+
+- [[Process] Regression: Error output-handling is affecting Drupal core development by TravisCarden · Pull Request #57317 · symfony/symfony](https://github.com/symfony/symfony/pull/57317)
+- [Track upstream Symfony Process regression and remove workaround · Issue #369 · php-tuf/composer-stager](https://github.com/php-tuf/composer-stager/issues/369)

--- a/src/Internal/SymfonyProcess/Service/ExecutableFinder.php
+++ b/src/Internal/SymfonyProcess/Service/ExecutableFinder.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Service;
+
+/**
+ * Generic executable finder.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ExecutableFinder
+{
+    private array $suffixes = ['.exe', '.bat', '.cmd', '.com'];
+
+    /**
+     * Replaces default suffixes of executable.
+     *
+     * @return void
+     */
+    public function setSuffixes(array $suffixes)
+    {
+        $this->suffixes = $suffixes;
+    }
+
+    /**
+     * Adds new possible suffix to check for executable.
+     *
+     * @return void
+     */
+    public function addSuffix(string $suffix)
+    {
+        $this->suffixes[] = $suffix;
+    }
+
+    /**
+     * Finds an executable by name.
+     *
+     * @param string      $name      The executable name (without the extension)
+     * @param string|null $default   The default to return if no executable is found
+     * @param array       $extraDirs Additional dirs to check into
+     */
+    public function find(string $name, ?string $default = null, array $extraDirs = []): ?string
+    {
+        $dirs = array_merge(
+            explode(\PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
+            $extraDirs
+        );
+
+        $suffixes = [''];
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $pathExt = getenv('PATHEXT');
+            $suffixes = array_merge($pathExt ? explode(\PATH_SEPARATOR, $pathExt) : $this->suffixes, $suffixes);
+        }
+        foreach ($suffixes as $suffix) {
+            foreach ($dirs as $dir) {
+                if (@is_file($file = $dir.\DIRECTORY_SEPARATOR.$name.$suffix) && ('\\' === \DIRECTORY_SEPARATOR || @is_executable($file))) {
+                    return $file;
+                }
+
+                if (!@is_dir($dir) && basename($dir) === $name.$suffix && @is_executable($dir)) {
+                    return $dir;
+                }
+            }
+        }
+
+        $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
+        if (\function_exists('exec') && ($executablePath = strtok(@exec($command.' '.escapeshellarg($name)), \PHP_EOL)) && @is_executable($executablePath)) {
+            return $executablePath;
+        }
+
+        return $default;
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/ExceptionInterface.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/ExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+/**
+ * Marker Interface for the Process Component.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/InvalidArgumentException.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/InvalidArgumentException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+/**
+ * InvalidArgumentException for the Process Component.
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/LogicException.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/LogicException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+/**
+ * LogicException for the Process Component.
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/ProcessFailedException.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/ProcessFailedException.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
+
+/**
+ * Exception for failed processes.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ProcessFailedException extends RuntimeException
+{
+    private Process $process;
+
+    public function __construct(Process $process)
+    {
+        if ($process->isSuccessful()) {
+            throw new InvalidArgumentException('Expected a failed process, but the given process was successful.');
+        }
+
+        $error = sprintf('The command "%s" failed.'."\n\nExit Code: %s(%s)\n\nWorking directory: %s",
+            $process->getCommandLine(),
+            $process->getExitCode(),
+            $process->getExitCodeText(),
+            $process->getWorkingDirectory()
+        );
+
+        if (!$process->isOutputDisabled()) {
+            $error .= sprintf("\n\nOutput:\n================\n%s\n\nError Output:\n================\n%s",
+                $process->getOutput(),
+                $process->getErrorOutput()
+            );
+        }
+
+        parent::__construct($error);
+
+        $this->process = $process;
+    }
+
+    /**
+     * @return Process
+     */
+    public function getProcess()
+    {
+        return $this->process;
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/ProcessSignaledException.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/ProcessSignaledException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
+
+/**
+ * Exception that is thrown when a process has been signaled.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class ProcessSignaledException extends RuntimeException
+{
+    private Process $process;
+
+    public function __construct(Process $process)
+    {
+        $this->process = $process;
+
+        parent::__construct(sprintf('The process has been signaled with signal "%s".', $process->getTermSignal()));
+    }
+
+    public function getProcess(): Process
+    {
+        return $this->process;
+    }
+
+    public function getSignal(): int
+    {
+        return $this->getProcess()->getTermSignal();
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/ProcessTimedOutException.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/ProcessTimedOutException.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
+
+/**
+ * Exception that is thrown when a process times out.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ProcessTimedOutException extends RuntimeException
+{
+    public const TYPE_GENERAL = 1;
+    public const TYPE_IDLE = 2;
+
+    private Process $process;
+    private int $timeoutType;
+
+    public function __construct(Process $process, int $timeoutType)
+    {
+        $this->process = $process;
+        $this->timeoutType = $timeoutType;
+
+        parent::__construct(sprintf(
+            'The process "%s" exceeded the timeout of %s seconds.',
+            $process->getCommandLine(),
+            $this->getExceededTimeout()
+        ));
+    }
+
+    /**
+     * @return Process
+     */
+    public function getProcess()
+    {
+        return $this->process;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGeneralTimeout()
+    {
+        return self::TYPE_GENERAL === $this->timeoutType;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIdleTimeout()
+    {
+        return self::TYPE_IDLE === $this->timeoutType;
+    }
+
+    public function getExceededTimeout(): ?float
+    {
+        return match ($this->timeoutType) {
+            self::TYPE_GENERAL => $this->process->getTimeout(),
+            self::TYPE_IDLE => $this->process->getIdleTimeout(),
+            default => throw new \LogicException(sprintf('Unknown timeout type "%d".', $this->timeoutType)),
+        };
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/RunProcessFailedException.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/RunProcessFailedException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Messenger\RunProcessContext;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RunProcessFailedException extends RuntimeException
+{
+    public function __construct(ProcessFailedException $exception, public readonly RunProcessContext $context)
+    {
+        parent::__construct($exception->getMessage(), $exception->getCode());
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Exception/RuntimeException.php
+++ b/src/Internal/SymfonyProcess/Value/Exception/RuntimeException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception;
+
+/**
+ * RuntimeException for the Process Component.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Internal/SymfonyProcess/Value/InputStream.php
+++ b/src/Internal/SymfonyProcess/Value/InputStream.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\RuntimeException;
+
+/**
+ * Provides a way to continuously write to the input of a Process until the InputStream is closed.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @implements \IteratorAggregate<int, string>
+ */
+class InputStream implements \IteratorAggregate
+{
+    private ?\Closure $onEmpty = null;
+    private array $input = [];
+    private bool $open = true;
+
+    /**
+     * Sets a callback that is called when the write buffer becomes empty.
+     *
+     * @return void
+     */
+    public function onEmpty(?callable $onEmpty = null)
+    {
+        $this->onEmpty = null !== $onEmpty ? $onEmpty(...) : null;
+    }
+
+    /**
+     * Appends an input to the write buffer.
+     *
+     * @param resource|string|int|float|bool|\Traversable|null $input The input to append as scalar,
+     *                                                                stream resource or \Traversable
+     *
+     * @return void
+     */
+    public function write(mixed $input)
+    {
+        if (null === $input) {
+            return;
+        }
+        if ($this->isClosed()) {
+            throw new RuntimeException(sprintf('"%s" is closed.', static::class));
+        }
+        $this->input[] = ProcessUtils::validateInput(__METHOD__, $input);
+    }
+
+    /**
+     * Closes the write buffer.
+     *
+     * @return void
+     */
+    public function close()
+    {
+        $this->open = false;
+    }
+
+    /**
+     * Tells whether the write buffer is closed or not.
+     *
+     * @return bool
+     */
+    public function isClosed()
+    {
+        return !$this->open;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        $this->open = true;
+
+        while ($this->open || $this->input) {
+            if (!$this->input) {
+                yield '';
+                continue;
+            }
+            $current = array_shift($this->input);
+
+            if ($current instanceof \Iterator) {
+                yield from $current;
+            } else {
+                yield $current;
+            }
+            if (!$this->input && $this->open && null !== $onEmpty = $this->onEmpty) {
+                $this->write($onEmpty($this));
+            }
+        }
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Messenger/RunProcessContext.php
+++ b/src/Internal/SymfonyProcess/Value/Messenger/RunProcessContext.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Messenger;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RunProcessContext
+{
+    public readonly ?int $exitCode;
+    public readonly ?string $output;
+    public readonly ?string $errorOutput;
+
+    public function __construct(
+        public readonly RunProcessMessage $message,
+        Process $process,
+    ) {
+        $this->exitCode = $process->getExitCode();
+        $this->output = $process->isOutputDisabled() ? null : $process->getOutput();
+        $this->errorOutput = $process->isOutputDisabled() ? null : $process->getErrorOutput();
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Messenger/RunProcessMessage.php
+++ b/src/Internal/SymfonyProcess/Value/Messenger/RunProcessMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Messenger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class RunProcessMessage implements \Stringable
+{
+    public function __construct(
+        public readonly array $command,
+        public readonly ?string $cwd = null,
+        public readonly ?array $env = null,
+        public readonly mixed $input = null,
+        public readonly ?float $timeout = 60.0,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return implode(' ', $this->command);
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Messenger/RunProcessMessageHandler.php
+++ b/src/Internal/SymfonyProcess/Value/Messenger/RunProcessMessageHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Messenger;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\ProcessFailedException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\RunProcessFailedException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class RunProcessMessageHandler
+{
+    public function __invoke(RunProcessMessage $message): RunProcessContext
+    {
+        $process = new Process($message->command, $message->cwd, $message->env, $message->input, $message->timeout);
+
+        try {
+            return new RunProcessContext($message, $process->mustRun());
+        } catch (ProcessFailedException $e) {
+            throw new RunProcessFailedException($e, new RunProcessContext($message, $e->getProcess()));
+        }
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/PhpExecutableFinder.php
+++ b/src/Internal/SymfonyProcess/Value/PhpExecutableFinder.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Service\ExecutableFinder;
+
+/**
+ * An executable finder specifically designed for the PHP executable.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class PhpExecutableFinder
+{
+    private ExecutableFinder $executableFinder;
+
+    public function __construct()
+    {
+        $this->executableFinder = new ExecutableFinder();
+    }
+
+    /**
+     * Finds The PHP executable.
+     */
+    public function find(bool $includeArgs = true): string|false
+    {
+        if ($php = getenv('PHP_BINARY')) {
+            if (!is_executable($php)) {
+                $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v --';
+                if (\function_exists('exec') && $php = strtok(exec($command.' '.escapeshellarg($php)), \PHP_EOL)) {
+                    if (!is_executable($php)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+
+            if (@is_dir($php)) {
+                return false;
+            }
+
+            return $php;
+        }
+
+        $args = $this->findArguments();
+        $args = $includeArgs && $args ? ' '.implode(' ', $args) : '';
+
+        // PHP_BINARY return the current sapi executable
+        if (\PHP_BINARY && \in_array(\PHP_SAPI, ['cli', 'cli-server', 'phpdbg'], true)) {
+            return \PHP_BINARY.$args;
+        }
+
+        if ($php = getenv('PHP_PATH')) {
+            if (!@is_executable($php) || @is_dir($php)) {
+                return false;
+            }
+
+            return $php;
+        }
+
+        if ($php = getenv('PHP_PEAR_PHP_BIN')) {
+            if (@is_executable($php) && !@is_dir($php)) {
+                return $php;
+            }
+        }
+
+        if (@is_executable($php = \PHP_BINDIR.('\\' === \DIRECTORY_SEPARATOR ? '\\php.exe' : '/php')) && !@is_dir($php)) {
+            return $php;
+        }
+
+        $dirs = [\PHP_BINDIR];
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $dirs[] = 'C:\xampp\php\\';
+        }
+
+        return $this->executableFinder->find('php', false, $dirs);
+    }
+
+    /**
+     * Finds the PHP executable arguments.
+     */
+    public function findArguments(): array
+    {
+        $arguments = [];
+        if ('phpdbg' === \PHP_SAPI) {
+            $arguments[] = '-qrr';
+        }
+
+        return $arguments;
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/PhpProcess.php
+++ b/src/Internal/SymfonyProcess/Value/PhpProcess.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\LogicException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\RuntimeException;
+
+/**
+ * PhpProcess runs a PHP script in an independent process.
+ *
+ *     $p = new PhpProcess('<?php echo "foo"; ?>');
+ *     $p->run();
+ *     print $p->getOutput()."\n";
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class PhpProcess extends Process
+{
+    /**
+     * @param string      $script  The PHP script to run (as a string)
+     * @param string|null $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null  $env     The environment variables or null to use the same environment as the current PHP process
+     * @param int         $timeout The timeout in seconds
+     * @param array|null  $php     Path to the PHP binary to use with any additional arguments
+     */
+    public function __construct(string $script, ?string $cwd = null, ?array $env = null, int $timeout = 60, ?array $php = null)
+    {
+        if (null === $php) {
+            $executableFinder = new PhpExecutableFinder();
+            $php = $executableFinder->find(false);
+            $php = false === $php ? null : array_merge([$php], $executableFinder->findArguments());
+        }
+        if ('phpdbg' === \PHP_SAPI) {
+            $file = tempnam(sys_get_temp_dir(), 'dbg');
+            file_put_contents($file, $script);
+            register_shutdown_function('unlink', $file);
+            $php[] = $file;
+            $script = null;
+        }
+
+        parent::__construct($php, $cwd, $env, $script, $timeout);
+    }
+
+    public static function fromShellCommandline(string $command, ?string $cwd = null, ?array $env = null, mixed $input = null, ?float $timeout = 60): static
+    {
+        throw new LogicException(sprintf('The "%s()" method cannot be called when using "%s".', __METHOD__, self::class));
+    }
+
+    /**
+     * @return void
+     */
+    public function start(?callable $callback = null, array $env = [])
+    {
+        if (null === $this->getCommandLine()) {
+            throw new RuntimeException('Unable to find the PHP executable.');
+        }
+
+        parent::start($callback, $env);
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/PhpSubprocess.php
+++ b/src/Internal/SymfonyProcess/Value/PhpSubprocess.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\LogicException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\RuntimeException;
+
+/**
+ * PhpSubprocess runs a PHP command as a subprocess while keeping the original php.ini settings.
+ *
+ * For this, it generates a temporary php.ini file taking over all the current settings and disables
+ * loading additional .ini files. Basically, your command gets prefixed using "php -n -c /tmp/temp.ini".
+ *
+ * Given your php.ini contains "memory_limit=-1" and you have a "MemoryTest.php" with the following content:
+ *
+ *     <?php var_dump(ini_get('memory_limit'));
+ *
+ * These are the differences between the regular Process and PhpSubprocess classes:
+ *
+ *     $p = new Process(['php', '-d', 'memory_limit=256M', 'MemoryTest.php']);
+ *     $p->run();
+ *     print $p->getOutput()."\n";
+ *
+ * This will output "string(2) "-1", because the process is started with the default php.ini settings.
+ *
+ *     $p = new PhpSubprocess(['MemoryTest.php'], null, null, 60, ['php', '-d', 'memory_limit=256M']);
+ *     $p->run();
+ *     print $p->getOutput()."\n";
+ *
+ * This will output "string(4) "256M"", because the process is started with the temporarily created php.ini settings.
+ *
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ * @author Partially copied and heavily inspired from composer/xdebug-handler by John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class PhpSubprocess extends Process
+{
+    /**
+     * @param array       $command The command to run and its arguments listed as separate entries. They will automatically
+     *                             get prefixed with the PHP binary
+     * @param string|null $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null  $env     The environment variables or null to use the same environment as the current PHP process
+     * @param int         $timeout The timeout in seconds
+     * @param array|null  $php     Path to the PHP binary to use with any additional arguments
+     */
+    public function __construct(array $command, ?string $cwd = null, ?array $env = null, int $timeout = 60, ?array $php = null)
+    {
+        if (null === $php) {
+            $executableFinder = new PhpExecutableFinder();
+            $php = $executableFinder->find(false);
+            $php = false === $php ? null : array_merge([$php], $executableFinder->findArguments());
+        }
+
+        if (null === $php) {
+            throw new RuntimeException('Unable to find PHP binary.');
+        }
+
+        $tmpIni = $this->writeTmpIni($this->getAllIniFiles(), sys_get_temp_dir());
+
+        $php = array_merge($php, ['-n', '-c', $tmpIni]);
+        register_shutdown_function('unlink', $tmpIni);
+
+        $command = array_merge($php, $command);
+
+        parent::__construct($command, $cwd, $env, null, $timeout);
+    }
+
+    public static function fromShellCommandline(string $command, ?string $cwd = null, ?array $env = null, mixed $input = null, ?float $timeout = 60): static
+    {
+        throw new LogicException(sprintf('The "%s()" method cannot be called when using "%s".', __METHOD__, self::class));
+    }
+
+    public function start(?callable $callback = null, array $env = []): void
+    {
+        if (null === $this->getCommandLine()) {
+            throw new RuntimeException('Unable to find the PHP executable.');
+        }
+
+        parent::start($callback, $env);
+    }
+
+    private function writeTmpIni(array $iniFiles, string $tmpDir): string
+    {
+        if (false === $tmpfile = @tempnam($tmpDir, '')) {
+            throw new RuntimeException('Unable to create temporary ini file.');
+        }
+
+        // $iniFiles has at least one item and it may be empty
+        if ('' === $iniFiles[0]) {
+            array_shift($iniFiles);
+        }
+
+        $content = '';
+
+        foreach ($iniFiles as $file) {
+            // Check for inaccessible ini files
+            if (($data = @file_get_contents($file)) === false) {
+                throw new RuntimeException('Unable to read ini: '.$file);
+            }
+            // Check and remove directives after HOST and PATH sections
+            if (preg_match('/^\s*\[(?:PATH|HOST)\s*=/mi', $data, $matches)) {
+                $data = substr($data, 0, $matches[0][1]);
+            }
+
+            $content .= $data."\n";
+        }
+
+        // Merge loaded settings into our ini content, if it is valid
+        $config = parse_ini_string($content);
+        $loaded = ini_get_all(null, false);
+
+        if (false === $config || false === $loaded) {
+            throw new RuntimeException('Unable to parse ini data.');
+        }
+
+        $content .= $this->mergeLoadedConfig($loaded, $config);
+
+        // Work-around for https://bugs.php.net/bug.php?id=75932
+        $content .= "opcache.enable_cli=0\n";
+
+        if (false === @file_put_contents($tmpfile, $content)) {
+            throw new RuntimeException('Unable to write temporary ini file.');
+        }
+
+        return $tmpfile;
+    }
+
+    private function mergeLoadedConfig(array $loadedConfig, array $iniConfig): string
+    {
+        $content = '';
+
+        foreach ($loadedConfig as $name => $value) {
+            if (!\is_string($value)) {
+                continue;
+            }
+
+            if (!isset($iniConfig[$name]) || $iniConfig[$name] !== $value) {
+                // Double-quote escape each value
+                $content .= $name.'="'.addcslashes($value, '\\"')."\"\n";
+            }
+        }
+
+        return $content;
+    }
+
+    private function getAllIniFiles(): array
+    {
+        $paths = [(string) php_ini_loaded_file()];
+
+        if (false !== $scanned = php_ini_scanned_files()) {
+            $paths = array_merge($paths, array_map('trim', explode(',', $scanned)));
+        }
+
+        return $paths;
+    }
+}

--- a/src/Internal/SymfonyProcess/Value/Pipes/AbstractPipes.php
+++ b/src/Internal/SymfonyProcess/Value/Pipes/AbstractPipes.php
@@ -1,25 +1,22 @@
 <?php
 
 /*
- * This file is a temporary fork of part of the Symfony package to work around a regression.
- * @see https://github.com/symfony/symfony/pull/57317
+ * This file is part of the Symfony package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
- * For the full copyright and license information, see
- * https://github.com/symfony/symfony/blob/6.4/LICENSE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
-namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Pipes;
 
-use Symfony\Component\Process\Exception\InvalidArgumentException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\InvalidArgumentException;
 
 /**
  * @author Romain Neutron <imprec@gmail.com>
  *
  * @internal
- *
- * @infection-ignore-all
  */
 abstract class AbstractPipes implements PipesInterface
 {

--- a/src/Internal/SymfonyProcess/Value/Pipes/PipesInterface.php
+++ b/src/Internal/SymfonyProcess/Value/Pipes/PipesInterface.php
@@ -1,16 +1,15 @@
 <?php
 
 /*
- * This file is a temporary fork of part of the Symfony package to work around a regression.
- * @see https://github.com/symfony/symfony/pull/57317
+ * This file is part of the Symfony package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
- * For the full copyright and license information, see
- * https://github.com/symfony/symfony/blob/6.4/LICENSE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
-namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Pipes;
 
 /**
  * PipesInterface manages descriptors and pipes for the use of proc_open.
@@ -18,8 +17,6 @@ namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
  * @author Romain Neutron <imprec@gmail.com>
  *
  * @internal
- *
- * @infection-ignore-all
  */
 interface PipesInterface
 {

--- a/src/Internal/SymfonyProcess/Value/Pipes/UnixPipes.php
+++ b/src/Internal/SymfonyProcess/Value/Pipes/UnixPipes.php
@@ -1,18 +1,17 @@
 <?php
 
 /*
- * This file is a temporary fork of part of the Symfony package to work around a regression.
- * @see https://github.com/symfony/symfony/pull/57317
+ * This file is part of the Symfony package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
- * For the full copyright and license information, see
- * https://github.com/symfony/symfony/blob/6.4/LICENSE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
-namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Pipes;
 
-use Symfony\Component\Process\Process;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
 
 /**
  * UnixPipes implementation uses unix pipes as handles.
@@ -20,8 +19,6 @@ use Symfony\Component\Process\Process;
  * @author Romain Neutron <imprec@gmail.com>
  *
  * @internal
- *
- * @infection-ignore-all
  */
 class UnixPipes extends AbstractPipes
 {

--- a/src/Internal/SymfonyProcess/Value/Pipes/WindowsPipes.php
+++ b/src/Internal/SymfonyProcess/Value/Pipes/WindowsPipes.php
@@ -1,19 +1,18 @@
 <?php
 
 /*
- * This file is a temporary fork of part of the Symfony package to work around a regression.
- * @see https://github.com/symfony/symfony/pull/57317
+ * This file is part of the Symfony package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
- * For the full copyright and license information, see
- * https://github.com/symfony/symfony/blob/6.4/LICENSE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
-namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Pipes;
 
-use Symfony\Component\Process\Exception\RuntimeException;
-use Symfony\Component\Process\Process;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\RuntimeException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
 
 /**
  * WindowsPipes implementation uses temporary files as handles.
@@ -24,8 +23,6 @@ use Symfony\Component\Process\Process;
  * @author Romain Neutron <imprec@gmail.com>
  *
  * @internal
- *
- * @infection-ignore-all
  */
 class WindowsPipes extends AbstractPipes
 {

--- a/src/Internal/SymfonyProcess/Value/ProcessUtils.php
+++ b/src/Internal/SymfonyProcess/Value/ProcessUtils.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpTuf\ComposerStager\Internal\SymfonyProcess\Value;
+
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\InvalidArgumentException;
+
+/**
+ * ProcessUtils is a bunch of utility methods.
+ *
+ * This class contains static methods only and is not meant to be instantiated.
+ *
+ * @author Martin Hasoň <martin.hason@gmail.com>
+ */
+class ProcessUtils
+{
+    /**
+     * This class should not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Validates and normalizes a Process input.
+     *
+     * @param string $caller The name of method call that validates the input
+     * @param mixed  $input  The input to validate
+     *
+     * @throws InvalidArgumentException In case the input is not valid
+     */
+    public static function validateInput(string $caller, mixed $input): mixed
+    {
+        if (null !== $input) {
+            if (\is_resource($input)) {
+                return $input;
+            }
+            if (\is_scalar($input)) {
+                return (string) $input;
+            }
+            if ($input instanceof Process) {
+                return $input->getIterator($input::ITER_SKIP_ERR);
+            }
+            if ($input instanceof \Iterator) {
+                return $input;
+            }
+            if ($input instanceof \Traversable) {
+                return new \IteratorIterator($input);
+            }
+
+            throw new InvalidArgumentException(sprintf('"%s" only accepts strings, Traversable objects or stream resources.', $caller));
+        }
+
+        return $input;
+    }
+}

--- a/tests/Compatability/CompatibilityTest.php
+++ b/tests/Compatability/CompatibilityTest.php
@@ -2,9 +2,9 @@
 
 namespace PhpTuf\ComposerStager\Tests\Compatability;
 
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\Process;
 
 /** @coversNothing */
 final class CompatibilityTest extends TestCase

--- a/tests/FileSyncer/Service/FileSyncerFunctionalTest.php
+++ b/tests/FileSyncer/Service/FileSyncerFunctionalTest.php
@@ -5,9 +5,9 @@ namespace PhpTuf\ComposerStager\Tests\FileSyncer\Service;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\FileSyncer\Service\FileSyncerInterface;
 use PhpTuf\ComposerStager\Internal\FileSyncer\Service\FileSyncer;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
-use Symfony\Component\Process\Process as SymfonyProcess;
 
 /** @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Service\FileSyncer */
 final class FileSyncerFunctionalTest extends TestCase

--- a/tests/Finder/Service/ExecutableFinderUnitTest.php
+++ b/tests/Finder/Service/ExecutableFinderUnitTest.php
@@ -5,10 +5,10 @@ namespace PhpTuf\ComposerStager\Tests\Finder\Service;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinder;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Service\ExecutableFinder as SymfonyExecutableFinder;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinder

--- a/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
+++ b/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
@@ -5,9 +5,9 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use Symfony\Component\Process\Process;
 
 /**
  * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses

--- a/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
+++ b/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
@@ -4,11 +4,11 @@ namespace PhpTuf\ComposerStager\Tests\Process\Factory;
 
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactory;
-use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\FixedSymfonyProcess as SymfonyProcess;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\LogicException as SymfonyLogicException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestSpyInterface;
 use PhpTuf\ComposerStager\Tests\TestUtils\BuiltinFunctionMocker;
-use Symfony\Component\Process\Exception\LogicException as SymfonyLogicException;
 
 /** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactory */
 final class SymfonyProcessFactoryUnitTest extends TestCase

--- a/tests/Process/Service/OutputCallbackAdapterUnitTest.php
+++ b/tests/Process/Service/OutputCallbackAdapterUnitTest.php
@@ -5,8 +5,8 @@ namespace PhpTuf\ComposerStager\Tests\Process\Service;
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use PhpTuf\ComposerStager\Tests\TestCase;
-use Symfony\Component\Process\Process as SymfonyProcess;
 
 /** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter */
 final class OutputCallbackAdapterUnitTest extends TestCase

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -13,7 +13,9 @@ use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapterInterface;
 use PhpTuf\ComposerStager\Internal\Process\Service\Process;
-use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\FixedSymfonyProcess as SymfonyProcess;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\LogicException as SymfonyLogicException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\RuntimeException as SymfonyRuntimeException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestStringable;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
@@ -21,8 +23,6 @@ use PhpTuf\ComposerStager\Tests\TestUtils\ProcessTestHelper;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
-use Symfony\Component\Process\Exception\LogicException as SymfonyLogicException;
-use Symfony\Component\Process\Exception\RuntimeException as SymfonyRuntimeException;
 use Throwable;
 
 /**

--- a/tests/TestUtils/ProcessTestHelper.php
+++ b/tests/TestUtils/ProcessTestHelper.php
@@ -2,8 +2,8 @@
 
 namespace PhpTuf\ComposerStager\Tests\TestUtils;
 
-use Symfony\Component\Process\Exception\ProcessFailedException as SymfonyProcessFailedException;
-use Symfony\Component\Process\Process as SymfonyProcess;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Exception\ProcessFailedException as SymfonyProcessFailedException;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use Throwable;
 
 final class ProcessTestHelper

--- a/tools/PHPBench/TestUtils/FixtureHelper.php
+++ b/tools/PHPBench/TestUtils/FixtureHelper.php
@@ -3,10 +3,10 @@
 namespace PhpTuf\ComposerStager\PHPBench\TestUtils;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
+use PhpTuf\ComposerStager\Internal\SymfonyProcess\Value\Process as SymfonyProcess;
 use PhpTuf\ComposerStager\Tests\TestUtils\PathTestHelperTrait;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Filesystem\Path as SymfonyPath;
-use Symfony\Component\Process\Process as SymfonyProcess;
 
 final class FixtureHelper
 {


### PR DESCRIPTION
Selectively overriding parts of the Symfony Process component per https://github.com/php-tuf/composer-stager/pull/368 turned out to be infeasible. This just outright forks the last good version, with no modifications except moving it into the Composer Stager namespace for autoloading.