### PR TITLE
Fix compatibility with `symfony/filesystem` >=v6.4.40/v7.4.11

### DIFF
--- a/src/Internal/Path/Service/PathHelper.php
+++ b/src/Internal/Path/Service/PathHelper.php
@@ -16,30 +16,53 @@ final class PathHelper implements PathHelperInterface
 
     public function canonicalize(string $path): string
     {
-        $path = SymfonyPath::canonicalize($path);
+        $path = self::normalize($path);
 
-        // Eliminate repeated slashes after Windows drive names.
-        $canonicalized = preg_replace('#/+#', '/', $path);
+        // symfony/filesystem ≥v6.4.40/v7.4.11 no longer recognizes Windows drive
+        // roots (e.g., "C:/") on non-Windows systems. Use a Unix sentinel root so
+        // ".." segments resolve correctly, then restore the drive prefix.
+        if (preg_match('#^([A-Za-z]:)(/?+)(.*)$#s', $path, $matches)) {
+            // Use a Unix sentinel root ('/') so '..' segments resolve correctly,
+            // then restore the drive prefix. Path::canonicalize('/') always returns
+            // '/' (never ''), so the result is always at least "$drive/".
+            return self::deduplicateSlashes($matches[1] . SymfonyPath::canonicalize('/' . $matches[3]));
+        }
 
-        assert(is_string($canonicalized));
-
-        return $canonicalized;
+        return self::deduplicateSlashes(SymfonyPath::canonicalize($path));
     }
 
     public function isAbsolute(string $path): bool
     {
-        return SymfonyPath::isAbsolute($path);
+        $path = self::normalize($path);
+
+        // symfony/filesystem ≥v6.4.40/v7.4.11 no longer recognizes Windows paths
+        // on non-Windows systems. Handle drive paths (e.g., "C:/", "C:") explicitly.
+        return preg_match('#^[A-Za-z]:(/|$)#', $path) === 1
+            || SymfonyPath::isAbsolute($path);
     }
 
     public function isDescendant(string $descendant, string $ancestor): bool
     {
-        $ancestor .= '/';
-
-        return str_starts_with($descendant, $ancestor);
+        return str_starts_with($descendant, $ancestor . '/');
     }
 
     public function isRelative(string $path): bool
     {
-        return SymfonyPath::isRelative($path);
+        return !$this->isAbsolute($path);
+    }
+
+    /** Converts Windows backslashes to forward slashes. */
+    private static function normalize(string $path): string
+    {
+        return str_replace('\\', '/', $path);
+    }
+
+    /** Collapses consecutive forward slashes into one. */
+    private static function deduplicateSlashes(string $path): string
+    {
+        $result = preg_replace('#/+#', '/', $path);
+        assert(is_string($result));
+
+        return $result;
     }
 }


### PR DESCRIPTION
An upstream change to `symfony/filesystem` broke our Windows path-handling. This fixes it.