### PR TITLE
Declare conflicts with vulnerable versions of symfony/process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,10 @@
         "symfony/yaml": "^6.3",
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
+    "conflict": {
+        "symfony/process": ">=6 <6.4.14 || >=7 <7.1.7",
+        "symfony/symfony": ">=6 <6.4.14 || >=7 <7.1.7"
+    },
     "suggest": {
         "symfony/dependency-injection": "For dependency injection",
         "symfony/translation": "For internationalization tools"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.1.0",
         "ext-json": "*",
         "symfony/filesystem": "^6.2 || ^7.0",
-        "symfony/process": "^6.2 || ^7.0",
+        "symfony/process": "^6.4.14 || ^7.1.7",
         "symfony/translation-contracts": "^3.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0c71d5db59ad7bef7376cdda99f7f7a",
+    "content-hash": "2db988fb038b837ffce302c7efa192e6",
     "packages": [
         {
             "name": "symfony/filesystem",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24a56f97c7c7a0bea502b28cd02cbba4",
+    "content-hash": "e0c71d5db59ad7bef7376cdda99f7f7a",
     "packages": [
         {
             "name": "symfony/filesystem",
@@ -233,16 +233,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.13",
+            "version": "v6.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1f9f59b46880201629df3bd950fc5ae8c55b960f"
+                "reference": "25214adbb0996d18112548de20c281be9f27279f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1f9f59b46880201629df3bd950fc5ae8c55b960f",
-                "reference": "1f9f59b46880201629df3bd950fc5ae8c55b960f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/25214adbb0996d18112548de20c281be9f27279f",
+                "reference": "25214adbb0996d18112548de20c281be9f27279f",
                 "shasum": ""
             },
             "require": {
@@ -274,7 +274,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.13"
+                "source": "https://github.com/symfony/process/tree/v6.4.14"
             },
             "funding": [
                 {
@@ -290,7 +290,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:18:03+00:00"
+            "time": "2024-11-06T09:25:01+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5716,13 +5716,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1.0",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`symfony/process` has announced a high severity vulnerability: [CVE-2024-51736 - Symfony vulnerable to command execution hijack on Windows with Process class](https://github.com/advisories/GHSA-qq5c-677p-737q). This could lead to serious compromises for users of Composer Stager. In order to prevent that, this adds Composer conflicts with vulnerable versions.