### PR TITLE
Stop looking for a PHAR file version of Composer

### DIFF
--- a/src/Internal/Finder/Service/ExecutableFinder.php
+++ b/src/Internal/Finder/Service/ExecutableFinder.php
@@ -26,11 +26,6 @@ final class ExecutableFinder implements ExecutableFinderInterface
 
     public function find(string $name): string
     {
-        // Look for PHAR files--a common case with Composer, for example.
-        // Note: As of 04/09/2024, this doesn't actually work as documented.
-        // @see https://github.com/symfony/symfony/pull/52679
-        $this->symfonyExecutableFinder->addSuffix('.phar');
-
         // Look for executable.
         $path = $this->symfonyExecutableFinder->find($name);
 

--- a/tests/Finder/Service/ExecutableFinderUnitTest.php
+++ b/tests/Finder/Service/ExecutableFinderUnitTest.php
@@ -40,9 +40,6 @@ final class ExecutableFinderUnitTest extends TestCase
     {
         $command = 'command_name';
         $this->symfonyExecutableFinder
-            ->addSuffix('.phar')
-            ->shouldBeCalled();
-        $this->symfonyExecutableFinder
             ->find($command)
             ->shouldBeCalledOnce()
             ->willReturn($command);
@@ -57,9 +54,6 @@ final class ExecutableFinderUnitTest extends TestCase
     public function testFindNotFound(): void
     {
         $command = 'command_name';
-        $this->symfonyExecutableFinder
-            ->addSuffix('.phar')
-            ->shouldBeCalledOnce();
         $this->symfonyExecutableFinder
             ->find($command)
             ->shouldBeCalledOnce()


### PR DESCRIPTION
The releases of https://github.com/symfony/symfony/pull/52679 and https://github.com/symfony/symfony/pull/58711, put together, broke our Windows support--apparently because the former caused `Symfony\Component\Process\ExecutableFinder` to start finding PHAR files the way it's supposed to (but wasn't before) and the latter caused them to be prioritized above BAT files, as far as I can tell. This created a scenario that couldn't exist before and therefore hadn't been tested: PHAR files on Windows. Since it never would have worked anyway, we'll just remove it.