### PR TITLE
Update TranslatableInterface.php

### DIFF
--- a/src/API/Translation/Value/TranslatableInterface.php
+++ b/src/API/Translation/Value/TranslatableInterface.php
@@ -3,7 +3,6 @@
 namespace PhpTuf\ComposerStager\API\Translation\Value;
 
 use PhpTuf\ComposerStager\API\Translation\Service\TranslatorInterface;
-use Stringable;
 
 /**
  * Handles a translatable message.
@@ -22,7 +21,7 @@ use Stringable;
  *
  * @api This interface is subject to our backward compatibility promise and may be safely depended upon.
  */
-interface TranslatableInterface extends Stringable
+interface TranslatableInterface
 {
     /** Translates the message. */
     public function trans(?TranslatorInterface $translator = null, ?string $locale = null): string;

--- a/src/API/Translation/Value/TranslatableInterface.php
+++ b/src/API/Translation/Value/TranslatableInterface.php
@@ -23,6 +23,7 @@ use PhpTuf\ComposerStager\API\Translation\Service\TranslatorInterface;
  */
 interface TranslatableInterface
 {
+    public function __toString();
     /** Translates the message. */
     public function trans(?TranslatorInterface $translator = null, ?string $locale = null): string;
 }


### PR DESCRIPTION
\Stringable is a pseudo class - it is not necessary to extend it. Any class that implements __toString() will return true for an instanceof check.

The current code generates warnings when combined with Drupal's \Drupal\Component\Utility\ToStringTrait since that does
`public function __toString() {` whereas Stringable is `public function __toString(): string {`