### PR TITLE
Upgrade PHPUnit to 10.x

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -89,7 +89,6 @@
       <path value="$PROJECT_DIR$/vendor/sebastian/object-enumerator" />
       <path value="$PROJECT_DIR$/vendor/sebastian/object-reflector" />
       <path value="$PROJECT_DIR$/vendor/sebastian/recursion-context" />
-      <path value="$PROJECT_DIR$/vendor/sebastian/resource-operations" />
       <path value="$PROJECT_DIR$/vendor/sebastian/type" />
       <path value="$PROJECT_DIR$/vendor/sebastian/version" />
       <path value="$PROJECT_DIR$/vendor/seld/jsonlint" />
@@ -117,6 +116,20 @@
       <path value="$PROJECT_DIR$/vendor/theseer/tokenizer" />
       <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
       <path value="$PROJECT_DIR$/vendor/webmozart/glob" />
+      <path value="$PROJECT_DIR$/vendor/ergebnis/composer-normalize" />
+      <path value="$PROJECT_DIR$/vendor/ergebnis/json" />
+      <path value="$PROJECT_DIR$/vendor/ergebnis/json-normalizer" />
+      <path value="$PROJECT_DIR$/vendor/ergebnis/json-pointer" />
+      <path value="$PROJECT_DIR$/vendor/ergebnis/json-printer" />
+      <path value="$PROJECT_DIR$/vendor/ergebnis/json-schema-validator" />
+      <path value="$PROJECT_DIR$/vendor/jangregor/phpstan-prophecy" />
+      <path value="$PROJECT_DIR$/vendor/localheinz/diff" />
+      <path value="$PROJECT_DIR$/vendor/pdepend/pdepend" />
+      <path value="$PROJECT_DIR$/vendor/php-parallel-lint/php-parallel-lint" />
+      <path value="$PROJECT_DIR$/vendor/phpmd/phpmd" />
+      <path value="$PROJECT_DIR$/vendor/phpstan/phpstan-deprecation-rules" />
+      <path value="$PROJECT_DIR$/vendor/psalm/phar" />
+      <path value="$PROJECT_DIR$/vendor/infection/mutator" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="8.1" />

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^10.5.19",
         "rector/rector": "^0.17.5 || ^0.18.0 || ^0.19.0 || ^1.0.0",
         "slevomat/coding-standard": "^8.13",
         "squizlabs/php_codesniffer": "^3.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2db988fb038b837ffce302c7efa192e6",
