### PR TITLE
Declare conflicts with vulnerable versions of `symfony/process`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,8 @@
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "conflict": {
-        "symfony/process": ">=6 <6.4.14 || >=7 <7.1.7",
-        "symfony/symfony": ">=6 <6.4.14 || >=7 <7.1.7"
+        "symfony/process": ">=6.4 <6.4.33 || >=7.3 <7.3.11 || >=7.4 <7.4.5",
+        "symfony/symfony": ">=6.4 <6.4.33 || >=7.3 <7.3.11 || >=7.4 <7.4.5"
     },
     "suggest": {
         "symfony/dependency-injection": "For dependency injection",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.1.0",
         "ext-json": "*",
         "symfony/filesystem": "^6.2 || ^7.0",
-        "symfony/process": "^6.4.14 || ^7.1.7",
+        "symfony/process": "^6.4.33 || ^7.3.11",
         "symfony/translation-contracts": "^3.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d61b520f0646eef428f6109ad24d7c09",
+    "content-hash": "9062baa32c9062eb06e90238619e6044",
     "packages": [
         {
             "name": "symfony/filesystem",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fa3cb37e18b1190220e9f0bcf680cc0",
+    "content-hash": "d61b520f0646eef428f6109ad24d7c09",
     "packages": [
         {
             "name": "symfony/filesystem",
@@ -233,16 +233,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.14",
+            "version": "v6.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "25214adbb0996d18112548de20c281be9f27279f"
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/25214adbb0996d18112548de20c281be9f27279f",
-                "reference": "25214adbb0996d18112548de20c281be9f27279f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
                 "shasum": ""
             },
             "require": {
@@ -274,7 +274,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.14"
+                "source": "https://github.com/symfony/process/tree/v6.4.33"
             },
             "funding": [
                 {
@@ -286,11 +286,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T09:25:01+00:00"
+            "time": "2026-01-23T16:02:12+00:00"
         },
         {
             "name": "symfony/translation-contracts",


### PR DESCRIPTION
`symfony/process` has announced a medium severity vulnerability: [CVE-2024-51736 - Symfony's incorrect argument escaping under MSYS2/Git Bash can lead to destructive file operations on Windows](https://github.com/advisories/GHSA-r39x-jcww-82v6). This adds Composer conflicts with vulnerable versions.