### PR TITLE
Make `Internal\Precondition\Service\RsyncIsAvailable` more robust

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,7 +17,7 @@ parameters:
         - docs/services.yml
         - src
     treatPhpDocTypesAsCertain: false
-    preconditionSystemHash: 8dfddc6171adcfe004a0bfaea2545f8e
+    preconditionSystemHash: 674c60ab5cf44e63da9c48fd60eadac7
     translationSystemHash: dec82389af17442fa61cc1fcc6f89c3e
     gitattributesExportInclude:
         - composer.json

--- a/src/Internal/Precondition/Service/RsyncIsAvailable.php
+++ b/src/Internal/Precondition/Service/RsyncIsAvailable.php
@@ -112,6 +112,7 @@ final class RsyncIsAvailable extends AbstractPrecondition implements RsyncIsAvai
             return false;
         }
 
-        return str_starts_with($output, 'rsync ');
+        // Look for "rsync version" at the beginning of any line of output (ignoring spacing).
+        return (bool) preg_match('/^ *rsync *version /m', $output);
     }
 }

--- a/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
+++ b/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
@@ -206,7 +206,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         TranslatableInterface $statusMessage,
         string $assertionMessage,
     ): void {
-        self::assertTrue($isFulfilled, $assertionMessage);
         self::assertEquals(static::FULFILLED_STATUS_MESSAGE, $statusMessage->trans(), 'Got correct status message');
+        self::assertTrue($isFulfilled, $assertionMessage);
     }
 }

--- a/tests/Precondition/Service/PreconditionUnitTestCase.php
+++ b/tests/Precondition/Service/PreconditionUnitTestCase.php
@@ -76,8 +76,8 @@ abstract class PreconditionUnitTestCase extends TestCase
         $actualStatusMessage = $sut->getStatusMessage($activeDirPath, $stagingDirPath, $this->exclusions, $timeout);
         $sut->assertIsFulfilled($activeDirPath, $stagingDirPath, $this->exclusions, $timeout);
 
-        self::assertTrue($isFulfilled);
         self::assertTranslatableMessage(static::FULFILLED_STATUS_MESSAGE, $actualStatusMessage, 'Got correct fulfilled status message.');
+        self::assertTrue($isFulfilled);
     }
 
     protected function doTestUnfulfilled(

--- a/tests/Precondition/Service/RsyncIsAvailableFunctionalTest.php
+++ b/tests/Precondition/Service/RsyncIsAvailableFunctionalTest.php
@@ -17,7 +17,7 @@ final class RsyncIsAvailableFunctionalTest extends TestCase
         $statusMessage = $sut->getStatusMessage(self::activeDirPath(), self::stagingDirPath());
 
         $message = 'Rsync is available.';
-        self::assertTrue($isFulfilled);
         self::assertSame($message, $statusMessage->trans());
+        self::assertTrue($isFulfilled);
     }
 }


### PR DESCRIPTION
`Internal\Precondition\Service\RsyncIsAvailable::isValidExecutable()` was written with the assumption that a valid `rsync` executable will always output a version beginning with the string `rsync`; but this turns out not to be the case, as illustrated here:

```
$ rsync --version
openrsync: protocol version 29
rsync version 2.6.9 compatible
```

This PR makes the test more robust by looking for `rsync version` at the beginning of _any_ line of output (ignoring spacing)