+    "content-hash": "5fe8ee3191d24e9417a1a6d7fbe25dad",
     "packages": [
         {
             "name": "symfony/filesystem",
@@ -1440,16 +1440,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -1488,7 +1488,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -1496,7 +1496,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2505,16 +2505,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
@@ -2522,18 +2522,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2542,7 +2542,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -2571,7 +2571,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -2579,32 +2579,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2631,7 +2631,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -2639,28 +2640,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2668,7 +2669,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2694,7 +2695,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2702,32 +2703,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2753,7 +2754,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -2761,32 +2763,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2812,7 +2814,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2820,24 +2822,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.21",
+            "version": "10.5.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
+                "reference": "a86773b9e887a67bc53efa9da9ad6e3f2498c132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a86773b9e887a67bc53efa9da9ad6e3f2498c132",
+                "reference": "a86773b9e887a67bc53efa9da9ad6e3f2498c132",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2847,27 +2848,26 @@
                 "myclabs/deep-copy": "^1.12.0",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.3",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -2875,7 +2875,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -2907,7 +2907,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.38"
             },
             "funding": [
                 {
@@ -2923,7 +2923,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T10:50:18+00:00"
+            "time": "2024-10-28T13:06:21+00:00"
         },
         {
             "name": "psr/cache",
@@ -3267,28 +3267,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3311,7 +3311,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -3319,32 +3320,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3367,7 +3368,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3375,32 +3376,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3422,7 +3423,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3430,34 +3431,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3496,7 +3499,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
             },
             "funding": [
                 {
@@ -3504,33 +3508,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2024-10-18T14:56:07+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -3553,7 +3557,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -3561,33 +3566,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -3619,7 +3624,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -3627,27 +3633,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -3655,7 +3661,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -3674,7 +3680,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -3682,7 +3688,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -3690,34 +3697,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -3759,7 +3766,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
             },
             "funding": [
                 {
@@ -3767,38 +3775,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2024-03-02T07:17:12+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3817,13 +3822,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
@@ -3831,33 +3837,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3880,7 +3886,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -3888,34 +3895,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3937,7 +3944,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3945,32 +3952,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3992,7 +3999,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -4000,32 +4007,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4055,7 +4062,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4063,86 +4070,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4165,7 +4118,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -4173,29 +4126,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4218,7 +4171,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -4226,7 +4179,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -5716,13 +5669,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1.0",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,14 +5,12 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheResultFile="var/phpunit/test-results"
+         cacheDirectory="var/phpunit/cache"
          executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         failOnRisky="true"
+         requireCoverageMetadata="true"
          failOnWarning="true"
-         verbose="true"
+         failOnRisky="true"
+         defaultTestSuite="all"
 >
     <testsuites>
         <testsuite name="all">
@@ -30,12 +28,13 @@
         </testsuite>
     </testsuites>
 
-    <coverage cacheDirectory="var/phpunit/coverage-cache"
-              processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
+    </source>
 
+    <coverage>
         <report>
             <clover outputFile="var/phpunit/clover.xml"/>
             <html outputDirectory="var/phpunit/html-coverage"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://docs.phpunit.de/en/9.6/configuration.html -->
+<!-- https://docs.phpunit.de/en/10.5/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"

--- a/tests/Compatibility/CompatibilityTest.php
+++ b/tests/Compatibility/CompatibilityTest.php
@@ -3,10 +3,12 @@
 namespace PhpTuf\ComposerStager\Tests\Compatibility;
 
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
-/** @coversNothing */
+#[CoversNothing]
 final class CompatibilityTest extends TestCase
 {
     // @see https://github.com/php-tuf/composer-stager/wiki/Library-compatibility-policy#drupal
@@ -29,10 +31,9 @@ final class CompatibilityTest extends TestCase
     /**
      * Tests for Composer compatibility with supported Drupal core versions.
      *
-     * @dataProvider providerDrupalVersionCompatibility
-     *
      * @see ../../composer.json
      */
+    #[DataProvider('providerDrupalVersionCompatibility')]
     public function testDrupalVersionCompatibility(string $versionConstraint): void
     {
         $fixtureDir = self::fixtureDir($versionConstraint);
@@ -54,7 +55,7 @@ final class CompatibilityTest extends TestCase
         ));
     }
 
-    public function providerDrupalVersionCompatibility(): array
+    public static function providerDrupalVersionCompatibility(): array
     {
         $data = [];
 

--- a/tests/Core/BeginnerUnitTest.php
+++ b/tests/Core/BeginnerUnitTest.php
@@ -15,14 +15,12 @@ use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\Internal\Core\Beginner;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Beginner
- *
- * @covers \PhpTuf\ComposerStager\Internal\Core\Beginner::__construct
- */
+#[CoversClass(Beginner::class)]
 final class BeginnerUnitTest extends TestCase
 {
     private BeginnerPreconditionsInterface|ObjectProphecy $preconditions;
@@ -42,7 +40,6 @@ final class BeginnerUnitTest extends TestCase
         return new Beginner($fileSyncer, $preconditions);
     }
 
-    /** @covers ::begin */
     public function testBeginWithMinimumParams(): void
     {
         $timeout = ProcessInterface::DEFAULT_TIMEOUT;
@@ -58,32 +55,28 @@ final class BeginnerUnitTest extends TestCase
         $sut->begin(self::activeDirPath(), self::stagingDirPath());
     }
 
-    /**
-     * @covers ::begin
-     *
-     * @dataProvider providerBeginWithOptionalParams
-     */
+    #[DataProvider('providerBeginWithOptionalParams')]
     public function testBeginWithOptionalParams(
         string $activeDir,
         string $stagingDir,
-        ?PathListInterface $exclusions,
+        ?PathListInterface $givenExclusions,
         ?OutputCallbackInterface $callback,
         int $timeout,
     ): void {
         $activeDir = self::createPath($activeDir);
         $stagingDir = self::createPath($stagingDir);
         $this->preconditions
-            ->assertIsFulfilled($activeDir, $stagingDir, $exclusions, $timeout)
+            ->assertIsFulfilled($activeDir, $stagingDir, $givenExclusions, $timeout)
             ->shouldBeCalledOnce();
         $this->fileSyncer
-            ->sync($activeDir, $stagingDir, $exclusions, $callback, $timeout)
+            ->sync($activeDir, $stagingDir, $givenExclusions, $callback, $timeout)
             ->shouldBeCalledOnce();
         $sut = $this->createSut();
 
-        $sut->begin($activeDir, $stagingDir, $exclusions, $callback, $timeout);
+        $sut->begin($activeDir, $stagingDir, $givenExclusions, $callback, $timeout);
     }
 
-    public function providerBeginWithOptionalParams(): array
+    public static function providerBeginWithOptionalParams(): array
     {
         return [
             'Minimum values' => [
@@ -103,7 +96,6 @@ final class BeginnerUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::begin */
     public function testBeginPreconditionsUnfulfilled(): void
     {
         $message = __METHOD__;
@@ -118,11 +110,7 @@ final class BeginnerUnitTest extends TestCase
         }, PreconditionException::class, $previous->getTranslatableMessage());
     }
 
-    /**
-     * @covers ::begin
-     *
-     * @dataProvider providerExceptions
-     */
+    #[DataProvider('providerExceptions')]
     public function testExceptions(ExceptionInterface $caughtException): void
     {
         $this->fileSyncer
@@ -135,7 +123,7 @@ final class BeginnerUnitTest extends TestCase
         }, RuntimeException::class, $caughtException->getMessage(), null, $caughtException::class);
     }
 
-    public function providerExceptions(): array
+    public static function providerExceptions(): array
     {
         return [
             'InvalidArgumentException' => [

--- a/tests/Core/CleanerUnitTest.php
+++ b/tests/Core/CleanerUnitTest.php
@@ -12,14 +12,12 @@ use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\Internal\Core\Cleaner;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Cleaner
- *
- * @covers \PhpTuf\ComposerStager\Internal\Core\Cleaner::__construct
- */
+#[CoversClass(Cleaner::class)]
 final class CleanerUnitTest extends TestCase
 {
     private CleanerPreconditionsInterface|ObjectProphecy $preconditions;
@@ -39,7 +37,6 @@ final class CleanerUnitTest extends TestCase
         return new Cleaner($filesystem, $preconditions);
     }
 
-    /** @covers ::clean */
     public function testCleanWithMinimumParams(): void
     {
         $timeout = ProcessInterface::DEFAULT_TIMEOUT;
@@ -55,11 +52,7 @@ final class CleanerUnitTest extends TestCase
         $sut->clean(self::activeDirPath(), self::stagingDirPath());
     }
 
-    /**
-     * @covers ::clean
-     *
-     * @dataProvider providerCleanWithOptionalParams
-     */
+    #[DataProvider('providerCleanWithOptionalParams')]
     public function testCleanWithOptionalParams(string $path, ?OutputCallbackInterface $callback, int $timeout): void
     {
         $path = self::createPath($path);
@@ -74,7 +67,7 @@ final class CleanerUnitTest extends TestCase
         $sut->clean(self::activeDirPath(), $path, $callback, $timeout);
     }
 
-    public function providerCleanWithOptionalParams(): array
+    public static function providerCleanWithOptionalParams(): array
     {
         return [
             'Minimum values' => [
@@ -90,7 +83,6 @@ final class CleanerUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::clean */
     public function testCleanPreconditionsUnfulfilled(): void
     {
         $message = __METHOD__;
@@ -105,7 +97,6 @@ final class CleanerUnitTest extends TestCase
         }, PreconditionException::class, $previous->getTranslatableMessage());
     }
 
-    /** @covers ::clean */
     public function testCleanFailToRemove(): void
     {
         $message = self::createTranslatableExceptionMessage(__METHOD__);

--- a/tests/Core/CommitterUnitTest.php
+++ b/tests/Core/CommitterUnitTest.php
@@ -15,14 +15,12 @@ use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\Internal\Core\Committer;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Committer
- *
- * @covers \PhpTuf\ComposerStager\Internal\Core\Committer::__construct
- */
+#[CoversClass(Committer::class)]
 final class CommitterUnitTest extends TestCase
 {
     private CommitterPreconditionsInterface|ObjectProphecy $preconditions;
@@ -42,7 +40,6 @@ final class CommitterUnitTest extends TestCase
         return new Committer($fileSyncer, $preconditions);
     }
 
-    /** @covers ::commit */
     public function testCommitWithMinimumParams(): void
     {
         $timeout = ProcessInterface::DEFAULT_TIMEOUT;
@@ -58,11 +55,7 @@ final class CommitterUnitTest extends TestCase
         $sut->commit(self::stagingDirPath(), self::activeDirPath());
     }
 
-    /**
-     * @covers ::commit
-     *
-     * @dataProvider providerCommitWithOptionalParams
-     */
+    #[DataProvider('providerCommitWithOptionalParams')]
     public function testCommitWithOptionalParams(
         string $stagingDir,
         string $activeDir,
@@ -83,7 +76,7 @@ final class CommitterUnitTest extends TestCase
         $sut->commit($stagingDir, $activeDir, $exclusions, $callback, $timeout);
     }
 
-    public function providerCommitWithOptionalParams(): array
+    public static function providerCommitWithOptionalParams(): array
     {
         return [
             'Minimum values' => [
@@ -103,7 +96,6 @@ final class CommitterUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::commit */
     public function testCommitPreconditionsUnfulfilled(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -122,11 +114,7 @@ final class CommitterUnitTest extends TestCase
         }, PreconditionException::class, $previous->getTranslatableMessage());
     }
 
-    /**
-     * @covers ::commit
-     *
-     * @dataProvider providerExceptions
-     */
+    #[DataProvider('providerExceptions')]
     public function testExceptions(ExceptionInterface $caughtException): void
     {
         $stagingDirPath = self::stagingDirPath();
@@ -142,7 +130,7 @@ final class CommitterUnitTest extends TestCase
         }, RuntimeException::class, $caughtException->getMessage(), null, $caughtException::class);
     }
 
-    public function providerExceptions(): array
+    public static function providerExceptions(): array
     {
         return [
             'InvalidArgumentException' => [

--- a/tests/Core/StagerUnitTest.php
+++ b/tests/Core/StagerUnitTest.php
@@ -15,14 +15,12 @@ use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\Internal\Core\Stager;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Core\Stager
- *
- * @covers \PhpTuf\ComposerStager\Internal\Core\Stager
- */
+#[CoversClass(Stager::class)]
 final class StagerUnitTest extends TestCase
 {
     private const INERT_COMMAND = 'about';
@@ -45,7 +43,6 @@ final class StagerUnitTest extends TestCase
         return new Stager($composerRunner, $preconditions, $translatableFactory);
     }
 
-    /** @covers ::stage */
     public function testStageWithMinimumParams(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -67,7 +64,7 @@ final class StagerUnitTest extends TestCase
         $sut->stage([self::INERT_COMMAND], $activeDirPath, $stagingDirPath);
     }
 
-    /** @dataProvider providerStageWithOptionalParams */
+    #[DataProvider('providerStageWithOptionalParams')]
     public function testStageWithOptionalParams(
         array $givenCommand,
         array $expectedCommand,
@@ -88,7 +85,7 @@ final class StagerUnitTest extends TestCase
         $sut->stage($givenCommand, $activeDirPath, $stagingDirPath, $callback, $timeout);
     }
 
-    public function providerStageWithOptionalParams(): array
+    public static function providerStageWithOptionalParams(): array
     {
         return [
             'Minimum values ' => [
@@ -113,7 +110,6 @@ final class StagerUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::validateCommand */
     public function testCommandIsEmpty(): void
     {
         $message = 'The Composer command cannot be empty';
@@ -125,7 +121,6 @@ final class StagerUnitTest extends TestCase
         }, InvalidArgumentException::class, $expectedExceptionMessage);
     }
 
-    /** @covers ::validateCommand */
     public function testCommandContainsComposer(): void
     {
         $sut = $this->createSut();
@@ -141,11 +136,7 @@ final class StagerUnitTest extends TestCase
         }, InvalidArgumentException::class, $expectedExceptionMessage);
     }
 
-    /**
-     * @covers ::validateCommand
-     *
-     * @dataProvider providerCommandContainsWorkingDirOption
-     */
+    #[DataProvider('providerCommandContainsWorkingDirOption')]
     public function testCommandContainsWorkingDirOption(array $command): void
     {
         $sut = $this->createSut();
@@ -158,7 +149,7 @@ final class StagerUnitTest extends TestCase
         }, InvalidArgumentException::class, $expectedExceptionMessage);
     }
 
-    public function providerCommandContainsWorkingDirOption(): array
+    public static function providerCommandContainsWorkingDirOption(): array
     {
         return [
             'Full name' => [['--working-dir' => 'example/package']],
@@ -166,7 +157,6 @@ final class StagerUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::stage */
     public function testStagePreconditionsUnfulfilled(): void
     {
         $message = __METHOD__;
@@ -182,7 +172,7 @@ final class StagerUnitTest extends TestCase
         }, PreconditionException::class, $previous->getTranslatableMessage());
     }
 
-    /** @dataProvider providerExceptions */
+    #[DataProvider('providerExceptions')]
     public function testExceptions(ExceptionInterface $caughtException): void
     {
         $this->composerRunner
@@ -195,7 +185,7 @@ final class StagerUnitTest extends TestCase
         }, RuntimeException::class, $caughtException->getMessage(), null, $caughtException::class);
     }
 
-    public function providerExceptions(): array
+    public static function providerExceptions(): array
     {
         return [
             'IOException' => [

--- a/tests/EndToEnd/EndToEndFunctionalTest.php
+++ b/tests/EndToEnd/EndToEndFunctionalTest.php
@@ -15,14 +15,15 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\EnvironmentTestHelper;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Provides end-to-end functional tests, including the API and internal layers.
- *
- * @coversNothing
- *
- * @group slow
  */
+#[CoversNothing]
+#[Group('slow')]
 final class EndToEndFunctionalTest extends TestCase
 {
     private const CHANGED_CONTENT = 'changed';
@@ -53,11 +54,8 @@ final class EndToEndFunctionalTest extends TestCase
         self::removeTestEnvironment();
     }
 
-    /**
-     * @dataProvider providerDirectories
-     *
-     * @group slow
-     */
+    #[DataProvider('providerDirectories')]
+    #[Group('slow')]
     public function testSync(string $activeDir, string $stagingDir): void
     {
         $activeDirPath = self::createPath($activeDir);
@@ -337,7 +335,7 @@ final class EndToEndFunctionalTest extends TestCase
         self::assertFileDoesNotExist($stagingDirPath->absolute(), 'Staging directory was completely removed.');
     }
 
-    public function providerDirectories(): array
+    public static function providerDirectories(): array
     {
         $data = [
             'Siblings' => [

--- a/tests/Environment/Service/EnvironmentFunctionalTest.php
+++ b/tests/Environment/Service/EnvironmentFunctionalTest.php
@@ -4,8 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Environment\Service;
 
 use PhpTuf\ComposerStager\Internal\Environment\Service\Environment;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Environment\Service\Environment */
+#[CoversClass(Environment::class)]
 final class EnvironmentFunctionalTest extends TestCase
 {
     private function createSut(): Environment
@@ -13,11 +15,7 @@ final class EnvironmentFunctionalTest extends TestCase
         return new Environment();
     }
 
-    /**
-     * @covers ::setTimeLimit
-     *
-     * @dataProvider providerSetTimeLimit
-     */
+    #[DataProvider('providerSetTimeLimit')]
     public function testSetTimeLimit(int $timeout): void
     {
         $sut = $this->createSut();
@@ -30,7 +28,7 @@ final class EnvironmentFunctionalTest extends TestCase
         self::assertSame($result, set_time_limit($timeout), 'Returned same result as set_time_limit() called directly.');
     }
 
-    public function providerSetTimeLimit(): array
+    public static function providerSetTimeLimit(): array
     {
         return [
             'Positive number' => [30],

--- a/tests/Environment/Service/EnvironmentUnitTest.php
+++ b/tests/Environment/Service/EnvironmentUnitTest.php
@@ -6,9 +6,12 @@ use PhpTuf\ComposerStager\Internal\Environment\Service\Environment;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestSpyInterface;
 use PhpTuf\ComposerStager\Tests\TestUtils\BuiltinFunctionMocker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Prophecy\Argument;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Environment\Service\Environment */
+#[CoversClass(Environment::class)]
 final class EnvironmentUnitTest extends TestCase
 {
     private function createSut(): Environment
@@ -16,7 +19,6 @@ final class EnvironmentUnitTest extends TestCase
         return new Environment();
     }
 
-    /** @covers ::isWindows */
     public function testIsWindows(): void
     {
         $isWindowsDirectorySeparator = DIRECTORY_SEPARATOR === '\\';
@@ -25,13 +27,8 @@ final class EnvironmentUnitTest extends TestCase
         self::assertEquals($isWindowsDirectorySeparator, $sut->isWindows());
     }
 
-    /**
-     * @covers ::setTimeLimit
-     *
-     * @dataProvider providerSetTimeLimitFunctionExists
-     *
-     * @runInSeparateProcess
-     */
+    #[DataProvider('providerSetTimeLimitFunctionExists')]
+    #[RunInSeparateProcess]
     public function testSetTimeLimitFunctionExists(int $seconds, bool $setTimeLimitReturn): void
     {
         BuiltinFunctionMocker::mock(['set_time_limit' => $this->prophesize(TestSpyInterface::class)]);
@@ -46,7 +43,7 @@ final class EnvironmentUnitTest extends TestCase
         self::assertSame($actualReturn, $setTimeLimitReturn, 'Passed through the return value from set_time_limit().');
     }
 
-    public function providerSetTimeLimitFunctionExists(): array
+    public static function providerSetTimeLimitFunctionExists(): array
     {
         return [
             [
@@ -60,11 +57,7 @@ final class EnvironmentUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::setTimeLimit
-     *
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testSetTimeLimitFunctionDoesNotExist(): void
     {
         BuiltinFunctionMocker::mock([

--- a/tests/Exception/ExceptionUnitTest.php
+++ b/tests/Exception/ExceptionUnitTest.php
@@ -10,18 +10,17 @@ use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Exception\RuntimeException;
 use PhpTuf\ComposerStager\Internal\Translation\Value\TranslatableMessage;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 
+#[CoversClass(InvalidArgumentException::class)]
+#[CoversClass(IOException::class)]
+#[CoversClass(LogicException::class)]
+#[CoversClass(RuntimeException::class)]
 final class ExceptionUnitTest extends TestCase
 {
-    /**
-     * @covers \PhpTuf\ComposerStager\API\Exception\InvalidArgumentException
-     * @covers \PhpTuf\ComposerStager\API\Exception\IOException
-     * @covers \PhpTuf\ComposerStager\API\Exception\LogicException
-     * @covers \PhpTuf\ComposerStager\API\Exception\RuntimeException
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(string $exception): void
     {
         $message = $exception;
@@ -39,7 +38,7 @@ final class ExceptionUnitTest extends TestCase
     }
 
     /** Provides a list of all exception classes except PreconditionException, which has a different signature. */
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         $exceptions = [
             InvalidArgumentException::class,

--- a/tests/Exception/PreconditionExceptionUnitTest.php
+++ b/tests/Exception/PreconditionExceptionUnitTest.php
@@ -6,15 +6,14 @@ use Exception;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Precondition\Service\TestPrecondition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
+#[CoversClass(PreconditionException::class)]
 final class PreconditionExceptionUnitTest extends TestCase
 {
-    /**
-     * @covers \PhpTuf\ComposerStager\API\Exception\PreconditionException
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(array $arguments, int $code, ?Throwable $previous): void
     {
         $sut = new PreconditionException(...array_values($arguments));
@@ -26,7 +25,7 @@ final class PreconditionExceptionUnitTest extends TestCase
         self::assertEquals($previous, $sut->getPrevious(), 'Got previous exception.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Minimum values' => [

--- a/tests/Exception/TranslatableExceptionTraitUnitTest.php
+++ b/tests/Exception/TranslatableExceptionTraitUnitTest.php
@@ -6,16 +6,13 @@ use Exception;
 use PhpTuf\ComposerStager\API\Exception\TranslatableExceptionTrait;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\API\Exception\TranslatableExceptionTrait */
+#[CoversNothing]
 final class TranslatableExceptionTraitUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::getTranslatableMessage
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(array $arguments, TranslatableInterface $message, int $code): void
     {
         $sut = new class(...$arguments) extends Exception {
@@ -27,7 +24,7 @@ final class TranslatableExceptionTraitUnitTest extends TestCase
         self::assertSame($code, $sut->getCode(), 'Returned correct code.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             [

--- a/tests/Exploratory/ExploratoryTestTemplate.php
+++ b/tests/Exploratory/ExploratoryTestTemplate.php
@@ -3,6 +3,7 @@
 namespace PhpTuf\ComposerStager\Tests\Exploratory;
 
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 /**
  * This class provides a template for temporary tests to quickly prove hypotheses or verify
@@ -11,9 +12,8 @@ use PhpTuf\ComposerStager\Tests\TestCase;
  * To use it, copy it to a file ending in "Test.php", e.g., "ExploratoryTest.php", so PHPUnit will find it. In order
  * to avoid dirtying the Git working directory or accidentally committing throwaway tests, all files except this one in
  * this directory are Git ignored. To commit a test permanently to the codebase, move it to a more appropriate location.
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class ExploratoryTestTemplate extends TestCase
 {
     public function test(): void

--- a/tests/FileSyncer/Service/FileSyncerUnitTest.php
+++ b/tests/FileSyncer/Service/FileSyncerUnitTest.php
@@ -16,20 +16,13 @@ use PhpTuf\ComposerStager\API\Process\Service\RsyncProcessRunnerInterface;
 use PhpTuf\ComposerStager\Internal\FileSyncer\Service\FileSyncer;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\FileSyncer\Service\FileSyncer
- *
- * @covers ::__construct
- * @covers ::buildCommand
- * @covers ::ensureDestinationDirectoryExists
- * @covers ::getRelativePath
- * @covers ::makeRelativeToSource
- * @covers ::runCommand
- * @covers ::sync
- */
+#[CoversClass(FileSyncer::class)]
 final class FileSyncerUnitTest extends TestCase
 {
     private EnvironmentInterface|ObjectProphecy $environment;
@@ -73,11 +66,7 @@ final class FileSyncerUnitTest extends TestCase
         );
     }
 
-    /**
-     * @covers ::sync
-     *
-     * @dataProvider providerSync
-     */
+    #[DataProvider('providerSync')]
     public function testSync(
         string $source,
         string $destination,
@@ -103,7 +92,7 @@ final class FileSyncerUnitTest extends TestCase
         $sut->sync($sourcePath, $destinationPath, ...$optionalArguments);
     }
 
-    public function providerSync(): array
+    public static function providerSync(): array
     {
         return [
             'Minimum arguments' => [
@@ -267,7 +256,6 @@ final class FileSyncerUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::assertRsyncIsAvailable */
     public function testNoRsyncError(): void
     {
         $message = 'Something went wrong.';
@@ -282,11 +270,7 @@ final class FileSyncerUnitTest extends TestCase
         }, LogicException::class, $message);
     }
 
-    /**
-     * @covers ::runCommand
-     *
-     * @dataProvider providerSyncFailure
-     */
+    #[DataProvider('providerSyncFailure')]
     public function testSyncFailure(ExceptionInterface $caughtException, string $thrownException): void
     {
         $this->rsync
@@ -299,7 +283,7 @@ final class FileSyncerUnitTest extends TestCase
         }, $thrownException, $caughtException->getMessage(), null, $caughtException::class);
     }
 
-    public function providerSyncFailure(): array
+    public static function providerSyncFailure(): array
     {
         $message = self::createTranslatableExceptionMessage(__METHOD__);
 
@@ -315,11 +299,7 @@ final class FileSyncerUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::getRelativePath
-     *
-     * @dataProvider providerGetRelativePath
-     */
+    #[DataProvider('providerGetRelativePath')]
     public function testGetRelativePath(string $ancestor, string $path, string $expected): void
     {
         // Expose private method for testing.
@@ -334,11 +314,9 @@ final class FileSyncerUnitTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * @group no_windows
-     * @phpcs:disable SlevomatCodingStandard.Whitespaces.DuplicateSpaces.DuplicateSpaces
-     */
-    public function providerGetRelativePath(): array
+    /** @phpcs:disable SlevomatCodingStandard.Whitespaces.DuplicateSpaces.DuplicateSpaces */
+    #[Group('no_windows')]
+    public static function providerGetRelativePath(): array
     {
         return [
             'Match: single directory depth' => [
@@ -384,7 +362,6 @@ final class FileSyncerUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::ensureDestinationDirectoryExists */
     public function testSyncCreateDestinationDirectoryFailed(): void
     {
         $message = self::createTranslatableExceptionMessage(__METHOD__);

--- a/tests/Filesystem/Service/FilesystemFunctionalTest.php
+++ b/tests/Filesystem/Service/FilesystemFunctionalTest.php
@@ -7,8 +7,10 @@ use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\Internal\Filesystem\Service\Filesystem;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Filesystem\Service\Filesystem */
+#[CoversClass(Filesystem::class)]
 final class FilesystemFunctionalTest extends TestCase
 {
     protected function setUp(): void
@@ -29,17 +31,7 @@ final class FilesystemFunctionalTest extends TestCase
         return ContainerTestHelper::get(Filesystem::class);
     }
 
-    /**
-     * @covers ::fileExists
-     * @covers ::getFileType
-     * @covers ::isDir
-     * @covers ::isFile
-     * @covers ::isHardLink
-     * @covers ::isLink
-     * @covers ::isSymlink
-     *
-     * @dataProvider providerTypeCheckMethods
-     */
+    #[DataProvider('providerTypeCheckMethods')]
     public function testTypeCheckMethods(
         array $files,
         array $directories,
@@ -75,7 +67,7 @@ final class FilesystemFunctionalTest extends TestCase
         self::assertSame($isSymlink, $actualIsSymlink, 'Correctly determined whether path is a symlink.');
     }
 
-    public function providerTypeCheckMethods(): array
+    public static function providerTypeCheckMethods(): array
     {
         return [
             'Path is a symlink to a file' => [
@@ -161,11 +153,7 @@ final class FilesystemFunctionalTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::readLink
-     *
-     * @dataProvider providerReadlink
-     */
+    #[DataProvider('providerReadlink')]
     public function testReadlink(string $given, string $expectedAbsolute): void
     {
         $basePath = self::sourceDirAbsolute();
@@ -191,7 +179,7 @@ final class FilesystemFunctionalTest extends TestCase
         }, IOException::class, $message);
     }
 
-    public function providerReadlink(): array
+    public static function providerReadlink(): array
     {
         $basePath = self::sourceDirAbsolute();
         $absolute = static fn ($path): string => self::makeAbsolute($path, $basePath);
@@ -208,7 +196,6 @@ final class FilesystemFunctionalTest extends TestCase
         ];
     }
 
-    /** @covers ::readLink */
     public function testReadlinkOnNonLink(): void
     {
         $file = self::createPath(__FILE__);
@@ -220,7 +207,6 @@ final class FilesystemFunctionalTest extends TestCase
         }, IOException::class, $message);
     }
 
-    /** @covers ::readLink */
     public function testReadlinkOnNonExistentFile(): void
     {
         $path = self::nonExistentFilePath();
@@ -232,7 +218,6 @@ final class FilesystemFunctionalTest extends TestCase
         }, IOException::class, $message);
     }
 
-    /** @covers ::touch */
     public function testTouch(): void
     {
         $path = self::arbitraryFilePath();
@@ -243,7 +228,6 @@ final class FilesystemFunctionalTest extends TestCase
         self::assertFileExists($path->absolute());
     }
 
-    /** @covers ::touch */
     public function testTouchAlreadyADirectory(): void
     {
         $directoryPath = self::arbitraryDirPath();

--- a/tests/Filesystem/Service/FilesystemUnitTest.php
+++ b/tests/Filesystem/Service/FilesystemUnitTest.php
@@ -12,16 +12,15 @@ use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestSpyInterface;
 use PhpTuf\ComposerStager\Tests\TestUtils\BuiltinFunctionMocker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Filesystem\Exception\IOException as SymfonyIOException;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Filesystem\Service\Filesystem
- *
- * @covers \PhpTuf\ComposerStager\Internal\Filesystem\Service\Filesystem::__construct
- */
+#[CoversClass(Filesystem::class)]
 final class FilesystemUnitTest extends TestCase
 {
     private EnvironmentInterface|ObjectProphecy $environment;
@@ -52,13 +51,8 @@ final class FilesystemUnitTest extends TestCase
         return new Filesystem($environment, $pathFactory, $symfonyFilesystem, $translatableFactory);
     }
 
-    /**
-     * @covers ::isWritable
-     *
-     * @dataProvider providerIsWritable
-     *
-     * @runInSeparateProcess
-     */
+    #[DataProvider('providerIsWritable')]
+    #[RunInSeparateProcess]
     public function testIsWritable(bool $expected): void
     {
         BuiltinFunctionMocker::mock(['is_writable' => $this->prophesize(TestSpyInterface::class)]);
@@ -73,7 +67,7 @@ final class FilesystemUnitTest extends TestCase
         self::assertSame($expected, $actual, 'Got correct writable status.');
     }
 
-    public function providerIsWritable(): array
+    public static function providerIsWritable(): array
     {
         return [
             [true],
@@ -81,11 +75,7 @@ final class FilesystemUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::mkdir
-     *
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testMkdir(): void
     {
         BuiltinFunctionMocker::mock([
@@ -105,11 +95,7 @@ final class FilesystemUnitTest extends TestCase
         $sut->mkdir(self::arbitraryDirPath());
     }
 
-    /**
-     * @covers ::mkdir
-     *
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testMkdirFailure(): void
     {
         $dirAbsolute = self::arbitraryDirAbsolute();
@@ -132,11 +118,7 @@ final class FilesystemUnitTest extends TestCase
         }, IOException::class, $message);
     }
 
-    /**
-     * @covers ::rm
-     *
-     * @dataProvider providerRm
-     */
+    #[DataProvider('providerRm')]
     public function testRm(string $path, ?OutputCallbackInterface $callback, int $timeout): void
     {
         $this->environment->setTimeLimit($timeout)
@@ -150,7 +132,7 @@ final class FilesystemUnitTest extends TestCase
         $sut->rm($stagingDir, $callback, $timeout);
     }
 
-    public function providerRm(): array
+    public static function providerRm(): array
     {
         return [
             'Default values' => [
@@ -166,7 +148,6 @@ final class FilesystemUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::rm */
     public function testRmException(): void
     {
         $message = 'Failed to remove directory.';
@@ -181,13 +162,8 @@ final class FilesystemUnitTest extends TestCase
         }, IOException::class, $message, null, $previous::class);
     }
 
-    /**
-     * @covers ::touch
-     *
-     * @dataProvider providerTouch
-     *
-     * @runInSeparateProcess
-     */
+    #[DataProvider('providerTouch')]
+    #[RunInSeparateProcess]
     public function testTouch(string $filename, array $givenArguments, array $expectedArguments): void
     {
         $path = self::createPath($filename);
@@ -201,7 +177,7 @@ final class FilesystemUnitTest extends TestCase
         $sut->touch($path, ...$givenArguments);
     }
 
-    public function providerTouch(): array
+    public static function providerTouch(): array
     {
         return [
             [
@@ -237,11 +213,7 @@ final class FilesystemUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::touch
-     *
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testTouchFailure(): void
     {
         $path = self::arbitraryFilePath();

--- a/tests/Finder/Service/ExecutableFinderFunctionalTest.php
+++ b/tests/Finder/Service/ExecutableFinderFunctionalTest.php
@@ -6,12 +6,9 @@ use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinder;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinder
- *
- * @covers ::__construct
- */
+#[CoversClass(ExecutableFinder::class)]
 final class ExecutableFinderFunctionalTest extends TestCase
 {
     private function createSut(): ExecutableFinder
@@ -19,7 +16,6 @@ final class ExecutableFinderFunctionalTest extends TestCase
         return ContainerTestHelper::get(ExecutableFinder::class);
     }
 
-    /** @covers ::find */
     public function testFindFound(): void
     {
         $sut = $this->createSut();
@@ -29,7 +25,6 @@ final class ExecutableFinderFunctionalTest extends TestCase
         self::assertMatchesRegularExpression('/rsync(.exe)?$/i', $actual);
     }
 
-    /** @covers ::find */
     public function testFindNotFound(): void
     {
         $sut = $this->createSut();

--- a/tests/Finder/Service/ExecutableFinderUnitTest.php
+++ b/tests/Finder/Service/ExecutableFinderUnitTest.php
@@ -6,15 +6,12 @@ use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinder;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Process\ExecutableFinder as SymfonyExecutableFinder;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Finder\Service\ExecutableFinder
- *
- * @covers ::__construct
- */
+#[CoversClass(ExecutableFinder::class)]
 final class ExecutableFinderUnitTest extends TestCase
 {
     private SymfonyExecutableFinder|ObjectProphecy $symfonyExecutableFinder;
@@ -35,7 +32,6 @@ final class ExecutableFinderUnitTest extends TestCase
         return new ExecutableFinder($executableFinder, $translatorFactory);
     }
 
-    /** @covers ::find */
     public function testFind(): void
     {
         $command = 'command_name';
@@ -50,7 +46,6 @@ final class ExecutableFinderUnitTest extends TestCase
         self::assertSame($command, $actual, 'Returned correct path');
     }
 
-    /** @covers ::find */
     public function testFindNotFound(): void
     {
         $command = 'command_name';

--- a/tests/Finder/Service/FileFinderFunctionalTest.php
+++ b/tests/Finder/Service/FileFinderFunctionalTest.php
@@ -5,12 +5,10 @@ namespace PhpTuf\ComposerStager\Tests\Finder\Service;
 use PhpTuf\ComposerStager\Internal\Finder\Service\FileFinder;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinder
- *
- * @covers ::__construct
- */
+#[CoversClass(FileFinder::class)]
 final class FileFinderFunctionalTest extends TestCase
 {
     protected function setUp(): void
@@ -28,12 +26,7 @@ final class FileFinderFunctionalTest extends TestCase
         return ContainerTestHelper::get(FileFinder::class);
     }
 
-    /**
-     * @covers ::find
-     * @covers ::getRecursiveDirectoryIterator
-     *
-     * @dataProvider providerFind
-     */
+    #[DataProvider('providerFind')]
     public function testFind(array $files, array $exclusions, array $expected): void
     {
         $expected = self::normalizePaths($expected);
@@ -45,7 +38,7 @@ final class FileFinderFunctionalTest extends TestCase
         self::assertArrayEquals($expected, $actual);
     }
 
-    public function providerFind(): array
+    public static function providerFind(): array
     {
         return [
             'No files, no exclusions' => [

--- a/tests/Finder/Service/FileFinderUnitTest.php
+++ b/tests/Finder/Service/FileFinderUnitTest.php
@@ -5,12 +5,9 @@ namespace PhpTuf\ComposerStager\Tests\Finder\Service;
 use PhpTuf\ComposerStager\API\Exception\IOException;
 use PhpTuf\ComposerStager\Internal\Finder\Service\FileFinder;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Finder\Service\FileFinder
- *
- * @covers ::__construct
- */
+#[CoversClass(FileFinder::class)]
 final class FileFinderUnitTest extends TestCase
 {
     private function createSut(): FileFinder
@@ -30,7 +27,6 @@ final class FileFinderUnitTest extends TestCase
         self::assertTranslatableAware($sut);
     }
 
-    /** @covers ::getRecursiveDirectoryIterator */
     public function testGetRecursiveDirectoryIteratorException(): void
     {
         $path = self::nonExistentFilePath();

--- a/tests/Misc/PhpAssumptionsFunctionalTest.php
+++ b/tests/Misc/PhpAssumptionsFunctionalTest.php
@@ -3,12 +3,12 @@
 namespace PhpTuf\ComposerStager\Tests\Misc;
 
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 /**
  * Tests assumptions about PHP built-in behavior.
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class PhpAssumptionsFunctionalTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Path/Factory/PathFactoryUnitTest.php
+++ b/tests/Path/Factory/PathFactoryUnitTest.php
@@ -5,8 +5,9 @@ namespace PhpTuf\ComposerStager\Tests\Path\Factory;
 use PhpTuf\ComposerStager\Internal\Path\Factory\PathFactory;
 use PhpTuf\ComposerStager\Internal\Path\Value\Path;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Path\Factory\PathFactory */
+#[CoversClass(PathFactory::class)]
 final class PathFactoryUnitTest extends TestCase
 {
     private function createSut(): PathFactory
@@ -16,10 +17,6 @@ final class PathFactoryUnitTest extends TestCase
         return new PathFactory($pathHelper);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::create
-     */
     public function testBasicFunctionality(): void
     {
         $pathHelper = self::createPathHelper();

--- a/tests/Path/Factory/PathListFactoryUnitTest.php
+++ b/tests/Path/Factory/PathListFactoryUnitTest.php
@@ -5,16 +5,13 @@ namespace PhpTuf\ComposerStager\Tests\Path\Factory;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\Internal\Path\Factory\PathListFactory;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Path\Factory\PathListFactory */
+#[CoversClass(PathListFactory::class)]
 final class PathListFactoryUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::create
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(array $paths, PathListInterface $expected): void
     {
         $pathHelper = self::createPathHelper();
@@ -25,7 +22,7 @@ final class PathListFactoryUnitTest extends TestCase
         self::assertEquals($expected, $actual, 'Returned correct path list object.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'No paths' => [

--- a/tests/Path/Service/PathHelperUnitTest.php
+++ b/tests/Path/Service/PathHelperUnitTest.php
@@ -4,8 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Path\Service;
 
 use PhpTuf\ComposerStager\Internal\Path\Service\PathHelper;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Path\Service\PathHelper */
+#[CoversClass(PathHelper::class)]
 final class PathHelperUnitTest extends TestCase
 {
     public function createSut(): PathHelper
@@ -13,11 +15,7 @@ final class PathHelperUnitTest extends TestCase
         return new PathHelper();
     }
 
-    /**
-     * @covers ::canonicalize
-     *
-     * @dataProvider providerCanonicalize
-     */
+    #[DataProvider('providerCanonicalize')]
     public function testCanonicalize(string $unixLike, string $windows, string $expected): void
     {
         $sut = $this->createSut();
@@ -29,7 +27,7 @@ final class PathHelperUnitTest extends TestCase
         self::assertSame($expected, $actualWindows, 'Correctly canonicalized Windows path.');
     }
 
-    public function providerCanonicalize(): array
+    public static function providerCanonicalize(): array
     {
         return [
             'Empty paths' => [
@@ -90,12 +88,7 @@ final class PathHelperUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::isAbsolute
-     * @covers ::isRelative
-     *
-     * @dataProvider providerAbsoluteRelative
-     */
+    #[DataProvider('providerAbsoluteRelative')]
     public function testAbsoluteRelative(bool $isAbsolute, string $path): void
     {
         $sut = $this->createSut();
@@ -104,7 +97,7 @@ final class PathHelperUnitTest extends TestCase
         self::assertSame(!$isAbsolute, $sut->isRelative($path));
     }
 
-    public function providerAbsoluteRelative(): array
+    public static function providerAbsoluteRelative(): array
     {
         return [
             // Yes.
@@ -118,21 +111,17 @@ final class PathHelperUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::isDescendant
-     *
-     * @dataProvider providerIsRelative
-     */
-    public function testIsRelative(string $descendant, string $ancestor, bool $expectedIsDescendant): void
+    #[DataProvider('providerIsRelative')]
+    public function testIsRelative(string $descendant, string $ancestor, bool $isDescendant): void
     {
         $sut = $this->createSut();
 
         $actualIsDescendant = $sut->isDescendant($descendant, $ancestor);
 
-        self::assertSame($expectedIsDescendant, $actualIsDescendant);
+        self::assertSame($isDescendant, $actualIsDescendant);
     }
 
-    public function providerIsRelative(): array
+    public static function providerIsRelative(): array
     {
         return [
             'Simple descendant' => [

--- a/tests/Path/Value/PathListUnitTest.php
+++ b/tests/Path/Value/PathListUnitTest.php
@@ -5,17 +5,13 @@ namespace PhpTuf\ComposerStager\Tests\Path\Value;
 use PhpTuf\ComposerStager\Internal\Path\Value\PathList;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\EnvironmentTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Path\Value\PathList */
+#[CoversClass(PathList::class)]
 final class PathListUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::add
-     * @covers ::getAll
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(array $given, array $add, array $expected): void
     {
         $pathHelper = self::createPathHelper();
@@ -26,16 +22,16 @@ final class PathListUnitTest extends TestCase
         self::assertEquals($expected, $sut->getAll(), 'Correctly added paths and got them.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         $data = [
             'None given, none added' => [
-                'paths' => [],
+                'given' => [],
                 'add' => [],
                 'expected' => [],
             ],
             'Some given, none added' => [
-                'paths' => [
+                'given' => [
                     'one',
                     'two',
                 ],
@@ -46,7 +42,7 @@ final class PathListUnitTest extends TestCase
                 ],
             ],
             'None given, some added' => [
-                'paths' => [],
+                'given' => [],
                 'add' => [
                     'one',
                     'two',
@@ -57,7 +53,7 @@ final class PathListUnitTest extends TestCase
                 ],
             ],
             'Some given, some added' => [
-                'paths' => [
+                'given' => [
                     'one',
                     'two',
                 ],
@@ -75,15 +71,15 @@ final class PathListUnitTest extends TestCase
         ];
 
         return array_merge($data, EnvironmentTestHelper::isWindows()
-            ? $this->providerBasicFunctionalityWindows()
-            : $this->providerBasicFunctionalityUnixLike());
+            ? self::providerBasicFunctionalityWindows()
+            : self::providerBasicFunctionalityUnixLike());
     }
 
-    private function providerBasicFunctionalityWindows(): array
+    private static function providerBasicFunctionalityWindows(): array
     {
         return [
             'Different directory separators' => [
-                'paths' => [
+                'given' => [
                     'one',
                     'two\\two',
                     'three/three/three',
@@ -101,7 +97,7 @@ final class PathListUnitTest extends TestCase
                 ],
             ],
             'Complex paths' => [
-                'paths' => [
+                'given' => [
                     'one\\two',
                     'three/four/five',
                     'six\\seven/..\\eight/nine',
@@ -115,7 +111,7 @@ final class PathListUnitTest extends TestCase
                 ],
             ],
             'Duplicate paths' => [
-                'paths' => [
+                'given' => [
                     'one\\two',
                     'one\\two',
                     'three\\four\\five',
@@ -134,11 +130,11 @@ final class PathListUnitTest extends TestCase
         ];
     }
 
-    private function providerBasicFunctionalityUnixLike(): array
+    private static function providerBasicFunctionalityUnixLike(): array
     {
         return [
             'Different directory separators' => [
-                'paths' => [
+                'given' => [
                     'one',
                     'two/two',
                     'three\\three\\three',
@@ -156,7 +152,7 @@ final class PathListUnitTest extends TestCase
                 ],
             ],
             'Complex paths' => [
-                'paths' => [
+                'given' => [
                     'one/two',
                     'three\\four\\five',
                     'six/seven\\../eight\\nine',
@@ -170,7 +166,7 @@ final class PathListUnitTest extends TestCase
                 ],
             ],
             'Duplicate paths' => [
-                'paths' => [
+                'given' => [
                     'one/two',
                     'one/two',
                     'three/four/five',

--- a/tests/Precondition/Service/AbstractFileIteratingPreconditionFunctionalTest.php
+++ b/tests/Precondition/Service/AbstractFileIteratingPreconditionFunctionalTest.php
@@ -7,8 +7,10 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPre
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition */
+#[CoversClass(AbstractFileIteratingPrecondition::class)]
 final class AbstractFileIteratingPreconditionFunctionalTest extends TestCase
 {
     protected function setUp(): void
@@ -29,13 +31,7 @@ final class AbstractFileIteratingPreconditionFunctionalTest extends TestCase
         return ContainerTestHelper::get(NoHardLinksExist::class);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::exitEarly
-     * @covers ::findFiles
-     *
-     * @dataProvider providerFulfilled
-     */
+    #[DataProvider('providerFulfilled')]
     public function testFulfilled(array $files): void
     {
         $activeDirPath = self::activeDirPath();
@@ -47,7 +43,7 @@ final class AbstractFileIteratingPreconditionFunctionalTest extends TestCase
         self::assertTrue($sut->isFulfilled($activeDirPath, $stagingDirPath));
     }
 
-    public function providerFulfilled(): array
+    public static function providerFulfilled(): array
     {
         return [
             'Files' => [
@@ -63,7 +59,6 @@ final class AbstractFileIteratingPreconditionFunctionalTest extends TestCase
         ];
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         // Use `NoHardLinksExist` to exercise `AbstractFileIteratingPrecondition` by extensions.
@@ -82,7 +77,6 @@ final class AbstractFileIteratingPreconditionFunctionalTest extends TestCase
         self::assertFalse($isFulfilled, 'Found unsupported links.');
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testWithStagingDirNestedUnderActiveDir(): void
     {
         // Use `NoHardLinksExist` to exercise `AbstractFileIteratingPrecondition` by extensions.
@@ -101,20 +95,15 @@ final class AbstractFileIteratingPreconditionFunctionalTest extends TestCase
         self::assertTrue($isFulfilled, 'Excluded nested staging directory while scanning parent active directory.');
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::findFiles
-     *
-     * @dataProvider providerWithAbsentDirectory
-     */
-    public function testWithAbsentDirectory(PathInterface $activeDirPath, PathInterface $stagingDirPath): void
+    #[DataProvider('providerWithAbsentDirectory')]
+    public function testWithAbsentDirectory(PathInterface $activeDir, PathInterface $stagingDir): void
     {
         $sut = $this->createSut();
 
-        self::assertTrue($sut->isFulfilled($activeDirPath, $stagingDirPath));
+        self::assertTrue($sut->isFulfilled($activeDir, $stagingDir));
     }
 
-    public function providerWithAbsentDirectory(): array
+    public static function providerWithAbsentDirectory(): array
     {
         return [
             'No active directory' => [

--- a/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
+++ b/tests/Precondition/Service/AbstractFileIteratingPreconditionUnitTest.php
@@ -10,14 +10,11 @@ use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition
- *
- * @covers ::__construct
- */
+#[CoversClass(AbstractFileIteratingPrecondition::class)]
 final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected const NAME = 'NAME';
@@ -107,10 +104,6 @@ final class AbstractFileIteratingPreconditionUnitTest extends FileIteratingPreco
         };
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::exitEarly
-     */
     public function testExitEarly(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/AbstractPreconditionUnitTest.php
+++ b/tests/Precondition/Service/AbstractPreconditionUnitTest.php
@@ -6,8 +6,10 @@ use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Precondition\Service\TestFulfilledPrecondition;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Precondition\Service\TestUnfulfilledPrecondition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition */
+#[CoversClass(AbstractPrecondition::class)]
 final class AbstractPreconditionUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = TestFulfilledPrecondition::NAME;
@@ -23,18 +25,7 @@ final class AbstractPreconditionUnitTest extends PreconditionUnitTestCase
         return new $class($environment, $translatableFactory);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::assertIsFulfilled
-     * @covers ::getDescription
-     * @covers ::getFulfilledStatusMessage
-     * @covers ::getLeaves
-     * @covers ::getName
-     * @covers ::getStatusMessage
-     * @covers ::isFulfilled
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(string $class, ?PathListInterface $exclusions, int $timeout): void
     {
         $activeDirPath = self::activeDirPath();
@@ -52,7 +43,7 @@ final class AbstractPreconditionUnitTest extends PreconditionUnitTestCase
         self::assertEquals([$sut], $sut->getLeaves());
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Fulfilled, without exclusions' => [

--- a/tests/Precondition/Service/AbstractPreconditionsTreeUnitTest.php
+++ b/tests/Precondition/Service/AbstractPreconditionsTreeUnitTest.php
@@ -9,14 +9,10 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPreconditionsTree;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Precondition\Service\TestFulfilledPrecondition;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Precondition\Service\TestUnfulfilledPrecondition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPreconditionsTree
- *
- * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::isFulfilled
- */
+#[CoversClass(AbstractPreconditionsTree::class)]
 final class AbstractPreconditionsTreeUnitTest extends PreconditionUnitTestCase
 {
     protected function createSut(...$children): AbstractPreconditionsTree
@@ -63,12 +59,7 @@ final class AbstractPreconditionsTreeUnitTest extends PreconditionUnitTestCase
         return new $class($environment, $translatableFactory);
     }
 
-    /**
-     * @covers ::getLeaves
-     * @covers ::getStatusMessage
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(string $class, ?PathListInterface $exclusions, int $timeout): void
     {
         $activeDirPath = self::activeDirPath();
@@ -100,7 +91,7 @@ final class AbstractPreconditionsTreeUnitTest extends PreconditionUnitTestCase
         self::assertSame([$child], $sut->getLeaves());
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Fulfilled, without exclusions' => [
@@ -116,7 +107,6 @@ final class AbstractPreconditionsTreeUnitTest extends PreconditionUnitTestCase
         ];
     }
 
-    /** @covers ::getLeaves */
     public function testIsFulfilledBubbling(): void
     {
         $leaves = [

--- a/tests/Precondition/Service/ActiveAndStagingDirsAreDifferentUnitTest.php
+++ b/tests/Precondition/Service/ActiveAndStagingDirsAreDifferentUnitTest.php
@@ -3,12 +3,9 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveAndStagingDirsAreDifferent;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveAndStagingDirsAreDifferent
- *
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
- */
+#[CoversClass(ActiveAndStagingDirsAreDifferent::class)]
 final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Active and staging directories are different';
@@ -23,10 +20,6 @@ final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionUnitTes
         return new ActiveAndStagingDirsAreDifferent($environment, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->doTestFulfilled(
@@ -36,7 +29,6 @@ final class ActiveAndStagingDirsAreDifferentUnitTest extends PreconditionUnitTes
         );
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The active and staging directories are the same.';

--- a/tests/Precondition/Service/ActiveDirExistsUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirExistsUnitTest.php
@@ -4,14 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirExists;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirExists
- *
- * @covers ::__construct
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
- */
+#[CoversClass(ActiveDirExists::class)]
 final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Active directory exists';
@@ -42,10 +38,6 @@ final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
         return new ActiveDirExists($environment, $filesystem, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->filesystem
@@ -59,7 +51,6 @@ final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testDoesNotExist(): void
     {
         $message = 'The active directory does not exist.';
@@ -70,7 +61,6 @@ final class ActiveDirExistsUnitTest extends PreconditionUnitTestCase
         $this->doTestUnfulfilled($message);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testIsNotADirectory(): void
     {
         $message = 'The active directory is not actually a directory.';

--- a/tests/Precondition/Service/ActiveDirIsReadyUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirIsReadyUnitTest.php
@@ -5,14 +5,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirExistsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\ActiveDirIsWritableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsReady;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsReady
- *
- * @covers ::__construct
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(ActiveDirIsReady::class)]
 final class ActiveDirIsReadyUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Active directory is ready';
@@ -46,7 +42,6 @@ final class ActiveDirIsReadyUnitTest extends PreconditionUnitTestCase
         return new ActiveDirIsReady($environment, $stagingDirExists, $stagingDirIsWritable, $translatableFactory);
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/ActiveDirIsWritableUnitTest.php
+++ b/tests/Precondition/Service/ActiveDirIsWritableUnitTest.php
@@ -4,13 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsWritable;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ActiveDirIsWritable
- *
- * @covers ::__construct
- */
+#[CoversClass(ActiveDirIsWritable::class)]
 final class ActiveDirIsWritableUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Active directory is writable';
@@ -35,10 +32,6 @@ final class ActiveDirIsWritableUnitTest extends PreconditionUnitTestCase
         return new ActiveDirIsWritable($environment, $filesystem, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->filesystem
@@ -49,7 +42,6 @@ final class ActiveDirIsWritableUnitTest extends PreconditionUnitTestCase
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The active directory is not writable.';

--- a/tests/Precondition/Service/BeginnerPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/BeginnerPreconditionsUnitTest.php
@@ -6,14 +6,10 @@ use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoUnsupportedLinksExistInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirDoesNotExistInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\BeginnerPreconditions;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\BeginnerPreconditions
- *
- * @covers ::__construct
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(BeginnerPreconditions::class)]
 final class BeginnerPreconditionsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Beginner preconditions';
@@ -59,7 +55,6 @@ final class BeginnerPreconditionsUnitTest extends PreconditionUnitTestCase
         );
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/CleanerPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/CleanerPreconditionsUnitTest.php
@@ -5,14 +5,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\CleanerPreconditions;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\CleanerPreconditions
- *
- * @covers ::__construct
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(CleanerPreconditions::class)]
 final class CleanerPreconditionsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Cleaner preconditions';
@@ -46,7 +42,6 @@ final class CleanerPreconditionsUnitTest extends PreconditionUnitTestCase
         return new CleanerPreconditions($environment, $commonPreconditions, $stagingDirIsReady, $translatableFactory);
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/CommitterPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/CommitterPreconditionsUnitTest.php
@@ -6,14 +6,10 @@ use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoUnsupportedLinksExistInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\CommitterPreconditions;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\CommitterPreconditions
- *
- * @covers ::__construct
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(CommitterPreconditions::class)]
 final class CommitterPreconditionsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Committer preconditions';
@@ -53,7 +49,6 @@ final class CommitterPreconditionsUnitTest extends PreconditionUnitTestCase
         return new CommitterPreconditions($environment, $commonPreconditions, $noUnsupportedLinksExist, $stagingDirIsReady, $translatableFactory);
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/CommonPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/CommonPreconditionsUnitTest.php
@@ -9,14 +9,10 @@ use PhpTuf\ComposerStager\API\Precondition\Service\HostSupportsRunningProcessesI
 use PhpTuf\ComposerStager\API\Precondition\Service\NoNestingOnWindowsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\RsyncIsAvailableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\CommonPreconditions;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\CommonPreconditions
- *
- * @covers ::__construct
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(CommonPreconditions::class)]
 final class CommonPreconditionsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Common preconditions';
@@ -83,7 +79,6 @@ final class CommonPreconditionsUnitTest extends PreconditionUnitTestCase
         );
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/ComposerIsAvailableFunctionalTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableFunctionalTest.php
@@ -11,14 +11,12 @@ use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\FilesystemTestHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\PathTestHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\TranslationTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 use Symfony\Component\DependencyInjection\Definition;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ComposerIsAvailable
- *
- * @covers ::__construct
- */
+#[CoversClass(ComposerIsAvailable::class)]
 final class ComposerIsAvailableFunctionalTest extends TestCase
 {
     protected function setUp(): void
@@ -51,13 +49,6 @@ final class ComposerIsAvailableFunctionalTest extends TestCase
         return $container->get(ComposerIsAvailable::class);
     }
 
-    /**
-     * @covers ::assertExecutableExists
-     * @covers ::assertIsActuallyComposer
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     * @covers ::isValidExecutable
-     */
     public function testFulfilled(): void
     {
         $sut = $this->createSut();
@@ -69,7 +60,6 @@ final class ComposerIsAvailableFunctionalTest extends TestCase
         self::assertTrue($isStillFulfilled, 'Achieved idempotency');
     }
 
-    /** @covers ::assertExecutableExists */
     public function testComposerNotFound(): void
     {
         $sut = $this->createSut(ComposerNotFoundExecutableFinder::class);
@@ -80,13 +70,7 @@ final class ComposerIsAvailableFunctionalTest extends TestCase
         }, PreconditionException::class, $message, null, LogicException::class);
     }
 
-    /**
-     * @covers ::assertIsActuallyComposer
-     * @covers ::getComposerOutput
-     * @covers ::isValidExecutable
-     *
-     * @dataProvider providerInvalidComposerFound
-     */
+    #[DataProvider('providerInvalidComposerFound')]
     public function testInvalidComposerFound(string $output): void
     {
         $sut = $this->createSut(InvalidComposerFoundExecutableFinder::class);
@@ -103,7 +87,7 @@ final class ComposerIsAvailableFunctionalTest extends TestCase
         }, PreconditionException::class, $message);
     }
 
-    public function providerInvalidComposerFound(): array
+    public static function providerInvalidComposerFound(): array
     {
         return [
             'No output' => [''],

--- a/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/ComposerIsAvailableUnitTest.php
@@ -9,17 +9,12 @@ use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ComposerProcessRunnerInterface;
 use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\ComposerIsAvailable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\ComposerIsAvailable
- *
- * @covers ::__construct
- * @covers ::assertExecutableExists
- * @covers ::assertIsActuallyComposer
- * @covers ::isValidExecutable
- */
+#[CoversClass(ComposerIsAvailable::class)]
 final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Composer';
@@ -67,13 +62,6 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
         );
     }
 
-    /**
-     * @covers ::assertExecutableExists
-     * @covers ::assertIsActuallyComposer
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     * @covers ::isValidExecutable
-     */
     public function testFulfilled(): void
     {
         $this->executableFinder
@@ -86,7 +74,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @dataProvider providerComposerProcessRunnerException */
+    #[DataProvider('providerComposerProcessRunnerException')]
     public function testComposerProcessRunnerException(string $exception): void
     {
         $this->expectException(PreconditionException::class);
@@ -98,7 +86,7 @@ final class ComposerIsAvailableUnitTest extends PreconditionUnitTestCase
         $sut->assertIsFulfilled(self::activeDirPath(), self::stagingDirPath());
     }
 
-    public function providerComposerProcessRunnerException(): array
+    public static function providerComposerProcessRunnerException(): array
     {
         return [
             [LogicException::class],

--- a/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
+++ b/tests/Precondition/Service/FileIteratingPreconditionUnitTestCase.php
@@ -14,11 +14,13 @@ use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Throwable;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition */
+#[CoversClass(AbstractFileIteratingPrecondition::class)]
 abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTestCase
 {
     // Override in subclasses.
@@ -46,7 +48,6 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         parent::setUp();
     }
 
-    /** @covers ::exitEarly */
     public function testExitEarly(): void
     {
         $this->filesystem
@@ -113,7 +114,6 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         $sut->assertIsFulfilled($activeDirPath, $stagingDirPath);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testActiveDirectoryDoesNotExistCountsAsFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -130,7 +130,6 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         $this->assertFulfilled($isFulfilled, $statusMessage, 'Treated non-existent directories as fulfilled.');
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testStagingDirectoryDoesNotExistCountsAsFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -147,7 +146,6 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         $this->assertFulfilled($isFulfilled, $statusMessage, 'Treated non-existent directories as fulfilled.');
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testNoFilesFound(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -164,11 +162,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         $this->assertFulfilled($isFulfilled, $statusMessage, 'Treated empty codebase as fulfilled.');
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     *
-     * @dataProvider providerFileFinderExceptions
-     */
+    #[DataProvider('providerFileFinderExceptions')]
     public function testFileFinderExceptions(ExceptionInterface $previous): void
     {
         $activeDirPath = self::activeDirPath();
@@ -192,7 +186,7 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         }
     }
 
-    public function providerFileFinderExceptions(): array
+    public static function providerFileFinderExceptions(): array
     {
         return [
             'InvalidArgumentException' => [new InvalidArgumentException(self::createTranslatableMessage('Exclusions include invalid paths.'))],
@@ -200,7 +194,6 @@ abstract class FileIteratingPreconditionUnitTestCase extends PreconditionUnitTes
         ];
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function assertFulfilled(
         bool $isFulfilled,
         TranslatableInterface $statusMessage,

--- a/tests/Precondition/Service/HostSupportsRunningProcessesFunctionalTest.php
+++ b/tests/Precondition/Service/HostSupportsRunningProcessesFunctionalTest.php
@@ -5,12 +5,9 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses
- *
- * @covers ::__construct
- */
+#[CoversClass(HostSupportsRunningProcesses::class)]
 final class HostSupportsRunningProcessesFunctionalTest extends TestCase
 {
     private function createSut(): HostSupportsRunningProcesses
@@ -19,8 +16,6 @@ final class HostSupportsRunningProcessesFunctionalTest extends TestCase
     }
 
     /**
-     * @covers ::doAssertIsFulfilled
-     *
      * This test proves that the precondition correctly detects a failure from
      * the Symfony Process component when the the proc_open() function is
      * unavailable. Unfortunately, it is infeasible to simulate that condition

--- a/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
+++ b/tests/Precondition/Service/HostSupportsRunningProcessesUnitTest.php
@@ -5,18 +5,12 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Exception\LogicException;
 use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Process\Process;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\HostSupportsRunningProcesses
- *
- * @covers ::__construct
- * @covers ::doAssertIsFulfilled
- * @covers ::isFulfilled
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
- */
+#[CoversClass(HostSupportsRunningProcesses::class)]
 final class HostSupportsRunningProcessesUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Host supports running processes';
@@ -44,10 +38,6 @@ final class HostSupportsRunningProcessesUnitTest extends PreconditionUnitTestCas
         return new HostSupportsRunningProcesses($environment, $processFactory, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->processFactory
@@ -57,7 +47,6 @@ final class HostSupportsRunningProcessesUnitTest extends PreconditionUnitTestCas
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = __METHOD__;

--- a/tests/Precondition/Service/LinkPreconditionsFunctionalTestCase.php
+++ b/tests/Precondition/Service/LinkPreconditionsFunctionalTestCase.php
@@ -4,8 +4,18 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\PreconditionInterface;
+use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition;
+use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition;
+use PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist;
+use PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversClass(AbstractFileIteratingPrecondition::class)]
+#[CoversClass(AbstractPrecondition::class)]
+#[CoversClass(NoLinksExistOnWindows::class)]
+#[CoversClass(NoHardLinksExist::class)]
 abstract class LinkPreconditionsFunctionalTestCase extends TestCase
 {
     protected function setUp(): void
@@ -21,16 +31,7 @@ abstract class LinkPreconditionsFunctionalTestCase extends TestCase
 
     abstract protected function createSut(): PreconditionInterface;
 
-    /**
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::doAssertIsFulfilled
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::findFiles
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::assertIsFulfilled
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::doAssertIsFulfilled
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::isFulfilled
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows::exitEarly
-     *
-     * @dataProvider providerFulfilledDirectoryDoesNotExist
-     */
+    #[DataProvider('providerFulfilledDirectoryDoesNotExist')]
     public function testFulfilledDirectoryDoesNotExist(PathInterface $activeDir, PathInterface $stagingDir): void
     {
         $this->doTestFulfilledDirectoryDoesNotExist($activeDir, $stagingDir);
@@ -45,7 +46,7 @@ abstract class LinkPreconditionsFunctionalTestCase extends TestCase
         self::assertTrue($isFulfilled, 'Silently ignored non-existent directory');
     }
 
-    final public function providerFulfilledDirectoryDoesNotExist(): array
+    final public static function providerFulfilledDirectoryDoesNotExist(): array
     {
         $nonexistentDir = self::nonExistentDirPath();
 
@@ -61,13 +62,6 @@ abstract class LinkPreconditionsFunctionalTestCase extends TestCase
         ];
     }
 
-    /**
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::doAssertIsFulfilled
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition::findFiles
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::isFulfilled
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist::assertIsSupportedFile
-     * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows::exitEarly
-     */
     public function testFulfilledWithNoLinks(): void
     {
         $sut = $this->createSut();
@@ -79,7 +73,7 @@ abstract class LinkPreconditionsFunctionalTestCase extends TestCase
 
     abstract public function testFulfilledExclusions(array $links, array $exclusions, bool $shouldBeFulfilled): void;
 
-    final public function providerExclusions(): array
+    final public static function providerExclusions(): array
     {
         return [
             'No links or exclusions' => [

--- a/tests/Precondition/Service/LinkPreconditionsIsolationFunctionalTest.php
+++ b/tests/Precondition/Service/LinkPreconditionsIsolationFunctionalTest.php
@@ -11,13 +11,14 @@ use PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTh
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\Precondition\Service\TestPreconditionsTree;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use Throwable;
 
 /**
  * Tests the interaction of unsupported links preconditions.
- *
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractFileIteratingPrecondition
  */
+#[CoversClass(AbstractFileIteratingPrecondition::class)]
 final class LinkPreconditionsIsolationFunctionalTest extends TestCase
 {
     private const COVERED_PRECONDITIONS = [
@@ -95,7 +96,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
         );
     }
 
-    /** @group no_windows */
+    #[Group('no_windows')]
     public function testNoAbsoluteSymlinksExist(): void
     {
         $source = self::path('source.txt');
@@ -106,7 +107,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
         $this->assertPreconditionIsIsolated(NoAbsoluteSymlinksExist::class);
     }
 
-    /** @group windows_only */
+    #[Group('windows_only')]
     public function testNoLinksExistOnWindows(): void
     {
         $source = self::path('source.txt');
@@ -122,7 +123,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
         }, PreconditionException::class);
     }
 
-    /** @group no_windows */
+    #[Group('no_windows')]
     public function testNoSymlinksPointOutsideTheCodebase(): void
     {
         $source = self::path('source.txt');
@@ -135,7 +136,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
         self::rm($target);
     }
 
-    /** @group no_windows */
+    #[Group('no_windows')]
     public function testNoHardLinksExistExist(): void
     {
         $source = self::path('source.txt');
@@ -146,7 +147,7 @@ final class LinkPreconditionsIsolationFunctionalTest extends TestCase
         $this->assertPreconditionIsIsolated(NoHardLinksExist::class);
     }
 
-    /** @group no_windows */
+    #[Group('no_windows')]
     private function assertPreconditionIsIsolated(string $sut): void
     {
         $sut = $this->createTestPreconditionsTree([$sut]);

--- a/tests/Precondition/Service/NoAbsoluteSymlinksExistFunctionalTest.php
+++ b/tests/Precondition/Service/NoAbsoluteSymlinksExistFunctionalTest.php
@@ -5,14 +5,12 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\PathTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist
- *
- * @covers ::__construct
- *
- * @group no_windows
- */
+#[CoversClass(NoAbsoluteSymlinksExist::class)]
+#[Group('no_windows')]
 final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {
     protected function createSut(): NoAbsoluteSymlinksExist
@@ -20,11 +18,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         return ContainerTestHelper::get(NoAbsoluteSymlinksExist::class);
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     *
-     * @dataProvider providerDoesNotContainLinks
-     */
+    #[DataProvider('providerDoesNotContainLinks')]
     public function testDoesNotContainLinks(array $files): void
     {
         self::touch($files, self::activeDirAbsolute());
@@ -35,7 +29,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         self::assertTrue($isFulfilled, 'Found no links.');
     }
 
-    public function providerDoesNotContainLinks(): array
+    public static function providerDoesNotContainLinks(): array
     {
         return [
             'Empty directory' => ['files' => []],
@@ -57,11 +51,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         ];
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     *
-     * @dataProvider providerLinksExist
-     */
+    #[DataProvider('providerLinksExist')]
     public function testAbsoluteLinksExist(string $dirName, string $basePath, string $link): void
     {
         $linkAbsolute = self::makeAbsolute($link, $basePath);
@@ -87,11 +77,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         self::assertTranslatableMessage($pattern, $statusMessage, 'Returned correct status message.');
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     *
-     * @dataProvider providerLinksExist
-     */
+    #[DataProvider('providerLinksExist')]
     public function testOnlyRelativeLinksExist(string $dirName, string $basePath, string $link): void
     {
         $linkAbsolute = self::makeAbsolute($link, $basePath);
@@ -110,7 +96,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         self::assertTrue($isFulfilled, 'Ignored relative links.');
     }
 
-    public function providerLinksExist(): array
+    public static function providerLinksExist(): array
     {
         return [
             'Active directory: root' => [
@@ -146,7 +132,6 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         ];
     }
 
-    /** @covers ::assertIsSupportedFile */
     public function testWithHardLink(): void
     {
         $link = self::makeAbsolute('link.txt', self::activeDirAbsolute());
@@ -162,11 +147,7 @@ final class NoAbsoluteSymlinksExistFunctionalTest extends LinkPreconditionsFunct
         self::assertTrue($isFulfilled, 'Ignored hard link.');
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     *
-     * @dataProvider providerExclusions
-     */
+    #[DataProvider('providerExclusions')]
     public function testFulfilledExclusions(array $links, array $exclusions, bool $shouldBeFulfilled): void
     {
         $targetFile = PathTestHelper::makeAbsolute('target.txt', self::activeDirAbsolute());

--- a/tests/Precondition/Service/NoAbsoluteSymlinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoAbsoluteSymlinksExistUnitTest.php
@@ -3,14 +3,9 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoAbsoluteSymlinksExist
- *
- * @covers ::assertIsSupportedFile
- * @covers ::exitEarly
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(NoAbsoluteSymlinksExist::class)]
 final class NoAbsoluteSymlinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected const NAME = 'No absolute links exist';

--- a/tests/Precondition/Service/NoHardLinksExistFunctionalTest.php
+++ b/tests/Precondition/Service/NoHardLinksExistFunctionalTest.php
@@ -5,13 +5,11 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Filesystem\Path;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist
- *
- * @covers ::__construct
- */
+#[CoversClass(NoHardLinksExist::class)]
 final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {
     protected function createSut(): NoHardLinksExist
@@ -19,7 +17,6 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         return ContainerTestHelper::get(NoHardLinksExist::class);
     }
 
-    /** @covers ::assertIsSupportedFile */
     public function testFulfilledWithSymlink(): void
     {
         $target = Path::makeAbsolute('target.txt', self::activeDirAbsolute());
@@ -33,11 +30,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         self::assertTrue($isFulfilled, 'Allowed symlink.');
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     *
-     * @dataProvider providerUnfulfilled
-     */
+    #[DataProvider('providerUnfulfilled')]
     public function testUnfulfilled(string $directory, string $dirName): void
     {
         $target = self::makeAbsolute('target.txt', $directory);
@@ -57,7 +50,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         }, PreconditionException::class, $message);
     }
 
-    public function providerUnfulfilled(): array
+    public static function providerUnfulfilled(): array
     {
         return [
             'In active directory' => [
@@ -71,11 +64,7 @@ final class NoHardLinksExistFunctionalTest extends LinkPreconditionsFunctionalTe
         ];
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     *
-     * @dataProvider providerExclusions
-     */
+    #[DataProvider('providerExclusions')]
     public function testFulfilledExclusions(array $links, array $exclusions, bool $shouldBeFulfilled): void
     {
         $targetFile = 'target.txt';

--- a/tests/Precondition/Service/NoHardLinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoHardLinksExistUnitTest.php
@@ -3,8 +3,9 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoHardLinksExist */
+#[CoversClass(NoHardLinksExist::class)]
 final class NoHardLinksExistUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected const NAME = 'No hard links exist';
@@ -23,16 +24,11 @@ final class NoHardLinksExistUnitTest extends FileIteratingPreconditionUnitTestCa
         return new NoHardLinksExist($environment, $fileFinder, $filesystem, $pathFactory, $pathListFactory, $translatableFactory);
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::assertIsSupportedFile */
     public function testUnfulfilled(): void
     {
         // @todo Implement once the corresponding functionality is added.

--- a/tests/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
+++ b/tests/Precondition/Service/NoLinksExistOnWindowsFunctionalTest.php
@@ -5,12 +5,11 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows
- *
- * @covers ::__construct
- */
+#[CoversClass(NoLinksExistOnWindows::class)]
 final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {
     protected function createSut(): NoLinksExistOnWindows
@@ -18,14 +17,8 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
         return ContainerTestHelper::get(NoLinksExistOnWindows::class);
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::exitEarly
-     *
-     * @dataProvider providerUnfulfilled
-     *
-     * @group windows_only
-     */
+    #[DataProvider('providerUnfulfilled')]
+    #[Group('windows_only')]
     public function testUnfulfilled(array $symlinks, array $hardLinks): void
     {
         $activeDirPath = self::activeDirPath();
@@ -52,7 +45,7 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
         }, PreconditionException::class, $message);
     }
 
-    public function providerUnfulfilled(): array
+    public static function providerUnfulfilled(): array
     {
         return [
             'Contains symlink' => [
@@ -66,14 +59,8 @@ final class NoLinksExistOnWindowsFunctionalTest extends LinkPreconditionsFunctio
         ];
     }
 
-    /**
-     * @covers ::exitEarly
-     * @covers ::isFulfilled
-     *
-     * @dataProvider providerExclusions
-     *
-     * @group windows_only
-     */
+    #[DataProvider('providerExclusions')]
+    #[Group('windows_only')]
     public function testFulfilledExclusions(array $links, array $exclusions, bool $shouldBeFulfilled): void
     {
         $targetFile = 'target.txt';

--- a/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
+++ b/tests/Precondition/Service/NoLinksExistOnWindowsUnitTest.php
@@ -3,15 +3,10 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Argument;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoLinksExistOnWindows
- *
- * @covers ::__construct
- * @covers ::assertIsSupportedFile
- * @covers ::exitEarly
- */
+#[CoversClass(NoLinksExistOnWindows::class)]
 final class NoLinksExistOnWindowsUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected const NAME = 'No links exist on Windows';
@@ -39,7 +34,6 @@ final class NoLinksExistOnWindowsUnitTest extends FileIteratingPreconditionUnitT
         return new NoLinksExistOnWindows($environment, $fileFinder, $filesystem, $pathFactory, $pathListFactory, $translatableFactory);
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);

--- a/tests/Precondition/Service/NoNestingOnWindowsUnitTest.php
+++ b/tests/Precondition/Service/NoNestingOnWindowsUnitTest.php
@@ -3,13 +3,10 @@
 namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoNestingOnWindows;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoNestingOnWindows
- *
- * @covers ::__construct
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
- */
+#[CoversClass(NoNestingOnWindows::class)]
 final class NoNestingOnWindowsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Active and staging directories not nested on Windows.';
@@ -34,19 +31,11 @@ final class NoNestingOnWindowsUnitTest extends PreconditionUnitTestCase
         return new NoNestingOnWindows($environment, $pathHelper, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testExitEarlyOnNonWindows(): void
     {
         $activeDirPath = self::createPath('/active-dir');
@@ -63,12 +52,7 @@ final class NoNestingOnWindowsUnitTest extends PreconditionUnitTestCase
         self::assertTrue($isFulfilled, 'Exited early on non-Windows');
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     *
-     * @dataProvider providerUnfulfilled
-     */
+    #[DataProvider('providerUnfulfilled')]
     public function testUnfulfilled(string $activeDir, string $stagingDir): void
     {
         $activeDirPath = self::createPath($activeDir);
@@ -83,7 +67,7 @@ final class NoNestingOnWindowsUnitTest extends PreconditionUnitTestCase
         $this->doTestUnfulfilled($expectedStatusMessage, null, $activeDirPath, $stagingDirPath);
     }
 
-    public function providerUnfulfilled(): array
+    public static function providerUnfulfilled(): array
     {
         return [
             [

--- a/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseFunctionalTest.php
@@ -5,15 +5,12 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTheCodebase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTheCodebase
- *
- * @covers ::__construct
- * @covers ::exitEarly
- *
- * @group no_windows
- */
+#[CoversClass(NoSymlinksPointOutsideTheCodebase::class)]
+#[Group('no_windows')]
 final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPreconditionsFunctionalTestCase
 {
     protected function createSut(): NoSymlinksPointOutsideTheCodebase
@@ -21,13 +18,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         return ContainerTestHelper::get(NoSymlinksPointOutsideTheCodebase::class);
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
-     * @covers ::linkPointsOutsidePath
-     *
-     * @dataProvider providerFulfilledWithValidLink
-     */
+    #[DataProvider('providerFulfilledWithValidLink')]
     public function testFulfilledWithValidLink(string $link, string $target): void
     {
         $activeDirPath = self::activeDirPath();
@@ -46,7 +37,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         self::assertTrue($isFulfilled, 'Allowed link pointing within the codebase.');
     }
 
-    public function providerFulfilledWithValidLink(): array
+    public static function providerFulfilledWithValidLink(): array
     {
         return [
             'Not in any package' => [
@@ -76,13 +67,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         ];
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
-     * @covers ::linkPointsOutsidePath
-     *
-     * @dataProvider providerUnfulfilled
-     */
+    #[DataProvider('providerUnfulfilled')]
     public function testUnfulfilled(string $targetDir, string $linkDir, string $linkDirName): void
     {
         $activeDirPath = self::activeDirPath();
@@ -105,7 +90,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         }, PreconditionException::class, $message);
     }
 
-    public function providerUnfulfilled(): array
+    public static function providerUnfulfilled(): array
     {
         return [
             'In active directory' => [
@@ -121,10 +106,6 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         ];
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
-     */
     public function testWithHardLink(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -144,11 +125,6 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         self::assertTrue($isFulfilled, 'Ignored hard link.');
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
-     * @covers ::linkPointsOutsidePath
-     */
     public function testWithAbsoluteLink(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -169,13 +145,7 @@ final class NoSymlinksPointOutsideTheCodebaseFunctionalTest extends LinkPrecondi
         self::assertTrue($isFulfilled, 'Ignored hard link.');
     }
 
-    /**
-     * @covers ::assertIsSupportedFile
-     * @covers ::isFulfilled
-     * @covers ::linkPointsOutsidePath
-     *
-     * @dataProvider providerExclusions
-     */
+    #[DataProvider('providerExclusions')]
     public function testFulfilledExclusions(array $links, array $exclusions, bool $shouldBeFulfilled): void
     {
         $targetFile = '../';

--- a/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
+++ b/tests/Precondition/Service/NoSymlinksPointOutsideTheCodebaseUnitTest.php
@@ -8,15 +8,10 @@ use PhpTuf\ComposerStager\API\Path\Factory\PathFactoryInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathInterface;
 use PhpTuf\ComposerStager\API\Path\Value\PathListInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTheCodebase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Argument;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoSymlinksPointOutsideTheCodebase
- *
- * @covers ::__construct
- * @covers ::assertIsSupportedFile
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(NoSymlinksPointOutsideTheCodebase::class)]
 final class NoSymlinksPointOutsideTheCodebaseUnitTest extends FileIteratingPreconditionUnitTestCase
 {
     protected const NAME = 'No symlinks point outside the codebase';

--- a/tests/Precondition/Service/NoUnsupportedLinksExistUnitTest.php
+++ b/tests/Precondition/Service/NoUnsupportedLinksExistUnitTest.php
@@ -8,14 +8,10 @@ use PhpTuf\ComposerStager\API\Precondition\Service\NoHardLinksExistInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoLinksExistOnWindowsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\NoSymlinksPointOutsideTheCodebaseInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\NoUnsupportedLinksExist;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\NoUnsupportedLinksExist
- *
- * @covers ::__construct
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(NoUnsupportedLinksExist::class)]
 final class NoUnsupportedLinksExistUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Unsupported links preconditions';
@@ -68,7 +64,6 @@ final class NoUnsupportedLinksExistUnitTest extends PreconditionUnitTestCase
         );
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/PreconditionUnitTestCase.php
+++ b/tests/Precondition/Service/PreconditionUnitTestCase.php
@@ -40,12 +40,6 @@ abstract class PreconditionUnitTestCase extends TestCase
 
     abstract protected function createSut(): PreconditionInterface;
 
-    /**
-     * @covers ::__construct
-     * @covers ::getDescription
-     * @covers ::getLeaves
-     * @covers ::getName
-     */
     public function testGetters(): void
     {
         $sut = $this->createSut();

--- a/tests/Precondition/Service/RsyncIsAvailableFunctionalTest.php
+++ b/tests/Precondition/Service/RsyncIsAvailableFunctionalTest.php
@@ -5,8 +5,9 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\RsyncIsAvailable;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
-/** @coversNothing */
+#[CoversNothing]
 final class RsyncIsAvailableFunctionalTest extends TestCase
 {
     public function testFulfilled(): void

--- a/tests/Precondition/Service/RsyncIsAvailableUnitTest.php
+++ b/tests/Precondition/Service/RsyncIsAvailableUnitTest.php
@@ -8,18 +8,12 @@ use PhpTuf\ComposerStager\API\Finder\Service\ExecutableFinderInterface;
 use PhpTuf\ComposerStager\API\Process\Factory\ProcessFactoryInterface;
 use PhpTuf\ComposerStager\API\Process\Service\ProcessInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\RsyncIsAvailable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\RsyncIsAvailable
- *
- * @covers ::__construct
- * @covers ::assertExecutableExists
- * @covers ::assertIsActuallyRsync
- * @covers ::getProcess
- * @covers ::isValidExecutable
- */
+#[CoversClass(RsyncIsAvailable::class)]
 final class RsyncIsAvailableUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Rsync';
@@ -63,16 +57,7 @@ final class RsyncIsAvailableUnitTest extends PreconditionUnitTestCase
         return new RsyncIsAvailable($environment, $executableFinder, $processFactory, $translatableFactory);
     }
 
-    /**
-     * @covers ::assertExecutableExists
-     * @covers ::assertIsActuallyRsync
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     * @covers ::getProcess
-     * @covers ::isValidExecutable
-     *
-     * @dataProvider providerFulfilled
-     */
+    #[DataProvider('providerFulfilled')]
     public function testFulfilled(string $output): void
     {
         $this->executableFinder
@@ -95,7 +80,7 @@ final class RsyncIsAvailableUnitTest extends PreconditionUnitTestCase
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    public function providerFulfilled(): array
+    public static function providerFulfilled(): array
     {
         return [
             'Command name on first line' => [
@@ -111,7 +96,6 @@ rsync version 2.6.9 compatible",
         ];
     }
 
-    /** @covers ::assertExecutableExists */
     public function testExecutableNotFound(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -133,12 +117,6 @@ rsync version 2.6.9 compatible",
         }, PreconditionException::class, $message);
     }
 
-    /**
-     * @covers ::assertExecutableExists
-     * @covers ::assertIsActuallyRsync
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getProcess
-     */
     public function testFailedToCreateProcess(): void
     {
         $message = __METHOD__;
@@ -153,7 +131,6 @@ rsync version 2.6.9 compatible",
         ), $previous::class);
     }
 
-    /** @covers ::getProcess */
     public function testFailedToRunProcess(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -174,7 +151,6 @@ rsync version 2.6.9 compatible",
         }, PreconditionException::class, $message);
     }
 
-    /** @covers ::isValidExecutable */
     public function testFailedToGetOutput(): void
     {
         $activeDirPath = self::activeDirPath();
@@ -196,7 +172,7 @@ rsync version 2.6.9 compatible",
         }, PreconditionException::class, $message);
     }
 
-    /** @dataProvider providerInvalidOutput */
+    #[DataProvider('providerInvalidOutput')]
     public function testInvalidOutput(string $output): void
     {
         $activeDirPath = self::activeDirPath();
@@ -217,7 +193,7 @@ rsync version 2.6.9 compatible",
         }, PreconditionException::class, $message);
     }
 
-    public function providerInvalidOutput(): array
+    public static function providerInvalidOutput(): array
     {
         return [
             'No output' => [''],

--- a/tests/Precondition/Service/StagerPreconditionsUnitTest.php
+++ b/tests/Precondition/Service/StagerPreconditionsUnitTest.php
@@ -5,18 +5,13 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Precondition\Service\CommonPreconditionsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsReadyInterface;
+use PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPreconditionsTree;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagerPreconditions;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagerPreconditions
- *
- * @covers ::__construct
- * @covers ::assertIsFulfilled
- * @covers ::getFulfilledStatusMessage
- * @covers ::getStatusMessage
- * @covers ::isFulfilled
- */
+#[CoversClass(AbstractPreconditionsTree::class)]
+#[CoversClass(StagerPreconditions::class)]
 final class StagerPreconditionsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Stager preconditions';
@@ -50,7 +45,6 @@ final class StagerPreconditionsUnitTest extends PreconditionUnitTestCase
         return new StagerPreconditions($environment, $translatableFactory, $commonPreconditions, $stagingDirIsReady);
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
+++ b/tests/Precondition/Service/StagingDirDoesNotExistUnitTest.php
@@ -4,15 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirDoesNotExist;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirDoesNotExist
- *
- * @covers ::__construct
- * @covers ::doAssertIsFulfilled
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
- */
+#[CoversClass(StagingDirDoesNotExist::class)]
 final class StagingDirDoesNotExistUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Staging directory does not exist';
@@ -37,10 +32,6 @@ final class StagingDirDoesNotExistUnitTest extends PreconditionUnitTestCase
         return new StagingDirDoesNotExist($environment, $filesystem, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->filesystem
@@ -51,7 +42,6 @@ final class StagingDirDoesNotExistUnitTest extends PreconditionUnitTestCase
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The staging directory already exists.';

--- a/tests/Precondition/Service/StagingDirExistsUnitTest.php
+++ b/tests/Precondition/Service/StagingDirExistsUnitTest.php
@@ -4,14 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirExists;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirExists
- *
- * @covers ::__construct
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
- */
+#[CoversClass(StagingDirExists::class)]
 final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Staging directory exists';
@@ -42,10 +38,6 @@ final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
         return new StagingDirExists($environment, $filesystem, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->filesystem
@@ -59,7 +51,6 @@ final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testDoesNotExist(): void
     {
         $message = 'The staging directory does not exist.';
@@ -70,7 +61,6 @@ final class StagingDirExistsUnitTest extends PreconditionUnitTestCase
         $this->doTestUnfulfilled($message);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testIsNotADirectory(): void
     {
         $message = 'The staging directory is not actually a directory.';

--- a/tests/Precondition/Service/StagingDirIsReadyUnitTest.php
+++ b/tests/Precondition/Service/StagingDirIsReadyUnitTest.php
@@ -6,14 +6,10 @@ use PhpTuf\ComposerStager\API\Exception\PreconditionException;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirExistsInterface;
 use PhpTuf\ComposerStager\API\Precondition\Service\StagingDirIsWritableInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsReady;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsReady
- *
- * @covers ::__construct
- * @covers ::getFulfilledStatusMessage
- */
+#[CoversClass(StagingDirIsReady::class)]
 final class StagingDirIsReadyUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Staging directory is ready';
@@ -47,7 +43,6 @@ final class StagingDirIsReadyUnitTest extends PreconditionUnitTestCase
         return new StagingDirIsReady($environment, $translatableFactory, $stagingDirExists, $stagingDirIsWritable);
     }
 
-    /** @covers ::getFulfilledStatusMessage */
     public function testFulfilled(): void
     {
         $activeDirPath = self::activeDirPath();

--- a/tests/Precondition/Service/StagingDirIsWritableUnitTest.php
+++ b/tests/Precondition/Service/StagingDirIsWritableUnitTest.php
@@ -4,15 +4,10 @@ namespace PhpTuf\ComposerStager\Tests\Precondition\Service;
 
 use PhpTuf\ComposerStager\API\Filesystem\Service\FilesystemInterface;
 use PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsWritable;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Precondition\Service\StagingDirIsWritable
- *
- * @covers ::__construct
- * @covers ::doAssertIsFulfilled
- * @covers \PhpTuf\ComposerStager\Internal\Precondition\Service\AbstractPrecondition::getStatusMessage
- */
+#[CoversClass(StagingDirIsWritable::class)]
 final class StagingDirIsWritableUnitTest extends PreconditionUnitTestCase
 {
     protected const NAME = 'Staging directory is writable';
@@ -38,10 +33,6 @@ final class StagingDirIsWritableUnitTest extends PreconditionUnitTestCase
         return new StagingDirIsWritable($environment, $filesystem, $translatableFactory);
     }
 
-    /**
-     * @covers ::doAssertIsFulfilled
-     * @covers ::getFulfilledStatusMessage
-     */
     public function testFulfilled(): void
     {
         $this->filesystem
@@ -52,7 +43,6 @@ final class StagingDirIsWritableUnitTest extends PreconditionUnitTestCase
         $this->doTestFulfilled(self::FULFILLED_STATUS_MESSAGE);
     }
 
-    /** @covers ::doAssertIsFulfilled */
     public function testUnfulfilled(): void
     {
         $message = 'The staging directory is not writable.';

--- a/tests/Process/Factory/ProcessFactoryUnitTest.php
+++ b/tests/Process/Factory/ProcessFactoryUnitTest.php
@@ -6,16 +6,13 @@ use PhpTuf\ComposerStager\Internal\Process\Factory\ProcessFactory;
 use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactory;
 use PhpTuf\ComposerStager\Internal\Process\Service\Process;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Factory\ProcessFactory */
+#[CoversClass(ProcessFactory::class)]
 final class ProcessFactoryUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::create
-     *
-     * @dataProvider providerFactory
-     */
+    #[DataProvider('providerFactory')]
     public function testFactory(array $command, array $optionalArguments): void
     {
         $translatableFactory = self::createTranslatableFactory();
@@ -29,7 +26,7 @@ final class ProcessFactoryUnitTest extends TestCase
         self::assertTranslatableAware($sut);
     }
 
-    public function providerFactory(): array
+    public static function providerFactory(): array
     {
         return [
             'Minimum values' => [

--- a/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
+++ b/tests/Process/Factory/SymfonyProcessFactoryUnitTest.php
@@ -7,18 +7,16 @@ use PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactory;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestSpyInterface;
 use PhpTuf\ComposerStager\Tests\TestUtils\BuiltinFunctionMocker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Process\Exception\LogicException as SymfonyLogicException;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Factory\SymfonyProcessFactory */
+#[CoversClass(SymfonyProcessFactory::class)]
 final class SymfonyProcessFactoryUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::create
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(array $given, array $expected): void
     {
         $translatableFactory = self::createTranslatableFactory();
@@ -31,7 +29,7 @@ final class SymfonyProcessFactoryUnitTest extends TestCase
         self::assertTranslatableAware($sut);
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Minimum values' => [
@@ -57,11 +55,7 @@ final class SymfonyProcessFactoryUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::create
-     *
-     * @runInSeparateProcess
-     */
+    #[RunInSeparateProcess]
     public function testFailure(): void
     {
         $previousMessage = 'Something went wrong';

--- a/tests/Process/Service/AbstractProcessRunnerUnitTest.php
+++ b/tests/Process/Service/AbstractProcessRunnerUnitTest.php
@@ -12,14 +12,12 @@ use PhpTuf\ComposerStager\API\Translation\Value\TranslatableInterface;
 use PhpTuf\ComposerStager\Internal\Process\Service\AbstractProcessRunner;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Service\AbstractProcessRunner
- *
- * @covers ::__construct
- */
+#[CoversClass(AbstractProcessRunner::class)]
 final class AbstractProcessRunnerUnitTest extends TestCase
 {
     private const COMMAND_NAME = 'test';
@@ -78,13 +76,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         };
     }
 
-    /**
-     * @covers ::executableName
-     * @covers ::findExecutable
-     * @covers ::run
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(
         string $executableName,
         array $givenRunArguments,
@@ -111,7 +103,7 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         $sut->run(...$givenRunArguments);
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Minimum values' => [
@@ -148,10 +140,6 @@ final class AbstractProcessRunnerUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::findExecutable
-     * @covers ::run
-     */
     public function testRunCannotFindGivenExecutable(): void
     {
         $previous = new IOException(self::createTranslatableExceptionMessage(__METHOD__));

--- a/tests/Process/Service/OutputCallbackAdapterUnitTest.php
+++ b/tests/Process/Service/OutputCallbackAdapterUnitTest.php
@@ -6,17 +6,14 @@ use PhpTuf\ComposerStager\API\Process\Service\OutputCallbackInterface;
 use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Service\OutputCallbackAdapter */
+#[CoversClass(OutputCallbackAdapter::class)]
 final class OutputCallbackAdapterUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::__invoke
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(string $givenType, OutputTypeEnum $expectedType, string $buffer): void
     {
         $callback = $this->prophesize(OutputCallbackInterface::class);
@@ -28,7 +25,7 @@ final class OutputCallbackAdapterUnitTest extends TestCase
         $sut($givenType, $buffer);
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'stdout' => [
@@ -44,12 +41,7 @@ final class OutputCallbackAdapterUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::__invoke
-     *
-     * @dataProvider providerNoCallback
-     */
+    #[DataProvider('providerNoCallback')]
     public function testNoCallback(array $constructorArguments): void
     {
         // No explicit assertion is necessary for this test. The SUT will
@@ -61,7 +53,7 @@ final class OutputCallbackAdapterUnitTest extends TestCase
         $sut(SymfonyProcess::OUT, __METHOD__);
     }
 
-    public function providerNoCallback(): array
+    public static function providerNoCallback(): array
     {
         return [
             'Implicit null' => [

--- a/tests/Process/Service/OutputCallbackUnitTest.php
+++ b/tests/Process/Service/OutputCallbackUnitTest.php
@@ -5,20 +5,13 @@ namespace PhpTuf\ComposerStager\Tests\Process\Service;
 use PhpTuf\ComposerStager\API\Process\Value\OutputTypeEnum;
 use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback */
+#[CoversClass(OutputCallback::class)]
 final class OutputCallbackUnitTest extends TestCase
 {
-    /**
-     * @covers ::__invoke
-     * @covers ::clearErrorOutput
-     * @covers ::clearOutput
-     * @covers ::getErrorOutput
-     * @covers ::getOutput
-     * @covers ::normalizeBuffer
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(
         array $givenOutput,
         array $expectedOutput,
@@ -50,7 +43,7 @@ final class OutputCallbackUnitTest extends TestCase
         self::assertOutput($sut, [], [], 'Cleared output.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         // Space ( ).
         $s = "\040";

--- a/tests/Process/Service/ProcessFunctionalTest.php
+++ b/tests/Process/Service/ProcessFunctionalTest.php
@@ -8,8 +8,9 @@ use PhpTuf\ComposerStager\Internal\Process\Service\OutputCallback;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\ProcessTestHelper;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
-/** @coversNothing */
+#[CoversNothing]
 final class ProcessFunctionalTest extends TestCase
 {
     private function createSut(array $command): ProcessInterface

--- a/tests/Process/Service/ProcessUnitTest.php
+++ b/tests/Process/Service/ProcessUnitTest.php
@@ -17,6 +17,8 @@ use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestDoubles\TestStringable;
 use PhpTuf\ComposerStager\Tests\TestUtils\ContainerTestHelper;
 use PhpTuf\ComposerStager\Tests\TestUtils\ProcessTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
@@ -25,11 +27,7 @@ use Symfony\Component\Process\Exception\RuntimeException as SymfonyRuntimeExcept
 use Symfony\Component\Process\Process as SymfonyProcess;
 use Throwable;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Process\Service\Process
- *
- * @covers ::__construct
- */
+#[CoversClass(Process::class)]
 final class ProcessUnitTest extends TestCase
 {
     private SymfonyProcessFactoryInterface|ObjectProphecy $symfonyProcessFactory;
@@ -66,20 +64,7 @@ final class ProcessUnitTest extends TestCase
         return new Process($symfonyProcessFactory, $translatableFactory, ...$givenConstructorArguments);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::assertValidEnvName
-     * @covers ::assertValidEnvValue
-     * @covers ::getEnv
-     * @covers ::getErrorOutput
-     * @covers ::getOutput
-     * @covers ::mustRun
-     * @covers ::run
-     * @covers ::setEnv
-     * @covers ::setTimeout
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(
         array $givenConstructorArguments,
         array $givenRunArguments,
@@ -138,7 +123,7 @@ final class ProcessUnitTest extends TestCase
         self::assertSame($expectedRunReturn, $actualRunReturn, 'Returned correct status code from ::run().');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Minimum arguments' => [
@@ -174,13 +159,7 @@ final class ProcessUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getEnv
-     * @covers ::setEnv
-     *
-     * @dataProvider providerEnv
-     */
+    #[DataProvider('providerEnv')]
     public function testEnv(array $optionalArguments, array $expectedInitialEnv, array $givenNewEnv): void
     {
         $symfonyProcessFactory = ContainerTestHelper::get(SymfonyProcessFactory::class);
@@ -195,7 +174,7 @@ final class ProcessUnitTest extends TestCase
         self::assertSame($givenNewEnv, $actualUpdatedEnv);
     }
 
-    public function providerEnv(): array
+    public static function providerEnv(): array
     {
         return [
             'No env argument' => [
@@ -228,11 +207,7 @@ final class ProcessUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::run
-     *
-     * @dataProvider providerRunStatusCode
-     */
+    #[DataProvider('providerRunStatusCode')]
     public function testRunStatusCode(int $expected): void
     {
         $this->symfonyProcess
@@ -246,7 +221,7 @@ final class ProcessUnitTest extends TestCase
         self::assertSame($expected, $actual, 'Returned correct status code.');
     }
 
-    public function providerRunStatusCode(): array
+    public static function providerRunStatusCode(): array
     {
         return [
             'success' => [0],
@@ -255,7 +230,6 @@ final class ProcessUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::getOutput */
     public function testGetOutputException(): void
     {
         $previous = ProcessTestHelper::createSymfonyProcessFailedException();
@@ -270,7 +244,6 @@ final class ProcessUnitTest extends TestCase
         }, LogicException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
-    /** @covers ::getErrorOutput */
     public function testGetErrorOutputException(): void
     {
         $previous = ProcessTestHelper::createSymfonyProcessFailedException();
@@ -285,7 +258,6 @@ final class ProcessUnitTest extends TestCase
         }, LogicException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
-    /** @covers ::mustRun */
     public function testMustRunException(): void
     {
         $previous = ProcessTestHelper::createSymfonyProcessFailedException();
@@ -300,11 +272,7 @@ final class ProcessUnitTest extends TestCase
         }, RuntimeException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
-    /**
-     * @covers ::run
-     *
-     * @dataProvider providerRunException
-     */
+    #[DataProvider('providerRunException')]
     public function testRunException(Throwable $previous): void
     {
         $this->symfonyProcess
@@ -319,7 +287,7 @@ final class ProcessUnitTest extends TestCase
         }, RuntimeException::class, $expectedExceptionMessage, null, $previous::class);
     }
 
-    public function providerRunException(): array
+    public static function providerRunException(): array
     {
         return [
             'SymfonyLogicException' => [new SymfonyLogicException('SymfonyLogicException')],
@@ -328,12 +296,7 @@ final class ProcessUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::assertValidEnv
-     * @covers ::assertValidEnvName
-     *
-     * @dataProvider providerSetEnvInvalidNames
-     */
+    #[DataProvider('providerSetEnvInvalidNames')]
     public function testSetEnvInvalidNames(array $values, string $invalidName): void
     {
         $this->symfonyProcess
@@ -349,7 +312,7 @@ final class ProcessUnitTest extends TestCase
         ));
     }
 
-    public function providerSetEnvInvalidNames(): array
+    public static function providerSetEnvInvalidNames(): array
     {
         return [
             'Empty string' => [
@@ -372,17 +335,12 @@ final class ProcessUnitTest extends TestCase
             // at least document the behavior with this test case.
             'Value with no name' => [
                 'values' => ['value'],
-                'invalidValue' => '0',
+                'invalidName' => '0',
             ],
         ];
     }
 
-    /**
-     * @covers ::assertValidEnv
-     * @covers ::assertValidEnvValue
-     *
-     * @dataProvider providerSetEnvInvalidValues
-     */
+    #[DataProvider('providerSetEnvInvalidValues')]
     public function testSetEnvInvalidValues(array $values, string $invalidValue): void
     {
         $this->symfonyProcess
@@ -398,7 +356,7 @@ final class ProcessUnitTest extends TestCase
         ));
     }
 
-    public function providerSetEnvInvalidValues(): array
+    public static function providerSetEnvInvalidValues(): array
     {
         return [
             'Array' => [
@@ -424,7 +382,6 @@ final class ProcessUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::setTimeout */
     public function testSetTimeoutException(): void
     {
         $previous = ProcessTestHelper::createSymfonyProcessFailedException();

--- a/tests/TestUtils/PathTestHelperUnitTest.php
+++ b/tests/TestUtils/PathTestHelperUnitTest.php
@@ -3,11 +3,13 @@
 namespace PhpTuf\ComposerStager\Tests\TestUtils;
 
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversNothing */
+#[CoversNothing]
 final class PathTestHelperUnitTest extends TestCase
 {
-    /** @dataProvider providerFixSeparatorsMultiple */
+    #[DataProvider('providerFixSeparatorsMultiple')]
     public function testFixSeparatorsMultiple(array $paths, array $expected): void
     {
         PathTestHelper::fixSeparatorsMultiple(...$paths);
@@ -15,7 +17,7 @@ final class PathTestHelperUnitTest extends TestCase
         self::assertSame($expected, $paths);
     }
 
-    public function providerFixSeparatorsMultiple(): array
+    public static function providerFixSeparatorsMultiple(): array
     {
         return [
             'Empty arrays' => [

--- a/tests/Translation/Factory/TranslatableAwareTraitUnitTest.php
+++ b/tests/Translation/Factory/TranslatableAwareTraitUnitTest.php
@@ -11,11 +11,12 @@ use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait;
 use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableFactory;
 use PhpTuf\ComposerStager\Internal\Translation\Value\TranslationParameters;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableAwareTrait */
+#[CoversNothing]
 final class TranslatableAwareTraitUnitTest extends TestCase
 {
-    /** @covers ::d */
     public function testDMethod(): void
     {
         $domainOptions = self::createDomainOptions();
@@ -36,7 +37,6 @@ final class TranslatableAwareTraitUnitTest extends TestCase
         self::assertSame($domainOptions, $actual);
     }
 
-    /** @covers ::d */
     public function testDMethodWithMissingTranslatableFactory(): void
     {
         $this->expectException(AssertionError::class);
@@ -50,12 +50,7 @@ final class TranslatableAwareTraitUnitTest extends TestCase
         $sut->callD();
     }
 
-    /**
-     * @covers ::setTranslatableFactory
-     * @covers ::t
-     *
-     * @dataProvider providerTMethod
-     */
+    #[DataProvider('providerTMethod')]
     public function testTMethod(array $arguments): void
     {
         $arguments = array_values($arguments);
@@ -76,7 +71,7 @@ final class TranslatableAwareTraitUnitTest extends TestCase
         self::assertEquals($expected, $actual, 'Returned correct translatable object.');
     }
 
-    public function providerTMethod(): array
+    public static function providerTMethod(): array
     {
         return [
             'Minimum values' => [
@@ -99,7 +94,6 @@ final class TranslatableAwareTraitUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::t */
     public function testTMethodWithMissingTranslatableFactory(): void
     {
         $this->expectException(AssertionError::class);
@@ -113,11 +107,7 @@ final class TranslatableAwareTraitUnitTest extends TestCase
         $sut->callT('Message');
     }
 
-    /**
-     * @covers ::p
-     *
-     * @dataProvider providerPMethod
-     */
+    #[DataProvider('providerPMethod')]
     public function testPMethod(array $parameters): void
     {
         $translatableFactory = self::createTranslatableFactory();
@@ -138,7 +128,7 @@ final class TranslatableAwareTraitUnitTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function providerPMethod(): array
+    public static function providerPMethod(): array
     {
         return [
             'Empty parameters' => [
@@ -153,7 +143,6 @@ final class TranslatableAwareTraitUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::p */
     public function testPMethodWithMissingTranslatableFactory(): void
     {
         $this->expectException(AssertionError::class);

--- a/tests/Translation/Factory/TranslatableFactoryUnitTest.php
+++ b/tests/Translation/Factory/TranslatableFactoryUnitTest.php
@@ -7,14 +7,12 @@ use PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableFactory;
 use PhpTuf\ComposerStager\Internal\Translation\Value\TranslatableMessage;
 use PhpTuf\ComposerStager\Internal\Translation\Value\TranslationParameters;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Factory\TranslatableFactory */
+#[CoversClass(TranslatableFactory::class)]
 final class TranslatableFactoryUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::createDomainOptions
-     */
     public function testCreateDomainOptions(): void
     {
         $expected = self::createDomainOptions();
@@ -25,11 +23,7 @@ final class TranslatableFactoryUnitTest extends TestCase
         self::assertSame($expected, $actual, 'Returned correct domain options object.');
     }
 
-    /**
-     * @covers ::createTranslatableMessage
-     *
-     * @dataProvider providerCreateTranslatableMessage
-     */
+    #[DataProvider('providerCreateTranslatableMessage')]
     public function testCreateTranslatableMessage(
         array $givenCreateMessageArguments,
         TranslatableInterface $expectedMessage,
@@ -42,7 +36,7 @@ final class TranslatableFactoryUnitTest extends TestCase
         self::assertEquals($expectedMessage, $actual, 'Returned correct translatable object.');
     }
 
-    public function providerCreateTranslatableMessage(): array
+    public static function providerCreateTranslatableMessage(): array
     {
         return [
             'Minimum values' => [
@@ -77,11 +71,7 @@ final class TranslatableFactoryUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::createTranslationParameters
-     *
-     * @dataProvider providerCreateTranslationParameters
-     */
+    #[DataProvider('providerCreateTranslationParameters')]
     public function testCreateTranslationParameters(array $parameters): void
     {
         $sut = new TranslatableFactory(self::createDomainOptions(), self::createTranslator());
@@ -92,7 +82,7 @@ final class TranslatableFactoryUnitTest extends TestCase
         self::assertEquals($expected, $actual, 'Returned correct translation parameters object.');
     }
 
-    public function providerCreateTranslationParameters(): array
+    public static function providerCreateTranslationParameters(): array
     {
         return [
             'Empty array' => [[]],

--- a/tests/Translation/Service/DomainOptionsUnitTest.php
+++ b/tests/Translation/Service/DomainOptionsUnitTest.php
@@ -2,16 +2,14 @@
 
 namespace PhpTuf\ComposerStager\Tests\Translation\Service;
 
+use PhpTuf\ComposerStager\Internal\Translation\Service\DomainOptions;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\TranslationTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Service\DomainOptions */
+#[CoversClass(DomainOptions::class)]
 final class DomainOptionsUnitTest extends TestCase
 {
-    /**
-     * @covers ::default
-     * @covers ::exceptions
-     */
     public function testBasicFunctionality(): void
     {
         $sut = self::createDomainOptions();

--- a/tests/Translation/Service/LocaleOptionsUnitTest.php
+++ b/tests/Translation/Service/LocaleOptionsUnitTest.php
@@ -2,14 +2,15 @@
 
 namespace PhpTuf\ComposerStager\Tests\Translation\Service;
 
+use PhpTuf\ComposerStager\Internal\Translation\Service\LocaleOptions;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Service\LocaleOptions */
+#[CoversClass(LocaleOptions::class)]
 final class LocaleOptionsUnitTest extends TestCase
 {
     private const DEFAULT = 'en_US';
 
-    /** @covers ::default */
     public function testBasicFunctionality(): void
     {
         $sut = self::createLocaleOptions();

--- a/tests/Translation/Service/SymfonyTranslatorProxyUnitTest.php
+++ b/tests/Translation/Service/SymfonyTranslatorProxyUnitTest.php
@@ -5,16 +5,13 @@ namespace PhpTuf\ComposerStager\Tests\Translation\Service;
 use PhpTuf\ComposerStager\Internal\Translation\Service\SymfonyTranslatorProxy;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\TranslationTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Service\SymfonyTranslatorProxy */
+#[CoversClass(SymfonyTranslatorProxy::class)]
 final class SymfonyTranslatorProxyUnitTest extends TestCase
 {
-    /**
-     * @covers ::getLocale
-     * @covers ::trans
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(array $arguments, string $expectedTranslation): void
     {
         $arguments = array_values($arguments);
@@ -27,7 +24,7 @@ final class SymfonyTranslatorProxyUnitTest extends TestCase
         self::assertEquals(TranslationTestHelper::LOCALE_DEFAULT, $actualLocale, 'Got correct default locale.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Minimum values' => [
@@ -76,10 +73,6 @@ final class SymfonyTranslatorProxyUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::symfonyTranslator
-     * @covers ::trans
-     */
     public function testSerializable(): void
     {
         $id = 'Arbitrary string';

--- a/tests/Translation/Service/TranslatorUnitTest.php
+++ b/tests/Translation/Service/TranslatorUnitTest.php
@@ -9,19 +9,19 @@ use PhpTuf\ComposerStager\API\Translation\Factory\TranslatableFactoryInterface;
 use PhpTuf\ComposerStager\API\Translation\Service\DomainOptionsInterface;
 use PhpTuf\ComposerStager\API\Translation\Service\LocaleOptionsInterface;
 use PhpTuf\ComposerStager\API\Translation\Value\TranslationParametersInterface;
+use PhpTuf\ComposerStager\Internal\Translation\Service\SymfonyTranslatorProxy;
 use PhpTuf\ComposerStager\Internal\Translation\Service\SymfonyTranslatorProxyInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Service\Translator;
 use PhpTuf\ComposerStager\Tests\TestCase;
 use PhpTuf\ComposerStager\Tests\TestUtils\TranslationTestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Throwable;
 
-/**
- * @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Service\Translator
- *
- * @covers \PhpTuf\ComposerStager\Internal\Translation\Service\SymfonyTranslatorProxy
- */
+#[CoversClass(SymfonyTranslatorProxy::class)]
+#[CoversClass(Translator::class)]
 final class TranslatorUnitTest extends TestCase
 {
     private DomainOptionsInterface $domainOptions;
@@ -45,13 +45,7 @@ final class TranslatorUnitTest extends TestCase
         return new Translator($this->domainOptions, $this->localeOptions, $this->symfonyTranslatorProxy);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getLocale
-     * @covers ::trans
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(
         string $message,
         ?TranslationParametersInterface $parameters,
@@ -67,7 +61,7 @@ final class TranslatorUnitTest extends TestCase
         self::assertEquals(TestLocaleOptions::DEFAULT, $sut->getLocale(), 'Returned correct default locale.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Empty values' => [
@@ -104,11 +98,7 @@ final class TranslatorUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::trans
-     *
-     * @dataProvider providerDomainHandling
-     */
+    #[DataProvider('providerDomainHandling')]
     public function testDomainHandling(string $defaultDomain, ?string $givenDomain, string $expectedDomain): void
     {
         $message = __METHOD__;
@@ -127,7 +117,7 @@ final class TranslatorUnitTest extends TestCase
         $sut->trans($message, null, $givenDomain);
     }
 
-    public function providerDomainHandling(): array
+    public static function providerDomainHandling(): array
     {
         return [
             'Default' => [
@@ -148,11 +138,7 @@ final class TranslatorUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::trans
-     *
-     * @dataProvider providerLocaleHandling
-     */
+    #[DataProvider('providerLocaleHandling')]
     public function testLocaleHandling(
         string $defaultLocale,
         ?string $givenLocale,
@@ -177,7 +163,7 @@ final class TranslatorUnitTest extends TestCase
         self::assertSame($expectedGetLocale, $sut->getLocale(), 'Returned correct locale.');
     }
 
-    public function providerLocaleHandling(): array
+    public static function providerLocaleHandling(): array
     {
         return [
             'Default' => [
@@ -201,7 +187,6 @@ final class TranslatorUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::create */
     public function testStaticFactory(): void
     {
         $domainOptions = self::createDomainOptions();
@@ -214,11 +199,7 @@ final class TranslatorUnitTest extends TestCase
         self::assertEquals($expected, $actual, 'Created new translator.');
     }
 
-    /**
-     * @covers ::trans
-     *
-     * @dataProvider providerTranslatorException
-     */
+    #[DataProvider('providerTranslatorException')]
     public function testTranslatorException(Throwable $exception): void
     {
         $message = __METHOD__;
@@ -243,7 +224,7 @@ final class TranslatorUnitTest extends TestCase
         }, AssertionError::class, $expectedMessage);
     }
 
-    public function providerTranslatorException(): array
+    public static function providerTranslatorException(): array
     {
         return [
             'Error' => [new Error('An Error')],

--- a/tests/Translation/Value/TranslatableMessageUnitTest.php
+++ b/tests/Translation/Value/TranslatableMessageUnitTest.php
@@ -5,10 +5,12 @@ namespace PhpTuf\ComposerStager\Tests\Translation\Value;
 use PhpTuf\ComposerStager\API\Translation\Service\TranslatorInterface;
 use PhpTuf\ComposerStager\Internal\Translation\Value\TranslatableMessage;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Value\TranslatableMessage */
+#[CoversClass(TranslatableMessage::class)]
 final class TranslatableMessageUnitTest extends TestCase
 {
     private TranslatorInterface|ObjectProphecy $translator;
@@ -18,13 +20,7 @@ final class TranslatableMessageUnitTest extends TestCase
         $this->translator = $this->prophesize(TranslatorInterface::class);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::__toString
-     * @covers ::trans
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(
         string $message,
         array $givenOptionalConstructorArguments,
@@ -52,7 +48,7 @@ final class TranslatableMessageUnitTest extends TestCase
         self::assertSame($expectedTranslation, (string) $sut, 'Returned correct typecast string value.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'Minimum values' => [
@@ -136,7 +132,6 @@ final class TranslatableMessageUnitTest extends TestCase
         ];
     }
 
-    /** @covers ::trans */
     public function testTransWithOptionalTranslatorArgument(): void
     {
         $constructorTranslator = $this->prophesize(TranslatorInterface::class);

--- a/tests/Translation/Value/TranslationParametersUnitTest.php
+++ b/tests/Translation/Value/TranslationParametersUnitTest.php
@@ -5,18 +5,14 @@ namespace PhpTuf\ComposerStager\Tests\Translation\Value;
 use AssertionError;
 use PhpTuf\ComposerStager\Internal\Translation\Value\TranslationParameters;
 use PhpTuf\ComposerStager\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
-/** @coversDefaultClass \PhpTuf\ComposerStager\Internal\Translation\Value\TranslationParameters */
+#[CoversClass(TranslationParameters::class)]
 final class TranslationParametersUnitTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::getAll
-     * @covers ::setValidParameters
-     *
-     * @dataProvider providerBasicFunctionality
-     */
+    #[DataProvider('providerBasicFunctionality')]
     public function testBasicFunctionality(array $parameters): void
     {
         $sut = new TranslationParameters($parameters);
@@ -24,7 +20,7 @@ final class TranslationParametersUnitTest extends TestCase
         self::assertSame($parameters, $sut->getAll(), 'Returned correct parameters.');
     }
 
-    public function providerBasicFunctionality(): array
+    public static function providerBasicFunctionality(): array
     {
         return [
             'No parameters' => [
@@ -54,11 +50,6 @@ final class TranslationParametersUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getAll
-     * @covers ::setValidParameters
-     */
     public function testDefaultParameters(): void
     {
         $sut = new TranslationParameters();
@@ -66,13 +57,7 @@ final class TranslationParametersUnitTest extends TestCase
         self::assertEquals([], $sut->getAll(), 'Got correct default parameters.');
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getAll
-     * @covers ::setValidParameters
-     *
-     * @dataProvider providerInvalidPlaceholders
-     */
+    #[DataProvider('providerInvalidPlaceholders')]
     public function testInvalidPlaceholders(array $given, array $expected, mixed $invalidPlaceholder): void
     {
         // Disable assertions so production error-handling can be tested.
@@ -93,7 +78,7 @@ final class TranslationParametersUnitTest extends TestCase
         ));
     }
 
-    public function providerInvalidPlaceholders(): array
+    public static function providerInvalidPlaceholders(): array
     {
         return [
             'Empty string' => [
@@ -157,13 +142,7 @@ final class TranslationParametersUnitTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getAll
-     * @covers ::setValidParameters
-     *
-     * @dataProvider providerInvalidValues
-     */
+    #[DataProvider('providerInvalidValues')]
     public function testInvalidValues(array $given, array $expected, string $invalidType): void
     {
         // Disable assertions so production error-handling can be tested.
@@ -183,7 +162,7 @@ final class TranslationParametersUnitTest extends TestCase
         ));
     }
 
-    public function providerInvalidValues(): array
+    public static function providerInvalidValues(): array
     {
         return [
             'Null' => [


### PR DESCRIPTION
This upgrades PHPUnit to the version now used by https://packagist.org/packages/drupal/core-dev#11.1.0-beta1: `^10.5.1`.

| Dev Changes                        | From   | To      | Compare                                                                                    |
|------------------------------------|--------|---------|--------------------------------------------------------------------------------------------|
| myclabs/deep-copy                  | 1.12.0 | 1.12.1  | [...](https://github.com/myclabs/DeepCopy/compare/1.12.0...1.12.1)                         |
| phpunit/php-code-coverage          | 9.2.32 | 10.1.16 | [...](https://github.com/sebastianbergmann/php-code-coverage/compare/9.2.32...10.1.16)     |
| phpunit/php-file-iterator          | 3.0.6  | 4.1.0   | [...](https://github.com/sebastianbergmann/php-file-iterator/compare/3.0.6...4.1.0)        |
| phpunit/php-invoker                | 3.1.1  | 4.0.0   | [...](https://github.com/sebastianbergmann/php-invoker/compare/3.1.1...4.0.0)              |
| phpunit/php-text-template          | 2.0.4  | 3.0.1   | [...](https://github.com/sebastianbergmann/php-text-template/compare/2.0.4...3.0.1)        |
| phpunit/php-timer                  | 5.0.3  | 6.0.0   | [...](https://github.com/sebastianbergmann/php-timer/compare/5.0.3...6.0.0)                |
| phpunit/phpunit                    | 9.6.21 | 10.5.38 | [...](https://github.com/sebastianbergmann/phpunit/compare/9.6.21...10.5.38)               |
| sebastian/cli-parser               | 1.0.2  | 2.0.1   | [...](https://github.com/sebastianbergmann/cli-parser/compare/1.0.2...2.0.1)               |
| sebastian/code-unit                | 1.0.8  | 2.0.0   | [...](https://github.com/sebastianbergmann/code-unit/compare/1.0.8...2.0.0)                |
| sebastian/code-unit-reverse-lookup | 2.0.3  | 3.0.0   | [...](https://github.com/sebastianbergmann/code-unit-reverse-lookup/compare/2.0.3...3.0.0) |
| sebastian/comparator               | 4.0.8  | 5.0.3   | [...](https://github.com/sebastianbergmann/comparator/compare/4.0.8...5.0.3)               |
| sebastian/complexity               | 2.0.3  | 3.2.0   | [...](https://github.com/sebastianbergmann/complexity/compare/2.0.3...3.2.0)               |
| sebastian/diff                     | 4.0.6  | 5.1.1   | [...](https://github.com/sebastianbergmann/diff/compare/4.0.6...5.1.1)                     |
| sebastian/environment              | 5.1.5  | 6.1.0   | [...](https://github.com/sebastianbergmann/environment/compare/5.1.5...6.1.0)              |
| sebastian/exporter                 | 4.0.6  | 5.1.2   | [...](https://github.com/sebastianbergmann/exporter/compare/4.0.6...5.1.2)                 |
| sebastian/global-state             | 5.0.7  | 6.0.2   | [...](https://github.com/sebastianbergmann/global-state/compare/5.0.7...6.0.2)             |
| sebastian/lines-of-code            | 1.0.4  | 2.0.2   | [...](https://github.com/sebastianbergmann/lines-of-code/compare/1.0.4...2.0.2)            |
| sebastian/object-enumerator        | 4.0.4  | 5.0.0   | [...](https://github.com/sebastianbergmann/object-enumerator/compare/4.0.4...5.0.0)        |
| sebastian/object-reflector         | 2.0.4  | 3.0.0   | [...](https://github.com/sebastianbergmann/object-reflector/compare/2.0.4...3.0.0)         |
| sebastian/recursion-context        | 4.0.5  | 5.0.0   | [...](https://github.com/sebastianbergmann/recursion-context/compare/4.0.5...5.0.0)        |
| sebastian/resource-operations      | 3.0.4  | REMOVED |                                                                                            |
| sebastian/type                     | 3.2.1  | 4.0.0   | [...](https://github.com/sebastianbergmann/type/compare/3.2.1...4.0.0)                     |
| sebastian/version                  | 3.0.2  | 4.0.1   | [...](https://github.com/sebastianbergmann/version/compare/3.0.2...4.0.1)                  |

